### PR TITLE
chore: add crates.io publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 authors = ["Khang Nghiêm"]
+repository = "https://github.com/khangnghiem/fast-draft"
+homepage = "https://github.com/khangnghiem/fast-draft"
+keywords = ["design", "canvas", "scene-graph", "lsp"]
+categories = ["graphics", "parser-implementations"]
 
 [workspace.dependencies]
 # Core

--- a/crates/fd-core/Cargo.toml
+++ b/crates/fd-core/Cargo.toml
@@ -5,6 +5,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 petgraph = { workspace = true }

--- a/crates/fd-lsp/Cargo.toml
+++ b/crates/fd-lsp/Cargo.toml
@@ -5,13 +5,17 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [[bin]]
 name = "fd-lsp"
 path = "src/main.rs"
 
 [dependencies]
-fd-core = { path = "../fd-core" }
+fd-core = { path = "../fd-core", version = "0.1.0" }
 tower-lsp = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Adds crates.io publish metadata to workspace and crate manifests.\n\n- `repository`, `homepage`, `keywords`, `categories` in workspace.package\n- Inherited in fd-core and fd-lsp\n- Versioned fd-core dependency in fd-lsp for registry resolution\n\nDry-run publishes pass for both crates."