### PR TITLE
feat(core): add ## annotation system for embedded requirements

### DIFF
--- a/.agents/skills/ftd-format/SKILL.md
+++ b/.agents/skills/ftd-format/SKILL.md
@@ -108,6 +108,29 @@ Easing: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `spring`
 @node_id -> fill_parent: 16
 ```
 
+### Annotations
+
+Structured metadata attached to nodes via `##` lines. Unlike `#` comments (which are discarded), annotations are parsed, stored on the scene graph, and survive round-trips.
+
+```
+rect @login_btn {
+  ## "Primary CTA — triggers login API call"
+  ## accept: "disabled state when fields empty"
+  ## status: in_progress
+  ## priority: high
+  ## tag: auth, mvp
+  w: 280 h: 48
+}
+```
+
+| Syntax               | Kind        | Purpose                        |
+| -------------------- | ----------- | ------------------------------ |
+| `## "text"`          | Description | What this node is/does         |
+| `## accept: "text"`  | Accept      | Acceptance criterion           |
+| `## status: value`   | Status      | `draft`, `in_progress`, `done` |
+| `## priority: value` | Priority    | `high`, `medium`, `low`        |
+| `## tag: value`      | Tag         | Categorization labels          |
+
 ## Token Efficiency Tips
 
 1. Use `w:` / `h:` shorthand, not `width:` / `height:`

--- a/crates/ftd-core/src/model.rs
+++ b/crates/ftd-core/src/model.rs
@@ -245,6 +245,24 @@ pub struct AnimProperties {
     pub translate: Option<(f32, f32)>,
 }
 
+// ─── Annotations ─────────────────────────────────────────────────────────
+
+/// Structured annotation attached to a scene node.
+/// Parsed from `##` lines in the FTD format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Annotation {
+    /// Freeform description: `## "User auth entry point"`
+    Description(String),
+    /// Acceptance criterion: `## accept: "validates email on blur"`
+    Accept(String),
+    /// Status: `## status: draft`
+    Status(String),
+    /// Priority: `## priority: high`
+    Priority(String),
+    /// Tag: `## tag: auth`
+    Tag(String),
+}
+
 // ─── Layout Constraints ──────────────────────────────────────────────────
 
 /// Constraint-based layout — no absolute coordinates in the format.
@@ -323,6 +341,9 @@ pub struct SceneNode {
 
     /// Animations attached to this node.
     pub animations: SmallVec<[AnimKeyframe; 2]>,
+
+    /// Structured annotations (`##` lines).
+    pub annotations: Vec<Annotation>,
 }
 
 impl SceneNode {
@@ -334,6 +355,7 @@ impl SceneNode {
             use_styles: SmallVec::new(),
             constraints: SmallVec::new(),
             animations: SmallVec::new(),
+            annotations: Vec::new(),
         }
     }
 }

--- a/examples/demo.ftd
+++ b/examples/demo.ftd
@@ -13,16 +13,26 @@ style accent {
 group @login_form {
   layout: column gap=16 pad=32
 
+  ## "User authentication entry point"
+  ## accept: "email + password fields visible"
+  ## accept: "sign-in button triggers auth flow"
+  ## status: draft
+
   text @title "Welcome Back" {
     use: base_text
     font: "Inter" 600 24
     fill: #1A1A2E
+    ## "Brand greeting — sets emotional tone"
   }
 
   rect @email_field {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
+    ## "Email input field"
+    ## accept: "validates email format on blur"
+    ## accept: "shows error state with red border"
+    ## priority: high
 
     text @email_hint "Email" {
       use: base_text
@@ -34,6 +44,8 @@ group @login_form {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
+    ## "Password input field"
+    ## accept: "minimum 8 characters"
 
     text @pass_hint "Password" {
       use: base_text
@@ -45,6 +57,10 @@ group @login_form {
     w: 280 h: 48
     corner: 10
     use: accent
+    ## "Primary CTA — triggers login API call"
+    ## accept: "disabled state when fields empty"
+    ## accept: "loading spinner during auth"
+    ## status: in_progress
 
     text @btn_label "Sign In" {
       font: "Inter" 600 16


### PR DESCRIPTION
## Summary\n\nAdd structured `##` annotations to FTD nodes — embedding requirements, descriptions, and acceptance criteria directly into `.ftd` files as first-class metadata on scene graph nodes.\n\n## Syntax\n\n```\nrect @login_btn {\n  ## \"Primary CTA — triggers login API call\"\n  ## accept: \"disabled state when fields empty\"\n  ## accept: \"loading spinner during auth\"\n  ## status: in_progress\n  ## priority: high\n  ## tag: auth\n  w: 280 h: 48\n}\n```\n\n## Changes\n\n- **model.rs** — `Annotation` enum with 5 variants + `annotations: Vec<Annotation>` on `SceneNode`\n- **parser.rs** — `##` lines parsed as structured data (not discarded like `#` comments)\n- **emitter.rs** — `emit_annotations` helper, annotations emitted as `##` lines\n- **demo.ftd** — Updated with annotations on all nodes\n- **SKILL.md** — Added Annotations reference section\n\n## Tests\n\n- 5 new roundtrip tests (all passing)\n- All 38 workspace tests pass\n- `cargo clippy --workspace -- -D warnings` clean\n- `cargo fmt --all -- --check` clean