### PR TITLE
feat(lsp,treesitter): Phase 1 — Universal editor support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +139,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -202,6 +230,19 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -221,6 +262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +286,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "euclid"
@@ -267,6 +329,18 @@ dependencies = [
  "log",
  "pretty_assertions",
  "smallvec",
+]
+
+[[package]]
+name = "fd-lsp"
+version = "0.1.0"
+dependencies = [
+ "fd-core",
+ "log",
+ "ropey",
+ "serde_json",
+ "tokio",
+ "tower-lsp",
 ]
 
 [[package]]
@@ -365,6 +439,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +489,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,8 +523,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -542,6 +677,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,7 +850,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e14eda50a3494b3bf7b9ce51c52434a761e383d7238ce1dd5dcec2fbc13e9fb"
 dependencies = [
- "dashmap",
+ "dashmap 6.1.0",
  "hashbrown 0.14.5",
 ]
 
@@ -634,6 +877,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +902,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -707,6 +969,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -848,6 +1121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +1134,26 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -880,6 +1179,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -979,6 +1287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1358,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,10 +1438,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "strum"
@@ -1131,6 +1492,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1183,6 +1555,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap 5.5.3",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1713,25 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vello"
@@ -1249,6 +1782,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1540,7 +2079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1550,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1563,7 +2102,7 @@ dependencies = [
  "windows-interface",
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1600,7 +2139,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1610,7 +2149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1628,14 +2176,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1645,10 +2210,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1657,10 +2234,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1669,10 +2258,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1681,10 +2282,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1694,6 +2307,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xml-rs"
@@ -1706,6 +2325,29 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1721,6 +2363,60 @@ name = "zerocopy-derive"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/fd-render",
     "crates/fd-editor",
     "crates/fd-wasm",
+    "crates/fd-lsp",
 ]
 
 [workspace.package]
@@ -40,6 +41,11 @@ js-sys = "0.3"
 # Logging
 log = "0.4"
 env_logger = "0.11"
+
+# LSP
+tower-lsp = "0.20"
+tokio = { version = "1", features = ["full"] }
+ropey = "1.6"
 
 # Testing
 pretty_assertions = "1.4"

--- a/crates/fd-lsp/Cargo.toml
+++ b/crates/fd-lsp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fd-lsp"
+description = "FD (Fast Draft) Language Server — diagnostics, completions, hover, symbols"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "fd-lsp"
+path = "src/main.rs"
+
+[dependencies]
+fd-core = { path = "../fd-core" }
+tower-lsp = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+log = { workspace = true }
+ropey = { workspace = true }

