### PR TITLE
chore: add extension LICENSE and #[must_use] attributes

### DIFF
--- a/crates/ftd-core/src/emitter.rs
+++ b/crates/ftd-core/src/emitter.rs
@@ -8,6 +8,7 @@ use petgraph::graph::NodeIndex;
 use std::fmt::Write;
 
 /// Emit a `SceneGraph` as an FTD text document.
+#[must_use]
 pub fn emit_document(graph: &SceneGraph) -> String {
     let mut out = String::with_capacity(1024);
     out.push_str("# FTD v1\n\n");

--- a/crates/ftd-core/src/model.rs
+++ b/crates/ftd-core/src/model.rs
@@ -361,6 +361,7 @@ pub struct SceneGraph {
 
 impl SceneGraph {
     /// Create a new empty scene graph with a root node.
+    #[must_use]
     pub fn new() -> Self {
         let mut graph = DiGraph::new();
         let root_node = SceneNode::new(NodeId::intern("root"), NodeKind::Root);

--- a/crates/ftd-core/src/parser.rs
+++ b/crates/ftd-core/src/parser.rs
@@ -14,6 +14,7 @@ use winnow::prelude::*;
 use winnow::token::{take_till, take_while};
 
 /// Parse an FTD document string into a `SceneGraph`.
+#[must_use = "parsing result should be used"]
 pub fn parse_document(input: &str) -> Result<SceneGraph, String> {
     let mut graph = SceneGraph::new();
     let mut rest = input;

--- a/ftd-vscode/LICENSE
+++ b/ftd-vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Khang Nghiêm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
- Copy MIT LICENSE to ftd-vscode/ (fixes marketplace warning)
- Add `#[must_use]` to `parse_document()`, `emit_document()`, `SceneGraph::new()`

All 33 tests pass, 0 clippy warnings.