### PR TITLE
fix(vscode): add wasm-unsafe-eval to CSP for WebAssembly support

### DIFF
--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -108,7 +108,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
-    script-src 'nonce-${nonce}' ${webview.cspSource};
+    script-src 'nonce-${nonce}' 'wasm-unsafe-eval' ${webview.cspSource};
     style-src 'nonce-${nonce}';
     img-src ${webview.cspSource};
     connect-src ${webview.cspSource};


### PR DESCRIPTION
## Problem\n\nOpening the FD Canvas Editor fails with:\n\n> CompileError: WebAssembly.instantiateStreaming(): Compiling or instantiating WebAssembly module violates the Content Security Policy directive because 'unsafe-eval' is not an allowed source of script.\n\n## Fix\n\nAdded `'wasm-unsafe-eval'` to the `script-src` CSP directive in the webview HTML. This is the standard, narrowly-scoped CSP directive for allowing WebAssembly compilation without opening the broader `'unsafe-eval'` hole.\n\n## Verification\n\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo fmt --all` — clean\n- ✅ `cargo test --workspace` — all pass"