--- a/crates/fd-lsp/src/completion.rs
+++ b/crates/fd-lsp/src/completion.rs
@@ -1,0 +1,262 @@
+//! Completions: context-aware FD completions.
+
+use tower_lsp::lsp_types::*;
+
+/// Compute completions at the given cursor position.
+///
+/// Uses a simple heuristic: look at the line content to determine context
+/// (top-level, inside a node block, after a colon, etc.).
+pub fn compute_completions(text: &str, pos: Position) -> Vec<CompletionItem> {
+    let line = text.lines().nth(pos.line as usize).unwrap_or("");
+    let before_cursor = &line[..std::cmp::min(pos.character as usize, line.len())];
+    let trimmed = before_cursor.trim();
+
+    // After a colon — suggest values
+    if let Some(prop_part) = trimmed.strip_suffix(':').or_else(|| {
+        if trimmed.ends_with(": ") {
+            Some(trimmed.trim_end_matches(": ").trim())
+        } else {
+            None
+        }
+    }) {
+        let prop = prop_part.split_whitespace().last().unwrap_or("");
+        return value_completions(prop);
+    }
+
+    // Detect if we're inside a block or at top level
+    let depth = compute_brace_depth(text, pos);
+
+    if depth == 0 {
+        top_level_completions()
+    } else {
+        node_body_completions()
+    }
+}
+
+/// Compute the brace nesting depth at the cursor position.
+fn compute_brace_depth(text: &str, pos: Position) -> usize {
+    let mut depth: i32 = 0;
+    for (i, line) in text.lines().enumerate() {
+        if i > pos.line as usize {
+            break;
+        }
+        let end = if i == pos.line as usize {
+            std::cmp::min(pos.character as usize, line.len())
+        } else {
+            line.len()
+        };
+        for ch in line[..end].chars() {
+            match ch {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+        }
+    }
+    depth.max(0) as usize
+}
+
+/// Completions at the top level of an FD document.
+fn top_level_completions() -> Vec<CompletionItem> {
+    let keywords = [
+        (
+            "group",
+            "Group container for child nodes",
+            "group @${1:name} {\n  $0\n}",
+        ),
+        (
+            "rect",
+            "Rectangle shape",
+            "rect @${1:name} {\n  w: ${2:100} h: ${3:50}\n  fill: #${4:6C5CE7}\n}",
+        ),
+        (
+            "ellipse",
+            "Ellipse / circle shape",
+            "ellipse @${1:name} {\n  w: ${2:50} h: ${3:50}\n  fill: #${4:FF6B6B}\n}",
+        ),
+        (
+            "text",
+            "Text label",
+            "text @${1:name} \"${2:Hello}\" {\n  fill: #${3:333333}\n}",
+        ),
+        ("path", "Freeform path", "path @${1:name} {\n  $0\n}"),
+        (
+            "style",
+            "Reusable style block",
+            "style ${1:name} {\n  fill: #${2:6C5CE7}\n}",
+        ),
+    ];
+
+    keywords
+        .into_iter()
+        .map(|(label, detail, snippet)| CompletionItem {
+            label: label.to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some(detail.to_string()),
+            insert_text: Some(snippet.to_string()),
+            insert_text_format: Some(InsertTextFormat::SNIPPET),
+            ..Default::default()
+        })
+        .collect()
+}
+
+/// Completions inside a node body `{ ... }`.
+fn node_body_completions() -> Vec<CompletionItem> {
+    let props = [
+        ("w:", "Width", CompletionItemKind::PROPERTY),
+        ("h:", "Height", CompletionItemKind::PROPERTY),
+        ("fill:", "Fill color", CompletionItemKind::PROPERTY),
+        (
+            "stroke:",
+            "Stroke color and width",
+            CompletionItemKind::PROPERTY,
+        ),
+        ("corner:", "Corner radius", CompletionItemKind::PROPERTY),
+        (
+            "opacity:",
+            "Opacity (0.0–1.0)",
+            CompletionItemKind::PROPERTY,
+        ),
+        (
+            "font:",
+            "Font family, weight, size",
+            CompletionItemKind::PROPERTY,
+        ),
+        (
+            "bg:",
+            "Background with inline shadow/corner",
+            CompletionItemKind::PROPERTY,
+        ),
+        (
+            "use:",
+            "Reference a named style",
+            CompletionItemKind::REFERENCE,
+        ),
+        (
+            "layout:",
+            "Layout mode for children",
+            CompletionItemKind::PROPERTY,
+        ),
+    ];
+
+    let mut items: Vec<CompletionItem> = props
+        .into_iter()
+        .map(|(label, detail, kind)| CompletionItem {
+            label: label.to_string(),
+            kind: Some(kind),
+            detail: Some(detail.to_string()),
+            ..Default::default()
+        })
+        .collect();
+
+    // Child node snippets
+    let child_nodes = [
+        ("group", "Nested group"),
+        ("rect", "Nested rectangle"),
+        ("ellipse", "Nested ellipse"),
+        ("text", "Nested text"),
+        ("path", "Nested path"),
+    ];
+    for (label, detail) in child_nodes {
+        items.push(CompletionItem {
+            label: label.to_string(),
+            kind: Some(CompletionItemKind::KEYWORD),
+            detail: Some(detail.to_string()),
+            ..Default::default()
+        });
+    }
+
+    // Animation block
+    items.push(CompletionItem {
+        label: "anim".to_string(),
+        kind: Some(CompletionItemKind::SNIPPET),
+        detail: Some("Animation block".to_string()),
+        insert_text: Some("anim :${1|hover,press,enter|} {\n  $0\n}".to_string()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        ..Default::default()
+    });
+
+    // Annotation
+    items.push(CompletionItem {
+        label: "##".to_string(),
+        kind: Some(CompletionItemKind::SNIPPET),
+        detail: Some("Annotation".to_string()),
+        insert_text: Some("## \"${1:description}\"".to_string()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        ..Default::default()
+    });
+
+    items
+}
+
+/// Value completions after a property colon.
+fn value_completions(property: &str) -> Vec<CompletionItem> {
+    let values: &[(&str, &str)] = match property {
+        "layout" => &[
+            ("column", "Vertical stack layout"),
+            ("row", "Horizontal stack layout"),
+            ("grid", "Grid layout"),
+            ("free", "Free / absolute positioning"),
+        ],
+        "ease" => &[
+            ("linear", "Linear easing"),
+            ("ease_in", "Ease in"),
+            ("ease_out", "Ease out"),
+            ("ease_in_out", "Ease in-out"),
+            ("spring", "Spring physics"),
+        ],
+        "status" => &[
+            ("draft", "Draft status"),
+            ("in_progress", "In progress"),
+            ("review", "Under review"),
+            ("done", "Completed"),
+        ],
+        "priority" => &[
+            ("low", "Low priority"),
+            ("medium", "Medium priority"),
+            ("high", "High priority"),
+            ("critical", "Critical priority"),
+        ],
+        _ => return Vec::new(),
+    };
+
+    values
+        .iter()
+        .map(|(label, detail)| CompletionItem {
+            label: label.to_string(),
+            kind: Some(CompletionItemKind::ENUM_MEMBER),
+            detail: Some(detail.to_string()),
+            ..Default::default()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn top_level_returns_node_keywords() {
+        let items = compute_completions("", Position::new(0, 0));
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"rect"));
+        assert!(labels.contains(&"group"));
+        assert!(labels.contains(&"style"));
+    }
+
+    #[test]
+    fn inside_node_returns_properties() {
+        let text = "rect @box {\n  ";
+        let items = compute_completions(text, Position::new(1, 2));
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"w:"));
+        assert!(labels.contains(&"fill:"));
+        assert!(labels.contains(&"anim"));
+    }
+
+    #[test]
+    fn brace_depth_computation() {
+        let text = "rect @a {\n  group @b {\n    ";
+        assert_eq!(compute_brace_depth(text, Position::new(2, 4)), 2);
+    }
+}

--- a/crates/fd-lsp/src/diagnostics.rs
+++ b/crates/fd-lsp/src/diagnostics.rs
@@ -1,0 +1,95 @@
+//! Diagnostics: parse FD text → LSP diagnostics.
+
+use tower_lsp::lsp_types::*;
+
+/// Compute diagnostics by parsing the document text.
+///
+/// On parse failure, extracts line/column from the error message and
+/// returns a single diagnostic. On success, returns an empty vec
+/// (clearing previous errors).
+pub fn compute_diagnostics(text: &str) -> Vec<Diagnostic> {
+    match fd_core::parser::parse_document(text) {
+        Ok(_) => Vec::new(),
+        Err(err_msg) => {
+            let (line, col) = extract_error_position(text, &err_msg);
+            vec![Diagnostic {
+                range: Range {
+                    start: Position::new(line, col),
+                    end: Position::new(line, col + 1),
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("fd-lsp".to_string()),
+                message: err_msg,
+                ..Default::default()
+            }]
+        }
+    }
+}
+
+/// Best-effort extraction of error position from winnow error messages.
+///
+/// Winnow errors typically contain the remaining unparsed text. We find
+/// where that text appears in the original input to compute line/col.
+fn extract_error_position(source: &str, error: &str) -> (u32, u32) {
+    // winnow errors often look like: "... at '...remaining...'"
+    // Try to find the remaining text in the source
+    if let Some(at_idx) = error.find("at '") {
+        let remaining = &error[at_idx + 4..];
+        if let Some(end) = remaining.find('\'') {
+            let snippet = &remaining[..end];
+            // Find this snippet in the source
+            if let Some(offset) = source.find(snippet) {
+                return offset_to_line_col(source, offset);
+            }
+        }
+    }
+
+    // Fallback: report at the end of the document
+    let line_count = source.lines().count();
+    if line_count == 0 {
+        return (0, 0);
+    }
+    let last_line = line_count.saturating_sub(1) as u32;
+    let last_col = source.lines().last().map_or(0, |l| l.len() as u32);
+    (last_line, last_col)
+}
+
+/// Convert a byte offset in source text to (line, col) zero-indexed.
+fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    let mut line = 0u32;
+    let mut col = 0u32;
+    for (i, ch) in source.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_document_produces_no_diagnostics() {
+        let text = r#"rect @box { w: 100 h: 50 fill: #FF0000 }"#;
+        let diags = compute_diagnostics(text);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn offset_to_line_col_basic() {
+        let src = "line0\nline1\nline2";
+        //          01234 5 6789A B CDEF0
+        assert_eq!(offset_to_line_col(src, 0), (0, 0));
+        assert_eq!(offset_to_line_col(src, 5), (0, 5));
+        assert_eq!(offset_to_line_col(src, 6), (1, 0));
+        assert_eq!(offset_to_line_col(src, 12), (2, 0));
+    }
+}

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -1,0 +1,188 @@
+//! Hover: show contextual information on hover.
+
+use fd_core::SceneGraph;
+use tower_lsp::lsp_types::*;
+
+/// Compute hover information at the given position.
+///
+/// - Hovering an `@id` → shows node type and properties.
+/// - Hovering a node keyword → shows description from FD spec.
+/// - Hovering a property name → shows accepted values.
+pub fn compute_hover(text: &str, pos: Position, graph: Option<&SceneGraph>) -> Option<Hover> {
+    let line = text.lines().nth(pos.line as usize)?;
+    let word = extract_word_at(line, pos.character as usize);
+
+    if word.is_empty() {
+        return None;
+    }
+
+    // Node ID hover (starts with @)
+    if let Some(id) = word.strip_prefix('@') {
+        return hover_node_id(id, graph);
+    }
+
+    // Keyword / property hover
+    hover_keyword(word)
+}
+
+/// Extract the word at a given column in a line.
+fn extract_word_at(line: &str, col: usize) -> &str {
+    let col = col.min(line.len());
+    let bytes = line.as_bytes();
+
+    // Find word start
+    let start = (0..col)
+        .rev()
+        .find(|&i| !is_word_char(bytes[i]))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+
+    // Find word end
+    let end = (col..bytes.len())
+        .find(|&i| !is_word_char(bytes[i]))
+        .unwrap_or(bytes.len());
+
+    &line[start..end]
+}
+
+fn is_word_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'@' || b == b'#'
+}
+
+/// Hover info for a node `@id`.
+fn hover_node_id(id: &str, graph: Option<&SceneGraph>) -> Option<Hover> {
+    let graph = graph?;
+    let node_id = fd_core::NodeId::intern(id);
+    let node = graph.get_by_id(node_id)?;
+
+    let kind_str = match &node.kind {
+        fd_core::NodeKind::Root => "Root",
+        fd_core::NodeKind::Group { .. } => "Group",
+        fd_core::NodeKind::Rect { width, height } => {
+            let desc = format!("**Rect** — {}×{}", width, height);
+            return Some(make_hover(&desc));
+        }
+        fd_core::NodeKind::Ellipse { rx, ry } => {
+            let desc = format!("**Ellipse** — rx={}, ry={}", rx, ry);
+            return Some(make_hover(&desc));
+        }
+        fd_core::NodeKind::Path { commands } => {
+            let desc = format!("**Path** — {} commands", commands.len());
+            return Some(make_hover(&desc));
+        }
+        fd_core::NodeKind::Text { content } => {
+            let desc = format!("**Text** — \"{}\"", content);
+            return Some(make_hover(&desc));
+        }
+    };
+
+    Some(make_hover(&format!("**{}** `@{}`", kind_str, id)))
+}
+
+/// Hover info for FD keywords and properties.
+fn hover_keyword(word: &str) -> Option<Hover> {
+    let info = match word {
+        // Node types
+        "group" => {
+            "**group** — Container node for child elements.\n\nSupports `layout:` for automatic arrangement of children."
+        }
+        "rect" => {
+            "**rect** — Rectangle shape.\n\nProperties: `w:` `h:` `fill:` `stroke:` `corner:` `opacity:`"
+        }
+        "ellipse" => {
+            "**ellipse** — Ellipse or circle shape.\n\nProperties: `w:` (rx) `h:` (ry) `fill:` `stroke:` `opacity:`"
+        }
+        "text" => {
+            "**text** — Text label node.\n\nInline content: `text @id \"content\" { ... }`\nProperties: `font:` `fill:` `opacity:`"
+        }
+        "path" => "**path** — Freeform vector path.\n\nSupports SVG-like path commands.",
+        "style" => {
+            "**style** — Reusable style definition.\n\nDefine once, apply to nodes with `use: style_name`."
+        }
+        // Properties
+        "w" | "width" => "**w:** — Width of the element in pixels.",
+        "h" | "height" => "**h:** — Height of the element in pixels.",
+        "fill" => "**fill:** — Fill color.\n\nAccepts hex: `#RGB`, `#RRGGBB`, `#RRGGBBAA`",
+        "stroke" => "**stroke:** — Stroke color and width.\n\nFormat: `stroke: #COLOR width`",
+        "corner" => "**corner:** — Corner radius for rounded shapes.",
+        "opacity" => "**opacity:** — Opacity value from 0.0 (transparent) to 1.0 (opaque).",
+        "font" => {
+            "**font:** — Font specification.\n\nFormat: `font: \"Family\" weight size`\nExample: `font: \"Inter\" 600 24`"
+        }
+        "bg" => {
+            "**bg:** — Background fill with inline corner/shadow.\n\nFormat: `bg: #COLOR corner=N shadow=(x,y,blur,#COL)`"
+        }
+        "use" => "**use:** — Reference a named style definition.\n\nExample: `use: accent`",
+        "layout" => {
+            "**layout:** — Children arrangement mode.\n\nValues: `column`, `row`, `grid`, `free`\nModifiers: `gap=N`, `pad=N`, `cols=N`"
+        }
+        // Layout modes
+        "column" => "**column** — Vertical stack layout.\n\nModifiers: `gap=N` `pad=N`",
+        "row" => "**row** — Horizontal stack layout.\n\nModifiers: `gap=N` `pad=N`",
+        "grid" => "**grid** — Grid layout.\n\nModifiers: `cols=N` `gap=N` `pad=N`",
+        // Animation
+        "anim" => {
+            "**anim** — Animation block.\n\nFormat: `anim :trigger { props }`\nTriggers: `:hover`, `:press`, `:enter`"
+        }
+        "ease" => {
+            "**ease:** — Easing function.\n\nValues: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `spring`\nFormat: `ease: spring 300ms`"
+        }
+        "spring" => "**spring** — Spring physics easing.\n\nnatural bounce animation.",
+        // Annotations
+        "accept" => {
+            "**## accept:** — Acceptance criterion annotation.\n\nFormat: `## accept: \"description\"`"
+        }
+        "status" => {
+            "**## status:** — Status annotation.\n\nValues: `draft`, `in_progress`, `review`, `done`"
+        }
+        "priority" => {
+            "**## priority:** — Priority annotation.\n\nValues: `low`, `medium`, `high`, `critical`"
+        }
+        "tag" => "**## tag:** — Tag annotation.\n\nFormat: `## tag: category_name`",
+        _ => return None,
+    };
+
+    Some(make_hover(info))
+}
+
+fn make_hover(content: &str) -> Hover {
+    Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: content.to_string(),
+        }),
+        range: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_word_from_line() {
+        let line = "  fill: #FF0000";
+        assert_eq!(extract_word_at(line, 4), "fill");
+        assert_eq!(extract_word_at(line, 8), "#FF0000");
+    }
+
+    #[test]
+    fn hover_on_keyword() {
+        let result = hover_keyword("rect");
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn hover_on_unknown_returns_none() {
+        let result = hover_keyword("foobar");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn hover_on_node_id_with_graph() {
+        let text = "rect @mybox { w: 100 h: 50 }";
+        let graph = fd_core::parser::parse_document(text).ok();
+        let result = compute_hover(text, Position::new(0, 6), graph.as_ref());
+        assert!(result.is_some());
+    }
+}

--- a/crates/fd-lsp/src/main.rs
+++ b/crates/fd-lsp/src/main.rs
@@ -1,0 +1,153 @@
+//! FD Language Server — diagnostics, completions, hover, document symbols.
+//!
+//! A `tower-lsp` based LSP server that wraps `fd-core` for real-time
+//! editor feedback in any LSP-compatible editor (Zed, Neovim, Helix, etc.).
+
+mod completion;
+mod diagnostics;
+mod hover;
+mod symbols;
+
+use std::sync::Mutex;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tower_lsp::{Client, LanguageServer, LspService, Server};
+
+/// Cached parse state for a single document.
+struct DocumentState {
+    text: String,
+    graph: Option<fd_core::SceneGraph>,
+}
+
+/// The FD language server backend.
+struct FdLanguageServer {
+    client: Client,
+    /// Cached document state by URI.
+    documents: Mutex<std::collections::HashMap<Url, DocumentState>>,
+}
+
+impl FdLanguageServer {
+    fn new(client: Client) -> Self {
+        Self {
+            client,
+            documents: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Reparse a document and publish diagnostics.
+    async fn on_change(&self, uri: Url, text: String) {
+        let diags = diagnostics::compute_diagnostics(&text);
+        let graph = fd_core::parser::parse_document(&text).ok();
+
+        {
+            let mut docs = self.documents.lock().unwrap();
+            docs.insert(uri.clone(), DocumentState { text, graph });
+        }
+
+        self.client.publish_diagnostics(uri, diags, None).await;
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for FdLanguageServer {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(
+                    TextDocumentSyncKind::FULL,
+                )),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![
+                        ":".to_string(),
+                        "@".to_string(),
+                        "#".to_string(),
+                    ]),
+                    ..Default::default()
+                }),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                document_symbol_provider: Some(OneOf::Left(true)),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        self.client
+            .log_message(MessageType::INFO, "fd-lsp initialized")
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        self.on_change(uri, text).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        if let Some(change) = params.content_changes.into_iter().next_back() {
+            self.on_change(uri, change.text).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let mut docs = self.documents.lock().unwrap();
+        docs.remove(&uri);
+    }
+
+    async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let uri = &params.text_document_position.text_document.uri;
+        let pos = params.text_document_position.position;
+
+        let docs = self.documents.lock().unwrap();
+        let items = if let Some(doc) = docs.get(uri) {
+            completion::compute_completions(&doc.text, pos)
+        } else {
+            Vec::new()
+        };
+
+        Ok(Some(CompletionResponse::Array(items)))
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
+
+        let docs = self.documents.lock().unwrap();
+        if let Some(doc) = docs.get(uri) {
+            Ok(hover::compute_hover(&doc.text, pos, doc.graph.as_ref()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let uri = &params.text_document.uri;
+
+        let docs = self.documents.lock().unwrap();
+        if let Some(doc) = docs.get(uri) {
+            let syms = symbols::compute_symbols(&doc.text, doc.graph.as_ref());
+            Ok(Some(DocumentSymbolResponse::Flat(syms)))
+        } else {
+            Ok(Some(DocumentSymbolResponse::Flat(Vec::new())))
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+
+    let (service, socket) = LspService::new(FdLanguageServer::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
+}

--- a/crates/fd-lsp/src/symbols.rs
+++ b/crates/fd-lsp/src/symbols.rs
@@ -1,0 +1,129 @@
+//! Document symbols: provide outline/go-to-symbol for FD documents.
+
+use fd_core::SceneGraph;
+use tower_lsp::lsp_types::*;
+
+/// Compute document symbols from parsed scene graph.
+///
+/// Returns a flat list of `SymbolInformation` for nodes and styles,
+/// with line ranges computed from the source text.
+#[allow(deprecated)] // SymbolInformation::deprecated is deprecated but required
+pub fn compute_symbols(text: &str, graph: Option<&SceneGraph>) -> Vec<SymbolInformation> {
+    let mut symbols = Vec::new();
+
+    // Style definitions
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("style ") {
+            if let Some(name) = rest.split_whitespace().next() {
+                symbols.push(SymbolInformation {
+                    name: format!("style {}", name),
+                    kind: SymbolKind::CLASS,
+                    location: Location {
+                        uri: Url::parse("file:///dummy").unwrap(),
+                        range: Range {
+                            start: Position::new(i as u32, 0),
+                            end: Position::new(i as u32, line.len() as u32),
+                        },
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: None,
+                });
+            }
+        }
+    }
+
+    // Scene graph nodes
+    if let Some(graph) = graph {
+        let node_lines = find_node_lines(text);
+        for (id_str, line_num) in &node_lines {
+            if let Some(node) = graph.get_by_id(fd_core::NodeId::intern(id_str)) {
+                let kind_name = match &node.kind {
+                    fd_core::NodeKind::Root => continue,
+                    fd_core::NodeKind::Group { .. } => "group",
+                    fd_core::NodeKind::Rect { .. } => "rect",
+                    fd_core::NodeKind::Ellipse { .. } => "ellipse",
+                    fd_core::NodeKind::Path { .. } => "path",
+                    fd_core::NodeKind::Text { .. } => "text",
+                };
+
+                let line = text.lines().nth(*line_num).unwrap_or("");
+
+                symbols.push(SymbolInformation {
+                    name: format!("{} @{}", kind_name, id_str),
+                    kind: match kind_name {
+                        "group" => SymbolKind::NAMESPACE,
+                        "text" => SymbolKind::STRING,
+                        _ => SymbolKind::OBJECT,
+                    },
+                    location: Location {
+                        uri: Url::parse("file:///dummy").unwrap(),
+                        range: Range {
+                            start: Position::new(*line_num as u32, 0),
+                            end: Position::new(*line_num as u32, line.len() as u32),
+                        },
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: None,
+                });
+            }
+        }
+    }
+
+    symbols
+}
+
+/// Find all `@id` declarations and their line numbers.
+fn find_node_lines(text: &str) -> Vec<(String, usize)> {
+    let mut results = Vec::new();
+    let node_keywords = ["group", "rect", "ellipse", "path", "text"];
+
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim();
+        for keyword in &node_keywords {
+            if trimmed.starts_with(keyword) {
+                if let Some(at_pos) = trimmed.find('@') {
+                    let after_at = &trimmed[at_pos + 1..];
+                    let id: String = after_at
+                        .chars()
+                        .take_while(|c| c.is_alphanumeric() || *c == '_')
+                        .collect();
+                    if !id.is_empty() && !id.starts_with("_anon_") {
+                        results.push((id, i));
+                    }
+                }
+            }
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_node_lines_basic() {
+        let text = "rect @box {\n  w: 100\n}\ntext @label \"Hi\" {\n  fill: #333\n}";
+        let lines = find_node_lines(text);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].0, "box");
+        assert_eq!(lines[0].1, 0);
+        assert_eq!(lines[1].0, "label");
+        assert_eq!(lines[1].1, 3);
+    }
+
+    #[test]
+    fn compute_symbols_with_graph() {
+        let text = "style accent {\n  fill: #6C5CE7\n}\nrect @box {\n  w: 100 h: 50\n}";
+        let graph = fd_core::parser::parse_document(text).ok();
+        let syms = compute_symbols(text, graph.as_ref());
+
+        let names: Vec<&str> = syms.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"style accent"));
+        assert!(names.contains(&"rect @box"));
+    }
+}

--- a/tree-sitter-fd/grammar.js
+++ b/tree-sitter-fd/grammar.js
@@ -1,0 +1,145 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
+/**
+ * Tree-sitter grammar for FD (Fast Draft) format.
+ *
+ * FD is a token-efficient format for describing 2D scene graphs
+ * with shapes, text, styles, animations, and constraints.
+ */
+module.exports = grammar({
+    name: "fd",
+
+    extras: ($) => [/\s/, $.comment],
+
+    rules: {
+        // ─── Document ────────────────────────────────────────────
+        document: ($) =>
+            repeat(
+                choice(
+                    $.style_block,
+                    $.node_declaration,
+                    $.constraint_line,
+                    $.annotation,
+                ),
+            ),
+
+        // ─── Comments ────────────────────────────────────────────
+        comment: (_$) => token(prec(-1, seq("#", /[^#\n][^\n]*/))),
+
+        // ─── Annotations ─────────────────────────────────────────
+        annotation: ($) =>
+            seq(
+                "##",
+                optional(
+                    choice($.annotation_typed, $.string, $.annotation_text),
+                ),
+            ),
+
+        annotation_typed: ($) =>
+            seq(
+                field("key", $.annotation_keyword),
+                ":",
+                field("value", choice($.string, $.annotation_text)),
+            ),
+
+        annotation_text: (_$) => /[^\n]+/,
+
+        annotation_keyword: (_$) =>
+            choice("accept", "status", "priority", "tag"),
+
+        // ─── Style Block ─────────────────────────────────────────
+        style_block: ($) =>
+            seq(
+                "style",
+                field("name", $.identifier),
+                "{",
+                repeat($.property),
+                "}",
+            ),
+
+        // ─── Node Declaration ────────────────────────────────────
+        node_declaration: ($) =>
+            seq(
+                field("kind", $.node_kind),
+                optional(field("id", $.node_id)),
+                optional(field("inline_text", $.string)),
+                "{",
+                repeat($.node_body_item),
+                "}",
+            ),
+
+        node_kind: (_$) => choice("group", "rect", "ellipse", "path", "text"),
+
+        node_body_item: ($) =>
+            choice(
+                $.property,
+                $.node_declaration,
+                $.anim_block,
+                $.annotation,
+            ),
+
+        // ─── Properties ──────────────────────────────────────────
+        property: ($) =>
+            prec.right(seq(
+                field("name", $.property_name),
+                ":",
+                repeat1($._value_item),
+            )),
+
+        property_name: (_$) =>
+            choice(
+                "w", "h", "width", "height",
+                "fill", "stroke", "corner", "opacity",
+                "font", "bg", "use", "layout",
+                "shadow", "scale", "rotate", "translate",
+                "center_in", "offset", "ease", "duration",
+            ),
+
+        _value_item: ($) =>
+            choice(
+                $.number,
+                $.hex_color,
+                $.string,
+                $.node_id,
+                $.key_value_pair,
+                $.identifier,
+            ),
+
+        key_value_pair: ($) =>
+            prec(1, seq($.identifier, "=", choice($.number, $.hex_color, $.string, $.identifier))),
+
+        // ─── Animation Block ─────────────────────────────────────
+        anim_block: ($) =>
+            seq(
+                "anim",
+                field("trigger", $.anim_trigger),
+                "{",
+                repeat($.property),
+                "}",
+            ),
+
+        anim_trigger: ($) => seq(":", $.identifier),
+
+        // ─── Constraint Line ─────────────────────────────────────
+        constraint_line: ($) =>
+            prec.right(seq(
+                field("target", $.node_id),
+                "->",
+                field("constraint_type", $.identifier),
+                ":",
+                repeat1($._value_item),
+            )),
+
+        // ─── Literals ────────────────────────────────────────────
+        node_id: ($) => seq("@", $.identifier),
+
+        identifier: (_$) => /[a-zA-Z_][a-zA-Z0-9_]*/,
+
+        number: (_$) => /-?\d+(\.\d+)?(ms)?/,
+
+        hex_color: (_$) => /#[0-9A-Fa-f]{3,8}/,
+
+        string: (_$) => seq('"', /[^"]*/, '"'),
+    },
+});

--- a/tree-sitter-fd/package.json
+++ b/tree-sitter-fd/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "tree-sitter-fd",
+  "version": "0.1.0",
+  "description": "Tree-sitter grammar for FD (Fast Draft) files",
+  "license": "MIT",
+  "author": "Khang Nghiêm",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/khangnghiem/fast-draft"
+  },
+  "main": "bindings/node",
+  "keywords": [
+    "tree-sitter",
+    "fd",
+    "fast-draft",
+    "parser"
+  ],
+  "files": [
+    "grammar.js",
+    "binding.gyp",
+    "prebuilds/**",
+    "bindings/node/*",
+    "queries/*",
+    "src/**"
+  ],
+  "dependencies": {
+    "nan": "^2.18.0"
+  },
+  "devDependencies": {
+    "tree-sitter-cli": "^0.24.0"
+  },
+  "scripts": {
+    "build": "tree-sitter generate && node-gyp build",
+    "test": "tree-sitter test",
+    "parse": "tree-sitter parse"
+  }
+}

--- a/tree-sitter-fd/queries/highlights.scm
+++ b/tree-sitter-fd/queries/highlights.scm
@@ -1,0 +1,49 @@
+; FD (Fast Draft) — Tree-sitter highlight queries
+; For use with Zed, Neovim, Helix, Emacs, etc.
+
+; ─── Comments ──────────────────────────────────────────────
+(comment) @comment
+
+; ─── Keywords ──────────────────────────────────────────────
+(node_kind) @keyword
+"style" @keyword
+"anim" @keyword
+
+; ─── Node IDs ──────────────────────────────────────────────
+(node_id
+  (identifier) @variable)
+(node_id) @variable
+
+; ─── Properties ────────────────────────────────────────────
+(property_name) @property
+
+; ─── Annotations ───────────────────────────────────────────
+"##" @attribute
+(annotation_keyword) @attribute
+
+; ─── Animation trigger ─────────────────────────────────────
+(anim_trigger
+  (identifier) @label)
+
+; ─── Constraint arrow ──────────────────────────────────────
+"->" @operator
+
+; ─── Literals ──────────────────────────────────────────────
+(number) @number
+(hex_color) @constant.builtin
+(string) @string
+
+; ─── Key-value pairs ───────────────────────────────────────
+(key_value_pair
+  key: (identifier) @property)
+
+; ─── Identifiers (layout modes, easing, etc.) ─────────────
+(property_value
+  (identifier) @constant)
+
+; ─── Punctuation ───────────────────────────────────────────
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+":" @punctuation.delimiter
+"," @punctuation.delimiter
+"=" @operator

--- a/tree-sitter-fd/src/grammar.json
+++ b/tree-sitter-fd/src/grammar.json
@@ -1,0 +1,603 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
+  "name": "fd",
+  "rules": {
+    "document": {
+      "type": "REPEAT",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "style_block"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "node_declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "constraint_line"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "annotation"
+          }
+        ]
+      }
+    },
+    "comment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "#"
+            },
+            {
+              "type": "PATTERN",
+              "value": "[^#\\n][^\\n]*"
+            }
+          ]
+        }
+      }
+    },
+    "annotation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "##"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "annotation_typed"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "string"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "annotation_text"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "annotation_typed": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "key",
+          "content": {
+            "type": "SYMBOL",
+            "name": "annotation_keyword"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "annotation_text"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "annotation_text": {
+      "type": "PATTERN",
+      "value": "[^\\n]+"
+    },
+    "annotation_keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "accept"
+        },
+        {
+          "type": "STRING",
+          "value": "status"
+        },
+        {
+          "type": "STRING",
+          "value": "priority"
+        },
+        {
+          "type": "STRING",
+          "value": "tag"
+        }
+      ]
+    },
+    "style_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "style"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "property"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "node_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "kind",
+          "content": {
+            "type": "SYMBOL",
+            "name": "node_kind"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "id",
+              "content": {
+                "type": "SYMBOL",
+                "name": "node_id"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "inline_text",
+              "content": {
+                "type": "SYMBOL",
+                "name": "string"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "node_body_item"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "node_kind": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "group"
+        },
+        {
+          "type": "STRING",
+          "value": "rect"
+        },
+        {
+          "type": "STRING",
+          "value": "ellipse"
+        },
+        {
+          "type": "STRING",
+          "value": "path"
+        },
+        {
+          "type": "STRING",
+          "value": "text"
+        }
+      ]
+    },
+    "node_body_item": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "property"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "node_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "anim_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "annotation"
+        }
+      ]
+    },
+    "property": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "property_name"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_value_item"
+            }
+          }
+        ]
+      }
+    },
+    "property_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "w"
+        },
+        {
+          "type": "STRING",
+          "value": "h"
+        },
+        {
+          "type": "STRING",
+          "value": "width"
+        },
+        {
+          "type": "STRING",
+          "value": "height"
+        },
+        {
+          "type": "STRING",
+          "value": "fill"
+        },
+        {
+          "type": "STRING",
+          "value": "stroke"
+        },
+        {
+          "type": "STRING",
+          "value": "corner"
+        },
+        {
+          "type": "STRING",
+          "value": "opacity"
+        },
+        {
+          "type": "STRING",
+          "value": "font"
+        },
+        {
+          "type": "STRING",
+          "value": "bg"
+        },
+        {
+          "type": "STRING",
+          "value": "use"
+        },
+        {
+          "type": "STRING",
+          "value": "layout"
+        },
+        {
+          "type": "STRING",
+          "value": "shadow"
+        },
+        {
+          "type": "STRING",
+          "value": "scale"
+        },
+        {
+          "type": "STRING",
+          "value": "rotate"
+        },
+        {
+          "type": "STRING",
+          "value": "translate"
+        },
+        {
+          "type": "STRING",
+          "value": "center_in"
+        },
+        {
+          "type": "STRING",
+          "value": "offset"
+        },
+        {
+          "type": "STRING",
+          "value": "ease"
+        },
+        {
+          "type": "STRING",
+          "value": "duration"
+        }
+      ]
+    },
+    "_value_item": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hex_color"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "node_id"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "key_value_pair"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "key_value_pair": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "STRING",
+            "value": "="
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "number"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "hex_color"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "string"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "anim_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "anim"
+        },
+        {
+          "type": "FIELD",
+          "name": "trigger",
+          "content": {
+            "type": "SYMBOL",
+            "name": "anim_trigger"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "property"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "anim_trigger": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "constraint_line": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "target",
+            "content": {
+              "type": "SYMBOL",
+              "name": "node_id"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "->"
+          },
+          {
+            "type": "FIELD",
+            "name": "constraint_type",
+            "content": {
+              "type": "SYMBOL",
+              "name": "identifier"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "REPEAT1",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_value_item"
+            }
+          }
+        ]
+      }
+    },
+    "node_id": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "@"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        }
+      ]
+    },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+    },
+    "number": {
+      "type": "PATTERN",
+      "value": "-?\\d+(\\.\\d+)?(ms)?"
+    },
+    "hex_color": {
+      "type": "PATTERN",
+      "value": "#[0-9A-Fa-f]{3,8}"
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\""
+        },
+        {
+          "type": "PATTERN",
+          "value": "[^\"]*"
+        },
+        {
+          "type": "STRING",
+          "value": "\""
+        }
+      ]
+    }
+  },
+  "extras": [
+    {
+      "type": "PATTERN",
+      "value": "\\s"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "comment"
+    }
+  ],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [],
+  "inline": [],
+  "supertypes": []
+}

--- a/tree-sitter-fd/src/node-types.json
+++ b/tree-sitter-fd/src/node-types.json
@@ -1,0 +1,563 @@
+[
+  {
+    "type": "anim_block",
+    "named": true,
+    "fields": {
+      "trigger": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "anim_trigger",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "property",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "anim_trigger",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "annotation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "annotation_text",
+          "named": true
+        },
+        {
+          "type": "annotation_typed",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "annotation_keyword",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "annotation_typed",
+    "named": true,
+    "fields": {
+      "key": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "annotation_keyword",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "annotation_text",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "constraint_line",
+    "named": true,
+    "fields": {
+      "constraint_type": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "target": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "node_id",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "hex_color",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "key_value_pair",
+          "named": true
+        },
+        {
+          "type": "node_id",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "document",
+    "named": true,
+    "root": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "constraint_line",
+          "named": true
+        },
+        {
+          "type": "node_declaration",
+          "named": true
+        },
+        {
+          "type": "style_block",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "key_value_pair",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "hex_color",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_body_item",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "anim_block",
+          "named": true
+        },
+        {
+          "type": "annotation",
+          "named": true
+        },
+        {
+          "type": "node_declaration",
+          "named": true
+        },
+        {
+          "type": "property",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_declaration",
+    "named": true,
+    "fields": {
+      "id": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "node_id",
+            "named": true
+          }
+        ]
+      },
+      "inline_text": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "string",
+            "named": true
+          }
+        ]
+      },
+      "kind": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "node_kind",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "node_body_item",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_id",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "node_kind",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "property",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "property_name",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "hex_color",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "key_value_pair",
+          "named": true
+        },
+        {
+          "type": "node_id",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "property_name",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "style_block",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "property",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "\"",
+    "named": false
+  },
+  {
+    "type": "##",
+    "named": false
+  },
+  {
+    "type": "->",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "accept",
+    "named": false
+  },
+  {
+    "type": "anim",
+    "named": false
+  },
+  {
+    "type": "annotation_text",
+    "named": true
+  },
+  {
+    "type": "bg",
+    "named": false
+  },
+  {
+    "type": "center_in",
+    "named": false
+  },
+  {
+    "type": "comment",
+    "named": true
+  },
+  {
+    "type": "corner",
+    "named": false
+  },
+  {
+    "type": "duration",
+    "named": false
+  },
+  {
+    "type": "ease",
+    "named": false
+  },
+  {
+    "type": "ellipse",
+    "named": false
+  },
+  {
+    "type": "fill",
+    "named": false
+  },
+  {
+    "type": "font",
+    "named": false
+  },
+  {
+    "type": "group",
+    "named": false
+  },
+  {
+    "type": "h",
+    "named": false
+  },
+  {
+    "type": "height",
+    "named": false
+  },
+  {
+    "type": "hex_color",
+    "named": true
+  },
+  {
+    "type": "identifier",
+    "named": true
+  },
+  {
+    "type": "layout",
+    "named": false
+  },
+  {
+    "type": "number",
+    "named": true
+  },
+  {
+    "type": "offset",
+    "named": false
+  },
+  {
+    "type": "opacity",
+    "named": false
+  },
+  {
+    "type": "path",
+    "named": false
+  },
+  {
+    "type": "priority",
+    "named": false
+  },
+  {
+    "type": "rect",
+    "named": false
+  },
+  {
+    "type": "rotate",
+    "named": false
+  },
+  {
+    "type": "scale",
+    "named": false
+  },
+  {
+    "type": "shadow",
+    "named": false
+  },
+  {
+    "type": "status",
+    "named": false
+  },
+  {
+    "type": "stroke",
+    "named": false
+  },
+  {
+    "type": "style",
+    "named": false
+  },
+  {
+    "type": "tag",
+    "named": false
+  },
+  {
+    "type": "text",
+    "named": false
+  },
+  {
+    "type": "translate",
+    "named": false
+  },
+  {
+    "type": "use",
+    "named": false
+  },
+  {
+    "type": "w",
+    "named": false
+  },
+  {
+    "type": "width",
+    "named": false
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]

--- a/tree-sitter-fd/src/parser.c
+++ b/tree-sitter-fd/src/parser.c
@@ -1,0 +1,6119 @@
+#include "tree_sitter/parser.h"
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#ifdef _MSC_VER
+#pragma optimize("", off)
+#elif defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC optimize ("O0")
+#endif
+
+#define LANGUAGE_VERSION 14
+#define STATE_COUNT 94
+#define LARGE_STATE_COUNT 18
+#define SYMBOL_COUNT 67
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 46
+#define EXTERNAL_TOKEN_COUNT 0
+#define FIELD_COUNT 9
+#define MAX_ALIAS_SEQUENCE_LENGTH 6
+#define PRODUCTION_ID_COUNT 10
+
+enum ts_symbol_identifiers {
+  sym_comment = 1,
+  anon_sym_POUND_POUND = 2,
+  anon_sym_COLON = 3,
+  sym_annotation_text = 4,
+  anon_sym_accept = 5,
+  anon_sym_status = 6,
+  anon_sym_priority = 7,
+  anon_sym_tag = 8,
+  anon_sym_style = 9,
+  anon_sym_LBRACE = 10,
+  anon_sym_RBRACE = 11,
+  anon_sym_group = 12,
+  anon_sym_rect = 13,
+  anon_sym_ellipse = 14,
+  anon_sym_path = 15,
+  anon_sym_text = 16,
+  anon_sym_w = 17,
+  anon_sym_h = 18,
+  anon_sym_width = 19,
+  anon_sym_height = 20,
+  anon_sym_fill = 21,
+  anon_sym_stroke = 22,
+  anon_sym_corner = 23,
+  anon_sym_opacity = 24,
+  anon_sym_font = 25,
+  anon_sym_bg = 26,
+  anon_sym_use = 27,
+  anon_sym_layout = 28,
+  anon_sym_shadow = 29,
+  anon_sym_scale = 30,
+  anon_sym_rotate = 31,
+  anon_sym_translate = 32,
+  anon_sym_center_in = 33,
+  anon_sym_offset = 34,
+  anon_sym_ease = 35,
+  anon_sym_duration = 36,
+  anon_sym_EQ = 37,
+  anon_sym_anim = 38,
+  anon_sym_DASH_GT = 39,
+  anon_sym_AT = 40,
+  sym_identifier = 41,
+  sym_number = 42,
+  sym_hex_color = 43,
+  anon_sym_DQUOTE = 44,
+  aux_sym_string_token1 = 45,
+  sym_document = 46,
+  sym_annotation = 47,
+  sym_annotation_typed = 48,
+  sym_annotation_keyword = 49,
+  sym_style_block = 50,
+  sym_node_declaration = 51,
+  sym_node_kind = 52,
+  sym_node_body_item = 53,
+  sym_property = 54,
+  sym_property_name = 55,
+  sym__value_item = 56,
+  sym_key_value_pair = 57,
+  sym_anim_block = 58,
+  sym_anim_trigger = 59,
+  sym_constraint_line = 60,
+  sym_node_id = 61,
+  sym_string = 62,
+  aux_sym_document_repeat1 = 63,
+  aux_sym_style_block_repeat1 = 64,
+  aux_sym_node_declaration_repeat1 = 65,
+  aux_sym_property_repeat1 = 66,
+};
+
+static const char * const ts_symbol_names[] = {
+  [ts_builtin_sym_end] = "end",
+  [sym_comment] = "comment",
+  [anon_sym_POUND_POUND] = "##",
+  [anon_sym_COLON] = ":",
+  [sym_annotation_text] = "annotation_text",
+  [anon_sym_accept] = "accept",
+  [anon_sym_status] = "status",
+  [anon_sym_priority] = "priority",
+  [anon_sym_tag] = "tag",
+  [anon_sym_style] = "style",
+  [anon_sym_LBRACE] = "{",
+  [anon_sym_RBRACE] = "}",
+  [anon_sym_group] = "group",
+  [anon_sym_rect] = "rect",
+  [anon_sym_ellipse] = "ellipse",
+  [anon_sym_path] = "path",
+  [anon_sym_text] = "text",
+  [anon_sym_w] = "w",
+  [anon_sym_h] = "h",
+  [anon_sym_width] = "width",
+  [anon_sym_height] = "height",
+  [anon_sym_fill] = "fill",
+  [anon_sym_stroke] = "stroke",
+  [anon_sym_corner] = "corner",
+  [anon_sym_opacity] = "opacity",
+  [anon_sym_font] = "font",
+  [anon_sym_bg] = "bg",
+  [anon_sym_use] = "use",
+  [anon_sym_layout] = "layout",
+  [anon_sym_shadow] = "shadow",
+  [anon_sym_scale] = "scale",
+  [anon_sym_rotate] = "rotate",
+  [anon_sym_translate] = "translate",
+  [anon_sym_center_in] = "center_in",
+  [anon_sym_offset] = "offset",
+  [anon_sym_ease] = "ease",
+  [anon_sym_duration] = "duration",
+  [anon_sym_EQ] = "=",
+  [anon_sym_anim] = "anim",
+  [anon_sym_DASH_GT] = "->",
+  [anon_sym_AT] = "@",
+  [sym_identifier] = "identifier",
+  [sym_number] = "number",
+  [sym_hex_color] = "hex_color",
+  [anon_sym_DQUOTE] = "\"",
+  [aux_sym_string_token1] = "string_token1",
+  [sym_document] = "document",
+  [sym_annotation] = "annotation",
+  [sym_annotation_typed] = "annotation_typed",
+  [sym_annotation_keyword] = "annotation_keyword",
+  [sym_style_block] = "style_block",
+  [sym_node_declaration] = "node_declaration",
+  [sym_node_kind] = "node_kind",
+  [sym_node_body_item] = "node_body_item",
+  [sym_property] = "property",
+  [sym_property_name] = "property_name",
+  [sym__value_item] = "_value_item",
+  [sym_key_value_pair] = "key_value_pair",
+  [sym_anim_block] = "anim_block",
+  [sym_anim_trigger] = "anim_trigger",
+  [sym_constraint_line] = "constraint_line",
+  [sym_node_id] = "node_id",
+  [sym_string] = "string",
+  [aux_sym_document_repeat1] = "document_repeat1",
+  [aux_sym_style_block_repeat1] = "style_block_repeat1",
+  [aux_sym_node_declaration_repeat1] = "node_declaration_repeat1",
+  [aux_sym_property_repeat1] = "property_repeat1",
+};
+
+static const TSSymbol ts_symbol_map[] = {
+  [ts_builtin_sym_end] = ts_builtin_sym_end,
+  [sym_comment] = sym_comment,
+  [anon_sym_POUND_POUND] = anon_sym_POUND_POUND,
+  [anon_sym_COLON] = anon_sym_COLON,
+  [sym_annotation_text] = sym_annotation_text,
+  [anon_sym_accept] = anon_sym_accept,
+  [anon_sym_status] = anon_sym_status,
+  [anon_sym_priority] = anon_sym_priority,
+  [anon_sym_tag] = anon_sym_tag,
+  [anon_sym_style] = anon_sym_style,
+  [anon_sym_LBRACE] = anon_sym_LBRACE,
+  [anon_sym_RBRACE] = anon_sym_RBRACE,
+  [anon_sym_group] = anon_sym_group,
+  [anon_sym_rect] = anon_sym_rect,
+  [anon_sym_ellipse] = anon_sym_ellipse,
+  [anon_sym_path] = anon_sym_path,
+  [anon_sym_text] = anon_sym_text,
+  [anon_sym_w] = anon_sym_w,
+  [anon_sym_h] = anon_sym_h,
+  [anon_sym_width] = anon_sym_width,
+  [anon_sym_height] = anon_sym_height,
+  [anon_sym_fill] = anon_sym_fill,
+  [anon_sym_stroke] = anon_sym_stroke,
+  [anon_sym_corner] = anon_sym_corner,
+  [anon_sym_opacity] = anon_sym_opacity,
+  [anon_sym_font] = anon_sym_font,
+  [anon_sym_bg] = anon_sym_bg,
+  [anon_sym_use] = anon_sym_use,
+  [anon_sym_layout] = anon_sym_layout,
+  [anon_sym_shadow] = anon_sym_shadow,
+  [anon_sym_scale] = anon_sym_scale,
+  [anon_sym_rotate] = anon_sym_rotate,
+  [anon_sym_translate] = anon_sym_translate,
+  [anon_sym_center_in] = anon_sym_center_in,
+  [anon_sym_offset] = anon_sym_offset,
+  [anon_sym_ease] = anon_sym_ease,
+  [anon_sym_duration] = anon_sym_duration,
+  [anon_sym_EQ] = anon_sym_EQ,
+  [anon_sym_anim] = anon_sym_anim,
+  [anon_sym_DASH_GT] = anon_sym_DASH_GT,
+  [anon_sym_AT] = anon_sym_AT,
+  [sym_identifier] = sym_identifier,
+  [sym_number] = sym_number,
+  [sym_hex_color] = sym_hex_color,
+  [anon_sym_DQUOTE] = anon_sym_DQUOTE,
+  [aux_sym_string_token1] = aux_sym_string_token1,
+  [sym_document] = sym_document,
+  [sym_annotation] = sym_annotation,
+  [sym_annotation_typed] = sym_annotation_typed,
+  [sym_annotation_keyword] = sym_annotation_keyword,
+  [sym_style_block] = sym_style_block,
+  [sym_node_declaration] = sym_node_declaration,
+  [sym_node_kind] = sym_node_kind,
+  [sym_node_body_item] = sym_node_body_item,
+  [sym_property] = sym_property,
+  [sym_property_name] = sym_property_name,
+  [sym__value_item] = sym__value_item,
+  [sym_key_value_pair] = sym_key_value_pair,
+  [sym_anim_block] = sym_anim_block,
+  [sym_anim_trigger] = sym_anim_trigger,
+  [sym_constraint_line] = sym_constraint_line,
+  [sym_node_id] = sym_node_id,
+  [sym_string] = sym_string,
+  [aux_sym_document_repeat1] = aux_sym_document_repeat1,
+  [aux_sym_style_block_repeat1] = aux_sym_style_block_repeat1,
+  [aux_sym_node_declaration_repeat1] = aux_sym_node_declaration_repeat1,
+  [aux_sym_property_repeat1] = aux_sym_property_repeat1,
+};
+
+static const TSSymbolMetadata ts_symbol_metadata[] = {
+  [ts_builtin_sym_end] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_comment] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_POUND_POUND] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_COLON] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_annotation_text] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_accept] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_status] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_priority] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_tag] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_style] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_LBRACE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RBRACE] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_group] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_rect] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_ellipse] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_path] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_text] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_w] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_h] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_width] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_height] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_fill] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_stroke] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_corner] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_opacity] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_font] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_bg] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_use] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_layout] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_shadow] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_scale] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_rotate] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_translate] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_center_in] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_offset] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_ease] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_duration] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_EQ] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_anim] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DASH_GT] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_AT] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_identifier] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_number] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_hex_color] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_DQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_string_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym_document] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_annotation] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_annotation_typed] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_annotation_keyword] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_style_block] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_declaration] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_kind] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_body_item] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_property] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_property_name] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__value_item] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_key_value_pair] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_anim_block] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_anim_trigger] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_constraint_line] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_node_id] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_string] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym_document_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_style_block_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_node_declaration_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+  [aux_sym_property_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+};
+
+enum ts_field_identifiers {
+  field_constraint_type = 1,
+  field_id = 2,
+  field_inline_text = 3,
+  field_key = 4,
+  field_kind = 5,
+  field_name = 6,
+  field_target = 7,
+  field_trigger = 8,
+  field_value = 9,
+};
+
+static const char * const ts_field_names[] = {
+  [0] = NULL,
+  [field_constraint_type] = "constraint_type",
+  [field_id] = "id",
+  [field_inline_text] = "inline_text",
+  [field_key] = "key",
+  [field_kind] = "kind",
+  [field_name] = "name",
+  [field_target] = "target",
+  [field_trigger] = "trigger",
+  [field_value] = "value",
+};
+
+static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
+  [1] = {.index = 0, .length = 1},
+  [2] = {.index = 1, .length = 2},
+  [3] = {.index = 3, .length = 1},
+  [4] = {.index = 4, .length = 2},
+  [5] = {.index = 6, .length = 2},
+  [6] = {.index = 8, .length = 1},
+  [7] = {.index = 9, .length = 3},
+  [8] = {.index = 12, .length = 2},
+  [9] = {.index = 14, .length = 1},
+};
+
+static const TSFieldMapEntry ts_field_map_entries[] = {
+  [0] =
+    {field_kind, 0},
+  [1] =
+    {field_key, 0},
+    {field_value, 2},
+  [3] =
+    {field_name, 1},
+  [4] =
+    {field_id, 1},
+    {field_kind, 0},
+  [6] =
+    {field_inline_text, 1},
+    {field_kind, 0},
+  [8] =
+    {field_name, 0},
+  [9] =
+    {field_id, 1},
+    {field_inline_text, 2},
+    {field_kind, 0},
+  [12] =
+    {field_constraint_type, 2},
+    {field_target, 0},
+  [14] =
+    {field_trigger, 1},
+};
+
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+  [0] = {0},
+};
+
+static const uint16_t ts_non_terminal_alias_map[] = {
+  0,
+};
+
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 15,
+  [16] = 16,
+  [17] = 17,
+  [18] = 15,
+  [19] = 3,
+  [20] = 20,
+  [21] = 21,
+  [22] = 22,
+  [23] = 23,
+  [24] = 24,
+  [25] = 25,
+  [26] = 26,
+  [27] = 27,
+  [28] = 28,
+  [29] = 29,
+  [30] = 2,
+  [31] = 31,
+  [32] = 32,
+  [33] = 33,
+  [34] = 14,
+  [35] = 15,
+  [36] = 16,
+  [37] = 17,
+  [38] = 38,
+  [39] = 39,
+  [40] = 40,
+  [41] = 41,
+  [42] = 42,
+  [43] = 43,
+  [44] = 3,
+  [45] = 4,
+  [46] = 46,
+  [47] = 47,
+  [48] = 14,
+  [49] = 16,
+  [50] = 17,
+  [51] = 15,
+  [52] = 52,
+  [53] = 53,
+  [54] = 53,
+  [55] = 55,
+  [56] = 56,
+  [57] = 57,
+  [58] = 57,
+  [59] = 57,
+  [60] = 60,
+  [61] = 16,
+  [62] = 62,
+  [63] = 63,
+  [64] = 64,
+  [65] = 65,
+  [66] = 66,
+  [67] = 67,
+  [68] = 68,
+  [69] = 66,
+  [70] = 70,
+  [71] = 71,
+  [72] = 72,
+  [73] = 73,
+  [74] = 74,
+  [75] = 75,
+  [76] = 76,
+  [77] = 77,
+  [78] = 78,
+  [79] = 79,
+  [80] = 80,
+  [81] = 74,
+  [82] = 66,
+  [83] = 83,
+  [84] = 84,
+  [85] = 74,
+  [86] = 86,
+  [87] = 87,
+  [88] = 74,
+  [89] = 66,
+  [90] = 83,
+  [91] = 77,
+  [92] = 83,
+  [93] = 83,
+};
+
+static bool ts_lex(TSLexer *lexer, TSStateId state) {
+  START_LEXER();
+  eof = lexer->eof(lexer);
+  switch (state) {
+    case 0:
+      if (eof) ADVANCE(117);
+      ADVANCE_MAP(
+        '"', 479,
+        '#', 6,
+        '-', 10,
+        ':', 123,
+        '=', 337,
+        '@', 342,
+        'a', 359,
+        'b', 386,
+        'c', 367,
+        'd', 459,
+        'e', 355,
+        'f', 393,
+        'g', 427,
+        'h', 280,
+        'l', 345,
+        'o', 384,
+        'p', 346,
+        'r', 379,
+        's', 361,
+        't', 348,
+        'u', 435,
+        'w', 277,
+        '{', 259,
+        '}', 260,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(0);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('i' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 1:
+      if (lookahead == '\n') SKIP(1);
+      if (lookahead == '"') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(128);
+      if (lookahead == 'a') ADVANCE(144);
+      if (lookahead == 'b') ADVANCE(169);
+      if (lookahead == 'c') ADVANCE(152);
+      if (lookahead == 'd') ADVANCE(238);
+      if (lookahead == 'e') ADVANCE(141);
+      if (lookahead == 'f') ADVANCE(176);
+      if (lookahead == 'g') ADVANCE(208);
+      if (lookahead == 'h') ADVANCE(282);
+      if (lookahead == 'l') ADVANCE(130);
+      if (lookahead == 'o') ADVANCE(167);
+      if (lookahead == 'p') ADVANCE(131);
+      if (lookahead == 'r') ADVANCE(162);
+      if (lookahead == 's') ADVANCE(147);
+      if (lookahead == 't') ADVANCE(132);
+      if (lookahead == 'u') ADVANCE(214);
+      if (lookahead == 'w') ADVANCE(279);
+      if (lookahead == '}') ADVANCE(261);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(125);
+      if (lookahead != 0) ADVANCE(247);
+      END_STATE();
+    case 2:
+      if (lookahead == '\n') SKIP(2);
+      if (lookahead == '"') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(127);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(126);
+      if (lookahead != 0) ADVANCE(247);
+      END_STATE();
+    case 3:
+      ADVANCE_MAP(
+        '"', 479,
+        '#', 6,
+        '-', 110,
+        '=', 337,
+        '@', 342,
+        'a', 410,
+        'b', 386,
+        'c', 367,
+        'd', 459,
+        'e', 355,
+        'f', 393,
+        'g', 427,
+        'h', 280,
+        'l', 345,
+        'o', 384,
+        'p', 347,
+        'r', 379,
+        's', 362,
+        't', 368,
+        'u', 435,
+        'w', 277,
+        '}', 260,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(3);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('i' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 4:
+      ADVANCE_MAP(
+        '"', 479,
+        '#', 112,
+        '-', 110,
+        '=', 337,
+        '@', 342,
+        'b', 386,
+        'c', 367,
+        'd', 459,
+        'e', 356,
+        'f', 393,
+        'h', 280,
+        'l', 345,
+        'o', 384,
+        'r', 420,
+        's', 362,
+        't', 432,
+        'u', 435,
+        'w', 277,
+        '}', 260,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(4);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 5:
+      if (lookahead == '"') ADVANCE(479);
+      if (lookahead == '#') ADVANCE(112);
+      if (lookahead == '-') ADVANCE(110);
+      if (lookahead == '@') ADVANCE(342);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(5);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 6:
+      if (lookahead == '#') ADVANCE(121);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(119);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(120);
+      END_STATE();
+    case 7:
+      if (lookahead == '#') ADVANCE(121);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(120);
+      END_STATE();
+    case 8:
+      if (lookahead == '#') ADVANCE(113);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(8);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 9:
+      if (lookahead == '>') ADVANCE(341);
+      END_STATE();
+    case 10:
+      if (lookahead == '>') ADVANCE(341);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      END_STATE();
+    case 11:
+      if (lookahead == '_') ADVANCE(53);
+      END_STATE();
+    case 12:
+      if (lookahead == 'a') ADVANCE(109);
+      END_STATE();
+    case 13:
+      if (lookahead == 'a') ADVANCE(89);
+      END_STATE();
+    case 14:
+      if (lookahead == 'a') ADVANCE(23);
+      END_STATE();
+    case 15:
+      if (lookahead == 'a') ADVANCE(25);
+      END_STATE();
+    case 16:
+      if (lookahead == 'a') ADVANCE(85);
+      if (lookahead == 'l') ADVANCE(57);
+      END_STATE();
+    case 17:
+      if (lookahead == 'a') ADVANCE(68);
+      END_STATE();
+    case 18:
+      if (lookahead == 'a') ADVANCE(59);
+      END_STATE();
+    case 19:
+      if (lookahead == 'a') ADVANCE(99);
+      END_STATE();
+    case 20:
+      if (lookahead == 'a') ADVANCE(100);
+      END_STATE();
+    case 21:
+      if (lookahead == 'a') ADVANCE(102);
+      END_STATE();
+    case 22:
+      if (lookahead == 'c') ADVANCE(18);
+      if (lookahead == 'h') ADVANCE(15);
+      if (lookahead == 't') ADVANCE(80);
+      END_STATE();
+    case 23:
+      if (lookahead == 'c') ADVANCE(54);
+      END_STATE();
+    case 24:
+      if (lookahead == 'c') ADVANCE(91);
+      END_STATE();
+    case 25:
+      if (lookahead == 'd') ADVANCE(71);
+      END_STATE();
+    case 26:
+      if (lookahead == 'd') ADVANCE(98);
+      END_STATE();
+    case 27:
+      if (lookahead == 'e') ADVANCE(24);
+      if (lookahead == 'o') ADVANCE(101);
+      END_STATE();
+    case 28:
+      if (lookahead == 'e') ADVANCE(107);
+      if (lookahead == 'r') ADVANCE(17);
+      END_STATE();
+    case 29:
+      if (lookahead == 'e') ADVANCE(307);
+      END_STATE();
+    case 30:
+      if (lookahead == 'e') ADVANCE(331);
+      END_STATE();
+    case 31:
+      if (lookahead == 'e') ADVANCE(316);
+      END_STATE();
+    case 32:
+      if (lookahead == 'e') ADVANCE(256);
+      END_STATE();
+    case 33:
+      if (lookahead == 'e') ADVANCE(319);
+      END_STATE();
+    case 34:
+      if (lookahead == 'e') ADVANCE(292);
+      END_STATE();
+    case 35:
+      if (lookahead == 'e') ADVANCE(268);
+      END_STATE();
+    case 36:
+      if (lookahead == 'e') ADVANCE(322);
+      END_STATE();
+    case 37:
+      if (lookahead == 'e') ADVANCE(66);
+      if (lookahead == 'o') ADVANCE(81);
+      END_STATE();
+    case 38:
+      if (lookahead == 'e') ADVANCE(78);
+      END_STATE();
+    case 39:
+      if (lookahead == 'e') ADVANCE(79);
+      END_STATE();
+    case 40:
+      if (lookahead == 'e') ADVANCE(95);
+      END_STATE();
+    case 41:
+      if (lookahead == 'f') ADVANCE(42);
+      if (lookahead == 'p') ADVANCE(14);
+      END_STATE();
+    case 42:
+      if (lookahead == 'f') ADVANCE(86);
+      END_STATE();
+    case 43:
+      if (lookahead == 'g') ADVANCE(304);
+      END_STATE();
+    case 44:
+      if (lookahead == 'g') ADVANCE(47);
+      END_STATE();
+    case 45:
+      if (lookahead == 'h') ADVANCE(271);
+      END_STATE();
+    case 46:
+      if (lookahead == 'h') ADVANCE(283);
+      END_STATE();
+    case 47:
+      if (lookahead == 'h') ADVANCE(93);
+      END_STATE();
+    case 48:
+      if (lookahead == 'i') ADVANCE(62);
+      END_STATE();
+    case 49:
+      if (lookahead == 'i') ADVANCE(76);
+      END_STATE();
+    case 50:
+      if (lookahead == 'i') ADVANCE(44);
+      END_STATE();
+    case 51:
+      if (lookahead == 'i') ADVANCE(58);
+      if (lookahead == 'o') ADVANCE(67);
+      END_STATE();
+    case 52:
+      if (lookahead == 'i') ADVANCE(74);
+      END_STATE();
+    case 53:
+      if (lookahead == 'i') ADVANCE(65);
+      END_STATE();
+    case 54:
+      if (lookahead == 'i') ADVANCE(96);
+      END_STATE();
+    case 55:
+      if (lookahead == 'k') ADVANCE(34);
+      END_STATE();
+    case 56:
+      if (lookahead == 'l') ADVANCE(289);
+      END_STATE();
+    case 57:
+      if (lookahead == 'l') ADVANCE(49);
+      END_STATE();
+    case 58:
+      if (lookahead == 'l') ADVANCE(56);
+      END_STATE();
+    case 59:
+      if (lookahead == 'l') ADVANCE(31);
+      END_STATE();
+    case 60:
+      if (lookahead == 'l') ADVANCE(32);
+      END_STATE();
+    case 61:
+      if (lookahead == 'l') ADVANCE(21);
+      END_STATE();
+    case 62:
+      if (lookahead == 'm') ADVANCE(338);
+      END_STATE();
+    case 63:
+      if (lookahead == 'n') ADVANCE(48);
+      END_STATE();
+    case 64:
+      if (lookahead == 'n') ADVANCE(334);
+      END_STATE();
+    case 65:
+      if (lookahead == 'n') ADVANCE(325);
+      END_STATE();
+    case 66:
+      if (lookahead == 'n') ADVANCE(97);
+      END_STATE();
+    case 67:
+      if (lookahead == 'n') ADVANCE(90);
+      END_STATE();
+    case 68:
+      if (lookahead == 'n') ADVANCE(87);
+      END_STATE();
+    case 69:
+      if (lookahead == 'n') ADVANCE(39);
+      END_STATE();
+    case 70:
+      if (lookahead == 'o') ADVANCE(55);
+      END_STATE();
+    case 71:
+      if (lookahead == 'o') ADVANCE(106);
+      END_STATE();
+    case 72:
+      if (lookahead == 'o') ADVANCE(103);
+      END_STATE();
+    case 73:
+      if (lookahead == 'o') ADVANCE(105);
+      END_STATE();
+    case 74:
+      if (lookahead == 'o') ADVANCE(64);
+      END_STATE();
+    case 75:
+      if (lookahead == 'p') ADVANCE(262);
+      END_STATE();
+    case 76:
+      if (lookahead == 'p') ADVANCE(88);
+      END_STATE();
+    case 77:
+      if (lookahead == 'r') ADVANCE(72);
+      END_STATE();
+    case 78:
+      if (lookahead == 'r') ADVANCE(11);
+      END_STATE();
+    case 79:
+      if (lookahead == 'r') ADVANCE(295);
+      END_STATE();
+    case 80:
+      if (lookahead == 'r') ADVANCE(70);
+      if (lookahead == 'y') ADVANCE(60);
+      END_STATE();
+    case 81:
+      if (lookahead == 'r') ADVANCE(69);
+      END_STATE();
+    case 82:
+      if (lookahead == 'r') ADVANCE(19);
+      END_STATE();
+    case 83:
+      if (lookahead == 's') ADVANCE(470);
+      END_STATE();
+    case 84:
+      if (lookahead == 's') ADVANCE(29);
+      END_STATE();
+    case 85:
+      if (lookahead == 's') ADVANCE(30);
+      END_STATE();
+    case 86:
+      if (lookahead == 's') ADVANCE(40);
+      END_STATE();
+    case 87:
+      if (lookahead == 's') ADVANCE(61);
+      END_STATE();
+    case 88:
+      if (lookahead == 's') ADVANCE(35);
+      END_STATE();
+    case 89:
+      if (lookahead == 't') ADVANCE(45);
+      END_STATE();
+    case 90:
+      if (lookahead == 't') ADVANCE(301);
+      END_STATE();
+    case 91:
+      if (lookahead == 't') ADVANCE(265);
+      END_STATE();
+    case 92:
+      if (lookahead == 't') ADVANCE(274);
+      END_STATE();
+    case 93:
+      if (lookahead == 't') ADVANCE(286);
+      END_STATE();
+    case 94:
+      if (lookahead == 't') ADVANCE(310);
+      END_STATE();
+    case 95:
+      if (lookahead == 't') ADVANCE(328);
+      END_STATE();
+    case 96:
+      if (lookahead == 't') ADVANCE(108);
+      END_STATE();
+    case 97:
+      if (lookahead == 't') ADVANCE(38);
+      END_STATE();
+    case 98:
+      if (lookahead == 't') ADVANCE(46);
+      END_STATE();
+    case 99:
+      if (lookahead == 't') ADVANCE(52);
+      END_STATE();
+    case 100:
+      if (lookahead == 't') ADVANCE(33);
+      END_STATE();
+    case 101:
+      if (lookahead == 't') ADVANCE(20);
+      END_STATE();
+    case 102:
+      if (lookahead == 't') ADVANCE(36);
+      END_STATE();
+    case 103:
+      if (lookahead == 'u') ADVANCE(75);
+      END_STATE();
+    case 104:
+      if (lookahead == 'u') ADVANCE(82);
+      END_STATE();
+    case 105:
+      if (lookahead == 'u') ADVANCE(94);
+      END_STATE();
+    case 106:
+      if (lookahead == 'w') ADVANCE(313);
+      END_STATE();
+    case 107:
+      if (lookahead == 'x') ADVANCE(92);
+      END_STATE();
+    case 108:
+      if (lookahead == 'y') ADVANCE(298);
+      END_STATE();
+    case 109:
+      if (lookahead == 'y') ADVANCE(73);
+      END_STATE();
+    case 110:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      END_STATE();
+    case 111:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(472);
+      END_STATE();
+    case 112:
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(119);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '#') ADVANCE(120);
+      END_STATE();
+    case 113:
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != '#') ADVANCE(120);
+      END_STATE();
+    case 114:
+      if (eof) ADVANCE(117);
+      if (lookahead == '\n') SKIP(114);
+      if (lookahead == '"') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(128);
+      if (lookahead == '@') ADVANCE(343);
+      if (lookahead == 'a') ADVANCE(145);
+      if (lookahead == 'e') ADVANCE(185);
+      if (lookahead == 'g') ADVANCE(208);
+      if (lookahead == 'p') ADVANCE(131);
+      if (lookahead == 'r') ADVANCE(163);
+      if (lookahead == 's') ADVANCE(228);
+      if (lookahead == 't') ADVANCE(133);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(124);
+      if (lookahead != 0) ADVANCE(247);
+      END_STATE();
+    case 115:
+      if (eof) ADVANCE(117);
+      ADVANCE_MAP(
+        '"', 479,
+        '#', 6,
+        '-', 110,
+        '=', 337,
+        '@', 342,
+        'e', 402,
+        'g', 427,
+        'p', 347,
+        'r', 380,
+        's', 453,
+        't', 369,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(115);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 116:
+      if (eof) ADVANCE(117);
+      ADVANCE_MAP(
+        '"', 479,
+        '#', 7,
+        '-', 9,
+        ':', 123,
+        '@', 342,
+        'a', 63,
+        'b', 43,
+        'c', 37,
+        'd', 104,
+        'e', 16,
+        'f', 51,
+        'g', 77,
+        'h', 281,
+        'l', 12,
+        'o', 41,
+        'p', 13,
+        'r', 27,
+        's', 22,
+        't', 28,
+        'u', 84,
+        'w', 278,
+        '{', 259,
+        '}', 260,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(116);
+      END_STATE();
+    case 117:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 118:
+      ACCEPT_TOKEN(sym_comment);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(478);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(120);
+      END_STATE();
+    case 119:
+      ACCEPT_TOKEN(sym_comment);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(118);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(120);
+      END_STATE();
+    case 120:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(120);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(anon_sym_POUND_POUND);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(anon_sym_POUND_POUND);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 123:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 124:
+      ACCEPT_TOKEN(sym_annotation_text);
+      ADVANCE_MAP(
+        '"', 480,
+        '#', 128,
+        '@', 343,
+        'a', 145,
+        'e', 185,
+        'g', 208,
+        'p', 131,
+        'r', 163,
+        's', 228,
+        't', 133,
+      );
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(124);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(247);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(sym_annotation_text);
+      ADVANCE_MAP(
+        '"', 480,
+        '#', 128,
+        'a', 144,
+        'b', 169,
+        'c', 152,
+        'd', 238,
+        'e', 141,
+        'f', 176,
+        'g', 208,
+        'h', 282,
+        'l', 130,
+        'o', 167,
+        'p', 131,
+        'r', 162,
+        's', 147,
+        't', 132,
+        'u', 214,
+        'w', 279,
+        '}', 261,
+      );
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(125);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(247);
+      END_STATE();
+    case 126:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == '"') ADVANCE(480);
+      if (lookahead == '#') ADVANCE(127);
+      if (lookahead == '\t' ||
+          (0x0b <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(126);
+      if (lookahead != 0 &&
+          (lookahead < '\t' || '\r' < lookahead)) ADVANCE(247);
+      END_STATE();
+    case 127:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == '#') ADVANCE(247);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 128:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == '#') ADVANCE(122);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 129:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == '_') ADVANCE(180);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 130:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(246);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 131:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(220);
+      if (lookahead == 'r') ADVANCE(177);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 132:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(170);
+      if (lookahead == 'e') ADVANCE(243);
+      if (lookahead == 'r') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 133:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(170);
+      if (lookahead == 'e') ADVANCE(243);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 134:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(150);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 135:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(148);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 136:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(195);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 137:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(189);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 138:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(232);
+      if (lookahead == 'r') ADVANCE(199);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 139:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(232);
+      if (lookahead == 'y') ADVANCE(190);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 140:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(234);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 141:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(216);
+      if (lookahead == 'l') ADVANCE(188);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 142:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(236);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 143:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'a') ADVANCE(237);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 144:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(146);
+      if (lookahead == 'n') ADVANCE(175);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 145:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(146);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 146:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(154);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 147:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(137);
+      if (lookahead == 'h') ADVANCE(134);
+      if (lookahead == 't') ADVANCE(138);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 148:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(182);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 149:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'c') ADVANCE(222);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 150:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'd') ADVANCE(200);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'd') ADVANCE(231);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(196);
+      if (lookahead == 'o') ADVANCE(211);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(309);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(206);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 155:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(333);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 156:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(318);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(321);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(294);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(270);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(324);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(258);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(149);
+      if (lookahead == 'o') ADVANCE(235);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 163:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(149);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(209);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(210);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'e') ADVANCE(227);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'f') ADVANCE(168);
+      if (lookahead == 'p') ADVANCE(135);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'f') ADVANCE(218);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'g') ADVANCE(306);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'g') ADVANCE(255);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'g') ADVANCE(174);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 172:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'h') ADVANCE(273);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 173:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'h') ADVANCE(285);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 174:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'h') ADVANCE(225);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 175:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(192);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 176:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(187);
+      if (lookahead == 'o') ADVANCE(197);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(203);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 178:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(207);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(171);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 180:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(194);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 181:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(204);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 182:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(229);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'i') ADVANCE(230);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 184:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'k') ADVANCE(158);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 185:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(188);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 186:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(291);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 187:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(186);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 188:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(178);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 189:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(156);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 190:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(161);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 191:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'l') ADVANCE(143);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 192:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'm') ADVANCE(340);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 193:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(336);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(327);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 195:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(217);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 196:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(233);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 197:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(221);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 198:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'n') ADVANCE(165);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 199:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(184);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 200:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(242);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 201:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(240);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 202:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(241);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 203:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(213);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 204:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'o') ADVANCE(193);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'p') ADVANCE(264);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 206:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'p') ADVANCE(224);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 207:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'p') ADVANCE(219);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 208:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(201);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(129);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 210:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(297);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 211:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(198);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(140);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 213:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'r') ADVANCE(183);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 214:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(153);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 215:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(251);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 216:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(155);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 217:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(191);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 218:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(166);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 219:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 's') ADVANCE(159);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 220:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(172);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 221:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(303);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 222:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(267);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 223:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(276);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 224:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(249);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 225:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(288);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 226:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(312);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 227:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(330);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 228:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(139);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 229:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(244);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 230:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(245);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 231:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(173);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 232:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(239);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 233:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(164);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 234:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(181);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 235:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(142);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 236:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(157);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 237:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 't') ADVANCE(160);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 238:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'u') ADVANCE(212);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 239:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'u') ADVANCE(215);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 240:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'u') ADVANCE(205);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 241:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'u') ADVANCE(226);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 242:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'w') ADVANCE(315);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 243:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'x') ADVANCE(223);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 244:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'y') ADVANCE(300);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 245:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'y') ADVANCE(253);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 246:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead == 'y') ADVANCE(202);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 247:
+      ACCEPT_TOKEN(sym_annotation_text);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 248:
+      ACCEPT_TOKEN(anon_sym_accept);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 249:
+      ACCEPT_TOKEN(anon_sym_accept);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 250:
+      ACCEPT_TOKEN(anon_sym_status);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 251:
+      ACCEPT_TOKEN(anon_sym_status);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 252:
+      ACCEPT_TOKEN(anon_sym_priority);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 253:
+      ACCEPT_TOKEN(anon_sym_priority);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 254:
+      ACCEPT_TOKEN(anon_sym_tag);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 255:
+      ACCEPT_TOKEN(anon_sym_tag);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 256:
+      ACCEPT_TOKEN(anon_sym_style);
+      END_STATE();
+    case 257:
+      ACCEPT_TOKEN(anon_sym_style);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 258:
+      ACCEPT_TOKEN(anon_sym_style);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 259:
+      ACCEPT_TOKEN(anon_sym_LBRACE);
+      END_STATE();
+    case 260:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      END_STATE();
+    case 261:
+      ACCEPT_TOKEN(anon_sym_RBRACE);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 262:
+      ACCEPT_TOKEN(anon_sym_group);
+      END_STATE();
+    case 263:
+      ACCEPT_TOKEN(anon_sym_group);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 264:
+      ACCEPT_TOKEN(anon_sym_group);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 265:
+      ACCEPT_TOKEN(anon_sym_rect);
+      END_STATE();
+    case 266:
+      ACCEPT_TOKEN(anon_sym_rect);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 267:
+      ACCEPT_TOKEN(anon_sym_rect);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 268:
+      ACCEPT_TOKEN(anon_sym_ellipse);
+      END_STATE();
+    case 269:
+      ACCEPT_TOKEN(anon_sym_ellipse);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 270:
+      ACCEPT_TOKEN(anon_sym_ellipse);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 271:
+      ACCEPT_TOKEN(anon_sym_path);
+      END_STATE();
+    case 272:
+      ACCEPT_TOKEN(anon_sym_path);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 273:
+      ACCEPT_TOKEN(anon_sym_path);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 274:
+      ACCEPT_TOKEN(anon_sym_text);
+      END_STATE();
+    case 275:
+      ACCEPT_TOKEN(anon_sym_text);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 276:
+      ACCEPT_TOKEN(anon_sym_text);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 277:
+      ACCEPT_TOKEN(anon_sym_w);
+      if (lookahead == 'i') ADVANCE(366);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 278:
+      ACCEPT_TOKEN(anon_sym_w);
+      if (lookahead == 'i') ADVANCE(26);
+      END_STATE();
+    case 279:
+      ACCEPT_TOKEN(anon_sym_w);
+      if (lookahead == 'i') ADVANCE(151);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 280:
+      ACCEPT_TOKEN(anon_sym_h);
+      if (lookahead == 'e') ADVANCE(396);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 281:
+      ACCEPT_TOKEN(anon_sym_h);
+      if (lookahead == 'e') ADVANCE(50);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(anon_sym_h);
+      if (lookahead == 'e') ADVANCE(179);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(anon_sym_width);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(anon_sym_width);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(anon_sym_width);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(anon_sym_height);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(anon_sym_height);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(anon_sym_height);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(anon_sym_fill);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(anon_sym_fill);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(anon_sym_fill);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(anon_sym_stroke);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(anon_sym_stroke);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(anon_sym_stroke);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(anon_sym_corner);
+      END_STATE();
+    case 296:
+      ACCEPT_TOKEN(anon_sym_corner);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 297:
+      ACCEPT_TOKEN(anon_sym_corner);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(anon_sym_opacity);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(anon_sym_opacity);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(anon_sym_opacity);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(anon_sym_font);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(anon_sym_font);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(anon_sym_font);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 304:
+      ACCEPT_TOKEN(anon_sym_bg);
+      END_STATE();
+    case 305:
+      ACCEPT_TOKEN(anon_sym_bg);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 306:
+      ACCEPT_TOKEN(anon_sym_bg);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 307:
+      ACCEPT_TOKEN(anon_sym_use);
+      END_STATE();
+    case 308:
+      ACCEPT_TOKEN(anon_sym_use);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 309:
+      ACCEPT_TOKEN(anon_sym_use);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 310:
+      ACCEPT_TOKEN(anon_sym_layout);
+      END_STATE();
+    case 311:
+      ACCEPT_TOKEN(anon_sym_layout);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 312:
+      ACCEPT_TOKEN(anon_sym_layout);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 313:
+      ACCEPT_TOKEN(anon_sym_shadow);
+      END_STATE();
+    case 314:
+      ACCEPT_TOKEN(anon_sym_shadow);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(anon_sym_shadow);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(anon_sym_scale);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(anon_sym_scale);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(anon_sym_scale);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(anon_sym_rotate);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(anon_sym_rotate);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(anon_sym_rotate);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(anon_sym_translate);
+      END_STATE();
+    case 323:
+      ACCEPT_TOKEN(anon_sym_translate);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 324:
+      ACCEPT_TOKEN(anon_sym_translate);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 325:
+      ACCEPT_TOKEN(anon_sym_center_in);
+      END_STATE();
+    case 326:
+      ACCEPT_TOKEN(anon_sym_center_in);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(anon_sym_center_in);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(anon_sym_offset);
+      END_STATE();
+    case 329:
+      ACCEPT_TOKEN(anon_sym_offset);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(anon_sym_offset);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 331:
+      ACCEPT_TOKEN(anon_sym_ease);
+      END_STATE();
+    case 332:
+      ACCEPT_TOKEN(anon_sym_ease);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 333:
+      ACCEPT_TOKEN(anon_sym_ease);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 334:
+      ACCEPT_TOKEN(anon_sym_duration);
+      END_STATE();
+    case 335:
+      ACCEPT_TOKEN(anon_sym_duration);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 336:
+      ACCEPT_TOKEN(anon_sym_duration);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 337:
+      ACCEPT_TOKEN(anon_sym_EQ);
+      END_STATE();
+    case 338:
+      ACCEPT_TOKEN(anon_sym_anim);
+      END_STATE();
+    case 339:
+      ACCEPT_TOKEN(anon_sym_anim);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 340:
+      ACCEPT_TOKEN(anon_sym_anim);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 342:
+      ACCEPT_TOKEN(anon_sym_AT);
+      END_STATE();
+    case 343:
+      ACCEPT_TOKEN(anon_sym_AT);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 344:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '_') ADVANCE(397);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 345:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(467);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 346:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(441);
+      if (lookahead == 'r') ADVANCE(394);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 347:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(441);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 348:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(387);
+      if (lookahead == 'e') ADVANCE(464);
+      if (lookahead == 'r') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 349:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(365);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 350:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(363);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 351:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(413);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 352:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(406);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 353:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(452);
+      if (lookahead == 'r') ADVANCE(417);
+      if (lookahead == 'y') ADVANCE(407);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 354:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(455);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 355:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(437);
+      if (lookahead == 'l') ADVANCE(405);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 356:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(437);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 357:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(457);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 358:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'a') ADVANCE(458);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(360);
+      if (lookahead == 'n') ADVANCE(392);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(371);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(352);
+      if (lookahead == 'h') ADVANCE(349);
+      if (lookahead == 't') ADVANCE(353);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(352);
+      if (lookahead == 'h') ADVANCE(349);
+      if (lookahead == 't') ADVANCE(431);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(399);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'c') ADVANCE(443);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 365:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(418);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 366:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(451);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 367:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(414);
+      if (lookahead == 'o') ADVANCE(430);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 368:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(464);
+      if (lookahead == 'r') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 369:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(464);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 370:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(308);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 371:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(425);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 372:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(332);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 373:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(317);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 374:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(257);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 375:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(320);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 376:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(293);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 377:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(269);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(323);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 379:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(364);
+      if (lookahead == 'o') ADVANCE(456);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 380:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(364);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 381:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(428);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(429);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 383:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'e') ADVANCE(448);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 384:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'f') ADVANCE(385);
+      if (lookahead == 'p') ADVANCE(350);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 385:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'f') ADVANCE(439);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 386:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(305);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 387:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(254);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 388:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'g') ADVANCE(391);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 389:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(272);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 390:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(284);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(446);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 392:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(409);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 393:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(404);
+      if (lookahead == 'o') ADVANCE(415);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(422);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(426);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(388);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 397:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(412);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(423);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(449);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'i') ADVANCE(450);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 401:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'k') ADVANCE(376);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(405);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 403:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(290);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(403);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(395);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(373);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 407:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(374);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 408:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'l') ADVANCE(358);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 409:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'm') ADVANCE(339);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 410:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(392);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 411:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(335);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(326);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(438);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(454);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(442);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(382);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(401);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(463);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(461);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 420:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(456);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 421:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(462);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 422:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(434);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 423:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'o') ADVANCE(411);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 424:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'p') ADVANCE(263);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'p') ADVANCE(445);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'p') ADVANCE(440);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(419);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 428:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(344);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 429:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(296);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 430:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(416);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 431:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(417);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 432:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(351);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 433:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(354);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 434:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(400);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 435:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(370);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 436:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(250);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 437:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(372);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 438:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(408);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 439:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(383);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 440:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(377);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 441:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(389);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 442:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(302);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 443:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(266);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 444:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(275);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 445:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(248);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 446:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(287);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 447:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(311);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 448:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(329);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 449:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(465);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 450:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(466);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 451:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(390);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 452:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(460);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 453:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(468);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 454:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(381);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 455:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(398);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 456:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(357);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 457:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(375);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 458:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 't') ADVANCE(378);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 459:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(433);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 460:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(436);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 461:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(424);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 462:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(447);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 463:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'w') ADVANCE(314);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 464:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'x') ADVANCE(444);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 465:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(299);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 466:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(252);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 467:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(421);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 468:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'y') ADVANCE(407);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 469:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(469);
+      END_STATE();
+    case 470:
+      ACCEPT_TOKEN(sym_number);
+      END_STATE();
+    case 471:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '.') ADVANCE(111);
+      if (lookahead == 'm') ADVANCE(83);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(471);
+      END_STATE();
+    case 472:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == 'm') ADVANCE(83);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(472);
+      END_STATE();
+    case 473:
+      ACCEPT_TOKEN(sym_hex_color);
+      END_STATE();
+    case 474:
+      ACCEPT_TOKEN(sym_hex_color);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(473);
+      END_STATE();
+    case 475:
+      ACCEPT_TOKEN(sym_hex_color);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(474);
+      END_STATE();
+    case 476:
+      ACCEPT_TOKEN(sym_hex_color);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(475);
+      END_STATE();
+    case 477:
+      ACCEPT_TOKEN(sym_hex_color);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(476);
+      END_STATE();
+    case 478:
+      ACCEPT_TOKEN(sym_hex_color);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(477);
+      END_STATE();
+    case 479:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      END_STATE();
+    case 480:
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(247);
+      END_STATE();
+    case 481:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\n') ADVANCE(484);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(481);
+      END_STATE();
+    case 482:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '#') ADVANCE(483);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(482);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '#') ADVANCE(484);
+      END_STATE();
+    case 483:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\n' ||
+          lookahead == '#') ADVANCE(484);
+      if (lookahead != 0 &&
+          lookahead != '"' &&
+          lookahead != '#') ADVANCE(481);
+      END_STATE();
+    case 484:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead != 0 &&
+          lookahead != '"') ADVANCE(484);
+      END_STATE();
+    default:
+      return false;
+  }
+}
+
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
+  [0] = {.lex_state = 0},
+  [1] = {.lex_state = 116},
+  [2] = {.lex_state = 3},
+  [3] = {.lex_state = 3},
+  [4] = {.lex_state = 1},
+  [5] = {.lex_state = 116},
+  [6] = {.lex_state = 116},
+  [7] = {.lex_state = 116},
+  [8] = {.lex_state = 116},
+  [9] = {.lex_state = 116},
+  [10] = {.lex_state = 116},
+  [11] = {.lex_state = 116},
+  [12] = {.lex_state = 116},
+  [13] = {.lex_state = 116},
+  [14] = {.lex_state = 3},
+  [15] = {.lex_state = 3},
+  [16] = {.lex_state = 3},
+  [17] = {.lex_state = 3},
+  [18] = {.lex_state = 116},
+  [19] = {.lex_state = 4},
+  [20] = {.lex_state = 116},
+  [21] = {.lex_state = 116},
+  [22] = {.lex_state = 116},
+  [23] = {.lex_state = 116},
+  [24] = {.lex_state = 116},
+  [25] = {.lex_state = 116},
+  [26] = {.lex_state = 116},
+  [27] = {.lex_state = 116},
+  [28] = {.lex_state = 116},
+  [29] = {.lex_state = 116},
+  [30] = {.lex_state = 4},
+  [31] = {.lex_state = 116},
+  [32] = {.lex_state = 116},
+  [33] = {.lex_state = 116},
+  [34] = {.lex_state = 4},
+  [35] = {.lex_state = 4},
+  [36] = {.lex_state = 4},
+  [37] = {.lex_state = 4},
+  [38] = {.lex_state = 116},
+  [39] = {.lex_state = 116},
+  [40] = {.lex_state = 116},
+  [41] = {.lex_state = 116},
+  [42] = {.lex_state = 116},
+  [43] = {.lex_state = 115},
+  [44] = {.lex_state = 115},
+  [45] = {.lex_state = 114},
+  [46] = {.lex_state = 116},
+  [47] = {.lex_state = 116},
+  [48] = {.lex_state = 115},
+  [49] = {.lex_state = 115},
+  [50] = {.lex_state = 115},
+  [51] = {.lex_state = 115},
+  [52] = {.lex_state = 5},
+  [53] = {.lex_state = 5},
+  [54] = {.lex_state = 5},
+  [55] = {.lex_state = 116},
+  [56] = {.lex_state = 116},
+  [57] = {.lex_state = 5},
+  [58] = {.lex_state = 5},
+  [59] = {.lex_state = 5},
+  [60] = {.lex_state = 116},
+  [61] = {.lex_state = 116},
+  [62] = {.lex_state = 116},
+  [63] = {.lex_state = 2},
+  [64] = {.lex_state = 116},
+  [65] = {.lex_state = 116},
+  [66] = {.lex_state = 116},
+  [67] = {.lex_state = 116},
+  [68] = {.lex_state = 116},
+  [69] = {.lex_state = 116},
+  [70] = {.lex_state = 8},
+  [71] = {.lex_state = 116},
+  [72] = {.lex_state = 116},
+  [73] = {.lex_state = 116},
+  [74] = {.lex_state = 8},
+  [75] = {.lex_state = 8},
+  [76] = {.lex_state = 116},
+  [77] = {.lex_state = 116},
+  [78] = {.lex_state = 116},
+  [79] = {.lex_state = 116},
+  [80] = {.lex_state = 116},
+  [81] = {.lex_state = 8},
+  [82] = {.lex_state = 116},
+  [83] = {.lex_state = 482},
+  [84] = {.lex_state = 116},
+  [85] = {.lex_state = 8},
+  [86] = {.lex_state = 116},
+  [87] = {.lex_state = 8},
+  [88] = {.lex_state = 8},
+  [89] = {.lex_state = 116},
+  [90] = {.lex_state = 482},
+  [91] = {.lex_state = 116},
+  [92] = {.lex_state = 482},
+  [93] = {.lex_state = 482},
+};
+
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+  [0] = {
+    [ts_builtin_sym_end] = ACTIONS(1),
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(1),
+    [anon_sym_COLON] = ACTIONS(1),
+    [anon_sym_accept] = ACTIONS(1),
+    [anon_sym_status] = ACTIONS(1),
+    [anon_sym_priority] = ACTIONS(1),
+    [anon_sym_tag] = ACTIONS(1),
+    [anon_sym_style] = ACTIONS(1),
+    [anon_sym_LBRACE] = ACTIONS(1),
+    [anon_sym_RBRACE] = ACTIONS(1),
+    [anon_sym_group] = ACTIONS(1),
+    [anon_sym_rect] = ACTIONS(1),
+    [anon_sym_ellipse] = ACTIONS(1),
+    [anon_sym_path] = ACTIONS(1),
+    [anon_sym_text] = ACTIONS(1),
+    [anon_sym_w] = ACTIONS(1),
+    [anon_sym_h] = ACTIONS(1),
+    [anon_sym_width] = ACTIONS(1),
+    [anon_sym_height] = ACTIONS(1),
+    [anon_sym_fill] = ACTIONS(1),
+    [anon_sym_stroke] = ACTIONS(1),
+    [anon_sym_corner] = ACTIONS(1),
+    [anon_sym_opacity] = ACTIONS(1),
+    [anon_sym_font] = ACTIONS(1),
+    [anon_sym_bg] = ACTIONS(1),
+    [anon_sym_use] = ACTIONS(1),
+    [anon_sym_layout] = ACTIONS(1),
+    [anon_sym_shadow] = ACTIONS(1),
+    [anon_sym_scale] = ACTIONS(1),
+    [anon_sym_rotate] = ACTIONS(1),
+    [anon_sym_translate] = ACTIONS(1),
+    [anon_sym_center_in] = ACTIONS(1),
+    [anon_sym_offset] = ACTIONS(1),
+    [anon_sym_ease] = ACTIONS(1),
+    [anon_sym_duration] = ACTIONS(1),
+    [anon_sym_EQ] = ACTIONS(1),
+    [anon_sym_anim] = ACTIONS(1),
+    [anon_sym_DASH_GT] = ACTIONS(1),
+    [anon_sym_AT] = ACTIONS(1),
+    [sym_identifier] = ACTIONS(1),
+    [sym_number] = ACTIONS(1),
+    [sym_hex_color] = ACTIONS(1),
+    [anon_sym_DQUOTE] = ACTIONS(1),
+  },
+  [1] = {
+    [sym_document] = STATE(68),
+    [sym_annotation] = STATE(47),
+    [sym_style_block] = STATE(47),
+    [sym_node_declaration] = STATE(47),
+    [sym_node_kind] = STATE(60),
+    [sym_constraint_line] = STATE(47),
+    [sym_node_id] = STATE(72),
+    [aux_sym_document_repeat1] = STATE(47),
+    [ts_builtin_sym_end] = ACTIONS(5),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(9),
+    [anon_sym_style] = ACTIONS(11),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_AT] = ACTIONS(15),
+  },
+  [2] = {
+    [sym__value_item] = STATE(3),
+    [sym_key_value_pair] = STATE(3),
+    [sym_node_id] = STATE(3),
+    [sym_string] = STATE(3),
+    [aux_sym_property_repeat1] = STATE(3),
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(17),
+    [anon_sym_RBRACE] = ACTIONS(17),
+    [anon_sym_group] = ACTIONS(19),
+    [anon_sym_rect] = ACTIONS(19),
+    [anon_sym_ellipse] = ACTIONS(19),
+    [anon_sym_path] = ACTIONS(19),
+    [anon_sym_text] = ACTIONS(19),
+    [anon_sym_w] = ACTIONS(19),
+    [anon_sym_h] = ACTIONS(19),
+    [anon_sym_width] = ACTIONS(19),
+    [anon_sym_height] = ACTIONS(19),
+    [anon_sym_fill] = ACTIONS(19),
+    [anon_sym_stroke] = ACTIONS(19),
+    [anon_sym_corner] = ACTIONS(19),
+    [anon_sym_opacity] = ACTIONS(19),
+    [anon_sym_font] = ACTIONS(19),
+    [anon_sym_bg] = ACTIONS(19),
+    [anon_sym_use] = ACTIONS(19),
+    [anon_sym_layout] = ACTIONS(19),
+    [anon_sym_shadow] = ACTIONS(19),
+    [anon_sym_scale] = ACTIONS(19),
+    [anon_sym_rotate] = ACTIONS(19),
+    [anon_sym_translate] = ACTIONS(19),
+    [anon_sym_center_in] = ACTIONS(19),
+    [anon_sym_offset] = ACTIONS(19),
+    [anon_sym_ease] = ACTIONS(19),
+    [anon_sym_duration] = ACTIONS(19),
+    [anon_sym_anim] = ACTIONS(19),
+    [anon_sym_AT] = ACTIONS(21),
+    [sym_identifier] = ACTIONS(23),
+    [sym_number] = ACTIONS(25),
+    [sym_hex_color] = ACTIONS(25),
+    [anon_sym_DQUOTE] = ACTIONS(27),
+  },
+  [3] = {
+    [sym__value_item] = STATE(3),
+    [sym_key_value_pair] = STATE(3),
+    [sym_node_id] = STATE(3),
+    [sym_string] = STATE(3),
+    [aux_sym_property_repeat1] = STATE(3),
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(29),
+    [anon_sym_RBRACE] = ACTIONS(29),
+    [anon_sym_group] = ACTIONS(31),
+    [anon_sym_rect] = ACTIONS(31),
+    [anon_sym_ellipse] = ACTIONS(31),
+    [anon_sym_path] = ACTIONS(31),
+    [anon_sym_text] = ACTIONS(31),
+    [anon_sym_w] = ACTIONS(31),
+    [anon_sym_h] = ACTIONS(31),
+    [anon_sym_width] = ACTIONS(31),
+    [anon_sym_height] = ACTIONS(31),
+    [anon_sym_fill] = ACTIONS(31),
+    [anon_sym_stroke] = ACTIONS(31),
+    [anon_sym_corner] = ACTIONS(31),
+    [anon_sym_opacity] = ACTIONS(31),
+    [anon_sym_font] = ACTIONS(31),
+    [anon_sym_bg] = ACTIONS(31),
+    [anon_sym_use] = ACTIONS(31),
+    [anon_sym_layout] = ACTIONS(31),
+    [anon_sym_shadow] = ACTIONS(31),
+    [anon_sym_scale] = ACTIONS(31),
+    [anon_sym_rotate] = ACTIONS(31),
+    [anon_sym_translate] = ACTIONS(31),
+    [anon_sym_center_in] = ACTIONS(31),
+    [anon_sym_offset] = ACTIONS(31),
+    [anon_sym_ease] = ACTIONS(31),
+    [anon_sym_duration] = ACTIONS(31),
+    [anon_sym_anim] = ACTIONS(31),
+    [anon_sym_AT] = ACTIONS(33),
+    [sym_identifier] = ACTIONS(36),
+    [sym_number] = ACTIONS(39),
+    [sym_hex_color] = ACTIONS(39),
+    [anon_sym_DQUOTE] = ACTIONS(42),
+  },
+  [4] = {
+    [sym_annotation_typed] = STATE(25),
+    [sym_annotation_keyword] = STATE(86),
+    [sym_string] = STATE(25),
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(45),
+    [sym_annotation_text] = ACTIONS(47),
+    [anon_sym_accept] = ACTIONS(49),
+    [anon_sym_status] = ACTIONS(49),
+    [anon_sym_priority] = ACTIONS(49),
+    [anon_sym_tag] = ACTIONS(49),
+    [anon_sym_RBRACE] = ACTIONS(45),
+    [anon_sym_group] = ACTIONS(45),
+    [anon_sym_rect] = ACTIONS(45),
+    [anon_sym_ellipse] = ACTIONS(45),
+    [anon_sym_path] = ACTIONS(45),
+    [anon_sym_text] = ACTIONS(45),
+    [anon_sym_w] = ACTIONS(45),
+    [anon_sym_h] = ACTIONS(45),
+    [anon_sym_width] = ACTIONS(45),
+    [anon_sym_height] = ACTIONS(45),
+    [anon_sym_fill] = ACTIONS(45),
+    [anon_sym_stroke] = ACTIONS(45),
+    [anon_sym_corner] = ACTIONS(45),
+    [anon_sym_opacity] = ACTIONS(45),
+    [anon_sym_font] = ACTIONS(45),
+    [anon_sym_bg] = ACTIONS(45),
+    [anon_sym_use] = ACTIONS(45),
+    [anon_sym_layout] = ACTIONS(45),
+    [anon_sym_shadow] = ACTIONS(45),
+    [anon_sym_scale] = ACTIONS(45),
+    [anon_sym_rotate] = ACTIONS(45),
+    [anon_sym_translate] = ACTIONS(45),
+    [anon_sym_center_in] = ACTIONS(45),
+    [anon_sym_offset] = ACTIONS(45),
+    [anon_sym_ease] = ACTIONS(45),
+    [anon_sym_duration] = ACTIONS(45),
+    [anon_sym_anim] = ACTIONS(45),
+    [anon_sym_DQUOTE] = ACTIONS(51),
+  },
+  [5] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(12),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(12),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(55),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [6] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(6),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(6),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(63),
+    [anon_sym_RBRACE] = ACTIONS(66),
+    [anon_sym_group] = ACTIONS(68),
+    [anon_sym_rect] = ACTIONS(68),
+    [anon_sym_ellipse] = ACTIONS(68),
+    [anon_sym_path] = ACTIONS(68),
+    [anon_sym_text] = ACTIONS(68),
+    [anon_sym_w] = ACTIONS(71),
+    [anon_sym_h] = ACTIONS(71),
+    [anon_sym_width] = ACTIONS(74),
+    [anon_sym_height] = ACTIONS(74),
+    [anon_sym_fill] = ACTIONS(74),
+    [anon_sym_stroke] = ACTIONS(74),
+    [anon_sym_corner] = ACTIONS(74),
+    [anon_sym_opacity] = ACTIONS(74),
+    [anon_sym_font] = ACTIONS(74),
+    [anon_sym_bg] = ACTIONS(74),
+    [anon_sym_use] = ACTIONS(74),
+    [anon_sym_layout] = ACTIONS(74),
+    [anon_sym_shadow] = ACTIONS(74),
+    [anon_sym_scale] = ACTIONS(74),
+    [anon_sym_rotate] = ACTIONS(74),
+    [anon_sym_translate] = ACTIONS(74),
+    [anon_sym_center_in] = ACTIONS(74),
+    [anon_sym_offset] = ACTIONS(74),
+    [anon_sym_ease] = ACTIONS(74),
+    [anon_sym_duration] = ACTIONS(74),
+    [anon_sym_anim] = ACTIONS(77),
+  },
+  [7] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(6),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(6),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(80),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [8] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(13),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(13),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(82),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [9] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(7),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(7),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(84),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [10] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(6),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(6),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(86),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [11] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(10),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(10),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(88),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [12] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(6),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(6),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(90),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [13] = {
+    [sym_annotation] = STATE(31),
+    [sym_node_declaration] = STATE(31),
+    [sym_node_kind] = STATE(60),
+    [sym_node_body_item] = STATE(6),
+    [sym_property] = STATE(31),
+    [sym_property_name] = STATE(77),
+    [sym_anim_block] = STATE(31),
+    [aux_sym_node_declaration_repeat1] = STATE(6),
+    [sym_comment] = ACTIONS(7),
+    [anon_sym_POUND_POUND] = ACTIONS(53),
+    [anon_sym_RBRACE] = ACTIONS(92),
+    [anon_sym_group] = ACTIONS(13),
+    [anon_sym_rect] = ACTIONS(13),
+    [anon_sym_ellipse] = ACTIONS(13),
+    [anon_sym_path] = ACTIONS(13),
+    [anon_sym_text] = ACTIONS(13),
+    [anon_sym_w] = ACTIONS(57),
+    [anon_sym_h] = ACTIONS(57),
+    [anon_sym_width] = ACTIONS(59),
+    [anon_sym_height] = ACTIONS(59),
+    [anon_sym_fill] = ACTIONS(59),
+    [anon_sym_stroke] = ACTIONS(59),
+    [anon_sym_corner] = ACTIONS(59),
+    [anon_sym_opacity] = ACTIONS(59),
+    [anon_sym_font] = ACTIONS(59),
+    [anon_sym_bg] = ACTIONS(59),
+    [anon_sym_use] = ACTIONS(59),
+    [anon_sym_layout] = ACTIONS(59),
+    [anon_sym_shadow] = ACTIONS(59),
+    [anon_sym_scale] = ACTIONS(59),
+    [anon_sym_rotate] = ACTIONS(59),
+    [anon_sym_translate] = ACTIONS(59),
+    [anon_sym_center_in] = ACTIONS(59),
+    [anon_sym_offset] = ACTIONS(59),
+    [anon_sym_ease] = ACTIONS(59),
+    [anon_sym_duration] = ACTIONS(59),
+    [anon_sym_anim] = ACTIONS(61),
+  },
+  [14] = {
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(94),
+    [anon_sym_RBRACE] = ACTIONS(94),
+    [anon_sym_group] = ACTIONS(96),
+    [anon_sym_rect] = ACTIONS(96),
+    [anon_sym_ellipse] = ACTIONS(96),
+    [anon_sym_path] = ACTIONS(96),
+    [anon_sym_text] = ACTIONS(96),
+    [anon_sym_w] = ACTIONS(96),
+    [anon_sym_h] = ACTIONS(96),
+    [anon_sym_width] = ACTIONS(96),
+    [anon_sym_height] = ACTIONS(96),
+    [anon_sym_fill] = ACTIONS(96),
+    [anon_sym_stroke] = ACTIONS(96),
+    [anon_sym_corner] = ACTIONS(96),
+    [anon_sym_opacity] = ACTIONS(96),
+    [anon_sym_font] = ACTIONS(96),
+    [anon_sym_bg] = ACTIONS(96),
+    [anon_sym_use] = ACTIONS(96),
+    [anon_sym_layout] = ACTIONS(96),
+    [anon_sym_shadow] = ACTIONS(96),
+    [anon_sym_scale] = ACTIONS(96),
+    [anon_sym_rotate] = ACTIONS(96),
+    [anon_sym_translate] = ACTIONS(96),
+    [anon_sym_center_in] = ACTIONS(96),
+    [anon_sym_offset] = ACTIONS(96),
+    [anon_sym_ease] = ACTIONS(96),
+    [anon_sym_duration] = ACTIONS(96),
+    [anon_sym_EQ] = ACTIONS(98),
+    [anon_sym_anim] = ACTIONS(96),
+    [anon_sym_AT] = ACTIONS(94),
+    [sym_identifier] = ACTIONS(96),
+    [sym_number] = ACTIONS(94),
+    [sym_hex_color] = ACTIONS(94),
+    [anon_sym_DQUOTE] = ACTIONS(94),
+  },
+  [15] = {
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(100),
+    [anon_sym_RBRACE] = ACTIONS(100),
+    [anon_sym_group] = ACTIONS(102),
+    [anon_sym_rect] = ACTIONS(102),
+    [anon_sym_ellipse] = ACTIONS(102),
+    [anon_sym_path] = ACTIONS(102),
+    [anon_sym_text] = ACTIONS(102),
+    [anon_sym_w] = ACTIONS(102),
+    [anon_sym_h] = ACTIONS(102),
+    [anon_sym_width] = ACTIONS(102),
+    [anon_sym_height] = ACTIONS(102),
+    [anon_sym_fill] = ACTIONS(102),
+    [anon_sym_stroke] = ACTIONS(102),
+    [anon_sym_corner] = ACTIONS(102),
+    [anon_sym_opacity] = ACTIONS(102),
+    [anon_sym_font] = ACTIONS(102),
+    [anon_sym_bg] = ACTIONS(102),
+    [anon_sym_use] = ACTIONS(102),
+    [anon_sym_layout] = ACTIONS(102),
+    [anon_sym_shadow] = ACTIONS(102),
+    [anon_sym_scale] = ACTIONS(102),
+    [anon_sym_rotate] = ACTIONS(102),
+    [anon_sym_translate] = ACTIONS(102),
+    [anon_sym_center_in] = ACTIONS(102),
+    [anon_sym_offset] = ACTIONS(102),
+    [anon_sym_ease] = ACTIONS(102),
+    [anon_sym_duration] = ACTIONS(102),
+    [anon_sym_anim] = ACTIONS(102),
+    [anon_sym_AT] = ACTIONS(100),
+    [sym_identifier] = ACTIONS(102),
+    [sym_number] = ACTIONS(100),
+    [sym_hex_color] = ACTIONS(100),
+    [anon_sym_DQUOTE] = ACTIONS(100),
+  },
+  [16] = {
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(104),
+    [anon_sym_RBRACE] = ACTIONS(104),
+    [anon_sym_group] = ACTIONS(106),
+    [anon_sym_rect] = ACTIONS(106),
+    [anon_sym_ellipse] = ACTIONS(106),
+    [anon_sym_path] = ACTIONS(106),
+    [anon_sym_text] = ACTIONS(106),
+    [anon_sym_w] = ACTIONS(106),
+    [anon_sym_h] = ACTIONS(106),
+    [anon_sym_width] = ACTIONS(106),
+    [anon_sym_height] = ACTIONS(106),
+    [anon_sym_fill] = ACTIONS(106),
+    [anon_sym_stroke] = ACTIONS(106),
+    [anon_sym_corner] = ACTIONS(106),
+    [anon_sym_opacity] = ACTIONS(106),
+    [anon_sym_font] = ACTIONS(106),
+    [anon_sym_bg] = ACTIONS(106),
+    [anon_sym_use] = ACTIONS(106),
+    [anon_sym_layout] = ACTIONS(106),
+    [anon_sym_shadow] = ACTIONS(106),
+    [anon_sym_scale] = ACTIONS(106),
+    [anon_sym_rotate] = ACTIONS(106),
+    [anon_sym_translate] = ACTIONS(106),
+    [anon_sym_center_in] = ACTIONS(106),
+    [anon_sym_offset] = ACTIONS(106),
+    [anon_sym_ease] = ACTIONS(106),
+    [anon_sym_duration] = ACTIONS(106),
+    [anon_sym_anim] = ACTIONS(106),
+    [anon_sym_AT] = ACTIONS(104),
+    [sym_identifier] = ACTIONS(106),
+    [sym_number] = ACTIONS(104),
+    [sym_hex_color] = ACTIONS(104),
+    [anon_sym_DQUOTE] = ACTIONS(104),
+  },
+  [17] = {
+    [sym_comment] = ACTIONS(3),
+    [anon_sym_POUND_POUND] = ACTIONS(108),
+    [anon_sym_RBRACE] = ACTIONS(108),
+    [anon_sym_group] = ACTIONS(110),
+    [anon_sym_rect] = ACTIONS(110),
+    [anon_sym_ellipse] = ACTIONS(110),
+    [anon_sym_path] = ACTIONS(110),
+    [anon_sym_text] = ACTIONS(110),
+    [anon_sym_w] = ACTIONS(110),
+    [anon_sym_h] = ACTIONS(110),
+    [anon_sym_width] = ACTIONS(110),
+    [anon_sym_height] = ACTIONS(110),
+    [anon_sym_fill] = ACTIONS(110),
+    [anon_sym_stroke] = ACTIONS(110),
+    [anon_sym_corner] = ACTIONS(110),
+    [anon_sym_opacity] = ACTIONS(110),
+    [anon_sym_font] = ACTIONS(110),
+    [anon_sym_bg] = ACTIONS(110),
+    [anon_sym_use] = ACTIONS(110),
+    [anon_sym_layout] = ACTIONS(110),
+    [anon_sym_shadow] = ACTIONS(110),
+    [anon_sym_scale] = ACTIONS(110),
+    [anon_sym_rotate] = ACTIONS(110),
+    [anon_sym_translate] = ACTIONS(110),
+    [anon_sym_center_in] = ACTIONS(110),
+    [anon_sym_offset] = ACTIONS(110),
+    [anon_sym_ease] = ACTIONS(110),
+    [anon_sym_duration] = ACTIONS(110),
+    [anon_sym_anim] = ACTIONS(110),
+    [anon_sym_AT] = ACTIONS(108),
+    [sym_identifier] = ACTIONS(110),
+    [sym_number] = ACTIONS(108),
+    [sym_hex_color] = ACTIONS(108),
+    [anon_sym_DQUOTE] = ACTIONS(108),
+  },
+};
+
+static const uint16_t ts_small_parse_table[] = {
+  [0] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(102), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(100), 30,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_LBRACE,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [40] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(29), 1,
+      anon_sym_RBRACE,
+    ACTIONS(112), 1,
+      anon_sym_AT,
+    ACTIONS(115), 1,
+      sym_identifier,
+    ACTIONS(121), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(118), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(19), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+    ACTIONS(31), 20,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [89] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(126), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(124), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [128] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(130), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(128), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [167] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(134), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(132), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [206] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(138), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(136), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [245] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(142), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(140), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [284] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(146), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(144), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [323] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(150), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(148), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [362] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(154), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(152), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [401] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(158), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(156), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [440] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(162), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(160), 29,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+      anon_sym_AT,
+  [479] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(17), 1,
+      anon_sym_RBRACE,
+    ACTIONS(164), 1,
+      anon_sym_AT,
+    ACTIONS(166), 1,
+      sym_identifier,
+    ACTIONS(170), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(168), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(19), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+    ACTIONS(19), 20,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [528] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(174), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(172), 26,
+      anon_sym_POUND_POUND,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+  [564] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(178), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(176), 26,
+      anon_sym_POUND_POUND,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+  [600] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(182), 2,
+      anon_sym_w,
+      anon_sym_h,
+    ACTIONS(180), 26,
+      anon_sym_POUND_POUND,
+      anon_sym_RBRACE,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      anon_sym_anim,
+  [636] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(184), 1,
+      anon_sym_EQ,
+    ACTIONS(94), 5,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(96), 21,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      sym_identifier,
+  [673] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(100), 5,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(102), 21,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      sym_identifier,
+  [707] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(104), 5,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(106), 21,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      sym_identifier,
+  [741] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(108), 5,
+      anon_sym_RBRACE,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(110), 21,
+      anon_sym_w,
+      anon_sym_h,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+      sym_identifier,
+  [775] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(186), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_property_name,
+    ACTIONS(57), 2,
+      anon_sym_w,
+      anon_sym_h,
+    STATE(42), 2,
+      sym_property,
+      aux_sym_style_block_repeat1,
+    ACTIONS(59), 18,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [813] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(188), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_property_name,
+    ACTIONS(57), 2,
+      anon_sym_w,
+      anon_sym_h,
+    STATE(40), 2,
+      sym_property,
+      aux_sym_style_block_repeat1,
+    ACTIONS(59), 18,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [851] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(190), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_property_name,
+    ACTIONS(192), 2,
+      anon_sym_w,
+      anon_sym_h,
+    STATE(40), 2,
+      sym_property,
+      aux_sym_style_block_repeat1,
+    ACTIONS(195), 18,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [889] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(198), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_property_name,
+    ACTIONS(57), 2,
+      anon_sym_w,
+      anon_sym_h,
+    STATE(39), 2,
+      sym_property,
+      aux_sym_style_block_repeat1,
+    ACTIONS(59), 18,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [927] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(200), 1,
+      anon_sym_RBRACE,
+    STATE(91), 1,
+      sym_property_name,
+    ACTIONS(57), 2,
+      anon_sym_w,
+      anon_sym_h,
+    STATE(40), 2,
+      sym_property,
+      aux_sym_style_block_repeat1,
+    ACTIONS(59), 18,
+      anon_sym_width,
+      anon_sym_height,
+      anon_sym_fill,
+      anon_sym_stroke,
+      anon_sym_corner,
+      anon_sym_opacity,
+      anon_sym_font,
+      anon_sym_bg,
+      anon_sym_use,
+      anon_sym_layout,
+      anon_sym_shadow,
+      anon_sym_scale,
+      anon_sym_rotate,
+      anon_sym_translate,
+      anon_sym_center_in,
+      anon_sym_offset,
+      anon_sym_ease,
+      anon_sym_duration,
+  [965] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(206), 1,
+      anon_sym_AT,
+    ACTIONS(208), 1,
+      sym_identifier,
+    ACTIONS(212), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(202), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+    ACTIONS(210), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(44), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+    ACTIONS(204), 6,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+  [1001] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(214), 1,
+      anon_sym_AT,
+    ACTIONS(217), 1,
+      sym_identifier,
+    ACTIONS(223), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(29), 2,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+    ACTIONS(220), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(44), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+    ACTIONS(31), 6,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+  [1037] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(47), 1,
+      sym_annotation_text,
+    ACTIONS(51), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(226), 1,
+      ts_builtin_sym_end,
+    STATE(86), 1,
+      sym_annotation_keyword,
+    STATE(25), 2,
+      sym_annotation_typed,
+      sym_string,
+    ACTIONS(49), 4,
+      anon_sym_accept,
+      anon_sym_status,
+      anon_sym_priority,
+      anon_sym_tag,
+    ACTIONS(45), 8,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_AT,
+  [1073] = 9,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(228), 1,
+      ts_builtin_sym_end,
+    ACTIONS(230), 1,
+      anon_sym_POUND_POUND,
+    ACTIONS(233), 1,
+      anon_sym_style,
+    ACTIONS(239), 1,
+      anon_sym_AT,
+    STATE(60), 1,
+      sym_node_kind,
+    STATE(72), 1,
+      sym_node_id,
+    ACTIONS(236), 5,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+    STATE(46), 5,
+      sym_annotation,
+      sym_style_block,
+      sym_node_declaration,
+      sym_constraint_line,
+      aux_sym_document_repeat1,
+  [1109] = 9,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(9), 1,
+      anon_sym_POUND_POUND,
+    ACTIONS(11), 1,
+      anon_sym_style,
+    ACTIONS(15), 1,
+      anon_sym_AT,
+    ACTIONS(242), 1,
+      ts_builtin_sym_end,
+    STATE(60), 1,
+      sym_node_kind,
+    STATE(72), 1,
+      sym_node_id,
+    ACTIONS(13), 5,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+    STATE(46), 5,
+      sym_annotation,
+      sym_style_block,
+      sym_node_declaration,
+      sym_constraint_line,
+      aux_sym_document_repeat1,
+  [1145] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(244), 1,
+      anon_sym_EQ,
+    ACTIONS(94), 6,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(96), 7,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      sym_identifier,
+  [1169] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(104), 6,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(106), 7,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      sym_identifier,
+  [1190] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(108), 6,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(110), 7,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      sym_identifier,
+  [1211] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(100), 6,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_AT,
+      sym_number,
+      sym_hex_color,
+      anon_sym_DQUOTE,
+    ACTIONS(102), 7,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      sym_identifier,
+  [1232] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(206), 1,
+      anon_sym_AT,
+    ACTIONS(212), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(246), 1,
+      sym_identifier,
+    ACTIONS(248), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(43), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+  [1256] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(21), 1,
+      anon_sym_AT,
+    ACTIONS(27), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(250), 1,
+      sym_identifier,
+    ACTIONS(252), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(2), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+  [1280] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(164), 1,
+      anon_sym_AT,
+    ACTIONS(170), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(254), 1,
+      sym_identifier,
+    ACTIONS(256), 2,
+      sym_number,
+      sym_hex_color,
+    STATE(30), 5,
+      sym__value_item,
+      sym_key_value_pair,
+      sym_node_id,
+      sym_string,
+      aux_sym_property_repeat1,
+  [1304] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(258), 9,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_AT,
+  [1319] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(260), 9,
+      ts_builtin_sym_end,
+      anon_sym_POUND_POUND,
+      anon_sym_style,
+      anon_sym_group,
+      anon_sym_rect,
+      anon_sym_ellipse,
+      anon_sym_path,
+      anon_sym_text,
+      anon_sym_AT,
+  [1334] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(212), 1,
+      anon_sym_DQUOTE,
+    STATE(50), 1,
+      sym_string,
+    ACTIONS(262), 3,
+      sym_identifier,
+      sym_number,
+      sym_hex_color,
+  [1349] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(170), 1,
+      anon_sym_DQUOTE,
+    STATE(37), 1,
+      sym_string,
+    ACTIONS(264), 3,
+      sym_identifier,
+      sym_number,
+      sym_hex_color,
+  [1364] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(27), 1,
+      anon_sym_DQUOTE,
+    STATE(17), 1,
+      sym_string,
+    ACTIONS(266), 3,
+      sym_identifier,
+      sym_number,
+      sym_hex_color,
+  [1379] = 6,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(15), 1,
+      anon_sym_AT,
+    ACTIONS(268), 1,
+      anon_sym_LBRACE,
+    ACTIONS(270), 1,
+      anon_sym_DQUOTE,
+    STATE(62), 1,
+      sym_node_id,
+    STATE(78), 1,
+      sym_string,
+  [1398] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(104), 3,
+      anon_sym_LBRACE,
+      anon_sym_DASH_GT,
+      anon_sym_DQUOTE,
+  [1407] = 4,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(270), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(272), 1,
+      anon_sym_LBRACE,
+    STATE(80), 1,
+      sym_string,
+  [1420] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(51), 1,
+      anon_sym_DQUOTE,
+    ACTIONS(274), 1,
+      sym_annotation_text,
+    STATE(27), 1,
+      sym_string,
+  [1433] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(276), 3,
+      anon_sym_LBRACE,
+      anon_sym_AT,
+      anon_sym_DQUOTE,
+  [1442] = 3,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(278), 1,
+      anon_sym_COLON,
+    STATE(71), 1,
+      sym_anim_trigger,
+  [1452] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(280), 1,
+      anon_sym_DQUOTE,
+  [1459] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(282), 1,
+      anon_sym_LBRACE,
+  [1466] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(284), 1,
+      ts_builtin_sym_end,
+  [1473] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(286), 1,
+      anon_sym_DQUOTE,
+  [1480] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(288), 1,
+      sym_identifier,
+  [1487] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(290), 1,
+      anon_sym_LBRACE,
+  [1494] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(292), 1,
+      anon_sym_DASH_GT,
+  [1501] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(294), 1,
+      anon_sym_COLON,
+  [1508] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(296), 1,
+      sym_identifier,
+  [1515] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      sym_identifier,
+  [1522] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(300), 1,
+      anon_sym_LBRACE,
+  [1529] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(302), 1,
+      anon_sym_COLON,
+  [1536] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(304), 1,
+      anon_sym_LBRACE,
+  [1543] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(306), 1,
+      anon_sym_COLON,
+  [1550] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(308), 1,
+      anon_sym_LBRACE,
+  [1557] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(310), 1,
+      sym_identifier,
+  [1564] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(312), 1,
+      anon_sym_DQUOTE,
+  [1571] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(314), 1,
+      aux_sym_string_token1,
+  [1578] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(316), 1,
+      anon_sym_COLON,
+  [1585] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(318), 1,
+      sym_identifier,
+  [1592] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(320), 1,
+      anon_sym_COLON,
+  [1599] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(322), 1,
+      sym_identifier,
+  [1606] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(324), 1,
+      sym_identifier,
+  [1613] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(326), 1,
+      anon_sym_DQUOTE,
+  [1620] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(328), 1,
+      aux_sym_string_token1,
+  [1627] = 2,
+    ACTIONS(7), 1,
+      sym_comment,
+    ACTIONS(330), 1,
+      anon_sym_COLON,
+  [1634] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(332), 1,
+      aux_sym_string_token1,
+  [1641] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(334), 1,
+      aux_sym_string_token1,
+};
+
+static const uint32_t ts_small_parse_table_map[] = {
+  [SMALL_STATE(18)] = 0,
+  [SMALL_STATE(19)] = 40,
+  [SMALL_STATE(20)] = 89,
+  [SMALL_STATE(21)] = 128,
+  [SMALL_STATE(22)] = 167,
+  [SMALL_STATE(23)] = 206,
+  [SMALL_STATE(24)] = 245,
+  [SMALL_STATE(25)] = 284,
+  [SMALL_STATE(26)] = 323,
+  [SMALL_STATE(27)] = 362,
+  [SMALL_STATE(28)] = 401,
+  [SMALL_STATE(29)] = 440,
+  [SMALL_STATE(30)] = 479,
+  [SMALL_STATE(31)] = 528,
+  [SMALL_STATE(32)] = 564,
+  [SMALL_STATE(33)] = 600,
+  [SMALL_STATE(34)] = 636,
+  [SMALL_STATE(35)] = 673,
+  [SMALL_STATE(36)] = 707,
+  [SMALL_STATE(37)] = 741,
+  [SMALL_STATE(38)] = 775,
+  [SMALL_STATE(39)] = 813,
+  [SMALL_STATE(40)] = 851,
+  [SMALL_STATE(41)] = 889,
+  [SMALL_STATE(42)] = 927,
+  [SMALL_STATE(43)] = 965,
+  [SMALL_STATE(44)] = 1001,
+  [SMALL_STATE(45)] = 1037,
+  [SMALL_STATE(46)] = 1073,
+  [SMALL_STATE(47)] = 1109,
+  [SMALL_STATE(48)] = 1145,
+  [SMALL_STATE(49)] = 1169,
+  [SMALL_STATE(50)] = 1190,
+  [SMALL_STATE(51)] = 1211,
+  [SMALL_STATE(52)] = 1232,
+  [SMALL_STATE(53)] = 1256,
+  [SMALL_STATE(54)] = 1280,
+  [SMALL_STATE(55)] = 1304,
+  [SMALL_STATE(56)] = 1319,
+  [SMALL_STATE(57)] = 1334,
+  [SMALL_STATE(58)] = 1349,
+  [SMALL_STATE(59)] = 1364,
+  [SMALL_STATE(60)] = 1379,
+  [SMALL_STATE(61)] = 1398,
+  [SMALL_STATE(62)] = 1407,
+  [SMALL_STATE(63)] = 1420,
+  [SMALL_STATE(64)] = 1433,
+  [SMALL_STATE(65)] = 1442,
+  [SMALL_STATE(66)] = 1452,
+  [SMALL_STATE(67)] = 1459,
+  [SMALL_STATE(68)] = 1466,
+  [SMALL_STATE(69)] = 1473,
+  [SMALL_STATE(70)] = 1480,
+  [SMALL_STATE(71)] = 1487,
+  [SMALL_STATE(72)] = 1494,
+  [SMALL_STATE(73)] = 1501,
+  [SMALL_STATE(74)] = 1508,
+  [SMALL_STATE(75)] = 1515,
+  [SMALL_STATE(76)] = 1522,
+  [SMALL_STATE(77)] = 1529,
+  [SMALL_STATE(78)] = 1536,
+  [SMALL_STATE(79)] = 1543,
+  [SMALL_STATE(80)] = 1550,
+  [SMALL_STATE(81)] = 1557,
+  [SMALL_STATE(82)] = 1564,
+  [SMALL_STATE(83)] = 1571,
+  [SMALL_STATE(84)] = 1578,
+  [SMALL_STATE(85)] = 1585,
+  [SMALL_STATE(86)] = 1592,
+  [SMALL_STATE(87)] = 1599,
+  [SMALL_STATE(88)] = 1606,
+  [SMALL_STATE(89)] = 1613,
+  [SMALL_STATE(90)] = 1620,
+  [SMALL_STATE(91)] = 1627,
+  [SMALL_STATE(92)] = 1634,
+  [SMALL_STATE(93)] = 1641,
+};
+
+static const TSParseActionEntry ts_parse_actions[] = {
+  [0] = {.entry = {.count = 0, .reusable = false}},
+  [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
+  [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 0, 0, 0),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(74),
+  [17] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property, 3, 0, 6),
+  [19] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_property, 3, 0, 6),
+  [21] = {.entry = {.count = 1, .reusable = true}}, SHIFT(81),
+  [23] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [29] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0),
+  [31] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0),
+  [33] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(81),
+  [36] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(14),
+  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(3),
+  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(90),
+  [45] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 1, 0, 0),
+  [47] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [49] = {.entry = {.count = 1, .reusable = false}}, SHIFT(79),
+  [51] = {.entry = {.count = 1, .reusable = false}}, SHIFT(83),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [55] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [57] = {.entry = {.count = 1, .reusable = false}}, SHIFT(73),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(73),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
+  [63] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(4),
+  [66] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0),
+  [68] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [71] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [74] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [77] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_node_declaration_repeat1, 2, 0, 0), SHIFT_REPEAT(65),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
+  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [86] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(28),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(29),
+  [94] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__value_item, 1, 0, 0),
+  [96] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__value_item, 1, 0, 0),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, 0, 0),
+  [102] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3, 0, 0),
+  [104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_id, 2, 0, 0),
+  [106] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_id, 2, 0, 0),
+  [108] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_key_value_pair, 3, 0, 0),
+  [110] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_key_value_pair, 3, 0, 0),
+  [112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(88),
+  [115] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
+  [118] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(19),
+  [121] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(93),
+  [124] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 4, 0, 1),
+  [126] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 4, 0, 1),
+  [128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 4, 0, 4),
+  [130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 4, 0, 4),
+  [132] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 3, 0, 1),
+  [134] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 3, 0, 1),
+  [136] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 5, 0, 7),
+  [138] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 5, 0, 7),
+  [140] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 4, 0, 5),
+  [142] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 4, 0, 5),
+  [144] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 2, 0, 0),
+  [146] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation, 2, 0, 0),
+  [148] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 5, 0, 4),
+  [150] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 5, 0, 4),
+  [152] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation_typed, 3, 0, 2),
+  [154] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_annotation_typed, 3, 0, 2),
+  [156] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 5, 0, 5),
+  [158] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 5, 0, 5),
+  [160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_declaration, 6, 0, 7),
+  [162] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_declaration, 6, 0, 7),
+  [164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
+  [166] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [168] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
+  [172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_body_item, 1, 0, 0),
+  [174] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_node_body_item, 1, 0, 0),
+  [176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_anim_block, 4, 0, 9),
+  [178] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_anim_block, 4, 0, 9),
+  [180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_anim_block, 5, 0, 9),
+  [182] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_anim_block, 5, 0, 9),
+  [184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(58),
+  [186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(55),
+  [188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(33),
+  [190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_style_block_repeat1, 2, 0, 0),
+  [192] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_style_block_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [195] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_style_block_repeat1, 2, 0, 0), SHIFT_REPEAT(73),
+  [198] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(56),
+  [202] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_constraint_line, 5, 0, 8),
+  [204] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_constraint_line, 5, 0, 8),
+  [206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [208] = {.entry = {.count = 1, .reusable = false}}, SHIFT(48),
+  [210] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [214] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(85),
+  [217] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(48),
+  [220] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(44),
+  [223] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_property_repeat1, 2, 0, 0), SHIFT_REPEAT(92),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation, 1, 0, 0),
+  [228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0),
+  [230] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(45),
+  [233] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(75),
+  [236] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(64),
+  [239] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_document_repeat1, 2, 0, 0), SHIFT_REPEAT(74),
+  [242] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_document, 1, 0, 0),
+  [244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [250] = {.entry = {.count = 1, .reusable = true}}, SHIFT(14),
+  [252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [254] = {.entry = {.count = 1, .reusable = true}}, SHIFT(34),
+  [256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(30),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_block, 4, 0, 3),
+  [260] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_style_block, 5, 0, 3),
+  [262] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [264] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [268] = {.entry = {.count = 1, .reusable = true}}, SHIFT(11),
+  [270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
+  [272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [274] = {.entry = {.count = 1, .reusable = false}}, SHIFT(27),
+  [276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_node_kind, 1, 0, 0),
+  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(70),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(38),
+  [284] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(41),
+  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
+  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_property_name, 1, 0, 0),
+  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(61),
+  [298] = {.entry = {.count = 1, .reusable = true}}, SHIFT(67),
+  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_anim_trigger, 2, 0, 0),
+  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(53),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [306] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_annotation_keyword, 1, 0, 0),
+  [308] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [314] = {.entry = {.count = 1, .reusable = true}}, SHIFT(69),
+  [316] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [318] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [320] = {.entry = {.count = 1, .reusable = true}}, SHIFT(63),
+  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
+  [324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(36),
+  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
+  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
+  [332] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
+  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef TREE_SITTER_HIDE_SYMBOLS
+#define TS_PUBLIC
+#elif defined(_WIN32)
+#define TS_PUBLIC __declspec(dllexport)
+#else
+#define TS_PUBLIC __attribute__((visibility("default")))
+#endif
+
+TS_PUBLIC const TSLanguage *tree_sitter_fd(void) {
+  static const TSLanguage language = {
+    .version = LANGUAGE_VERSION,
+    .symbol_count = SYMBOL_COUNT,
+    .alias_count = ALIAS_COUNT,
+    .token_count = TOKEN_COUNT,
+    .external_token_count = EXTERNAL_TOKEN_COUNT,
+    .state_count = STATE_COUNT,
+    .large_state_count = LARGE_STATE_COUNT,
+    .production_id_count = PRODUCTION_ID_COUNT,
+    .field_count = FIELD_COUNT,
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
+    .parse_actions = ts_parse_actions,
+    .symbol_names = ts_symbol_names,
+    .field_names = ts_field_names,
+    .field_map_slices = ts_field_map_slices,
+    .field_map_entries = ts_field_map_entries,
+    .symbol_metadata = ts_symbol_metadata,
+    .public_symbol_map = ts_symbol_map,
+    .alias_map = ts_non_terminal_alias_map,
+    .alias_sequences = &ts_alias_sequences[0][0],
+    .lex_modes = ts_lex_modes,
+    .lex_fn = ts_lex,
+    .primary_state_ids = ts_primary_state_ids,
+  };
+  return &language;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/tree-sitter-fd/src/tree_sitter/alloc.h
+++ b/tree-sitter-fd/src/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/tree-sitter-fd/src/tree_sitter/array.h
+++ b/tree-sitter-fd/src/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/tree-sitter-fd/src/tree_sitter/parser.h
+++ b/tree-sitter-fd/src/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/tree-sitter-fd/tree-sitter.json
+++ b/tree-sitter-fd/tree-sitter.json
@@ -1,0 +1,36 @@
+{
+  "grammars": [
+    {
+      "name": "fd",
+      "camelcase": "Fd",
+      "scope": "source.fd",
+      "path": ".",
+      "file-types": [
+        "fd"
+      ],
+      "highlights": "queries/highlights.scm",
+      "injection-regex": "^fd$"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "Tree-sitter grammar for FD (Fast Draft) files",
+    "authors": [
+      {
+        "name": "Khang Nghiêm"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/khangnghiem/fast-draft"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
## Summary\n\nPhase 1 of universal editor support: `fd-lsp` Language Server and `tree-sitter-fd` grammar.\n\n### fd-lsp — Language Server Protocol\n\nA standalone Rust binary (`tower-lsp`) that wraps `fd-core` for real-time editor feedback:\n\n- **Diagnostics** — parse errors as you type with line/column positions\n- **Completions** — context-aware: top-level keywords, node properties, value suggestions\n- **Hover** — documentation for keywords, properties, node IDs\n- **Document Symbols** — outline/go-to-symbol for nodes and styles\n\n### tree-sitter-fd — Grammar\n\nComplete Tree-sitter grammar for Zed, Neovim, Helix, Emacs:\n\n- Covers: comments, annotations, style blocks, node declarations, properties, animations, constraints\n- Highlight queries: `queries/highlights.scm`\n- Parses `demo.fd` with zero errors\n\n### Verification\n\n- ✅ `cargo clippy --workspace -- -D warnings` clean\n- ✅ `cargo fmt --all` clean\n- ✅ 43 tests pass (32 fd-core + 11 new fd-lsp)\n- ✅ `tree-sitter parse demo.fd` — 0 errors\n\n### Editor Setup\n\nWith these two components, any LSP-compatible editor gains FD support:\n\n| Editor | What you need |\n|--------|---------------|\n| VS Code | Already has extension; can also use fd-lsp |\n| Zed | `tree-sitter-fd` for highlights + `fd-lsp` for diagnostics |\n| Neovim | `:TSInstall fd` + `lspconfig` entry for `fd-lsp` |\n| Helix | `languages.toml` entry |\n| Emacs | `eglot`/`lsp-mode` + tree-sitter |\n| Sublime | LSP package config |"