### PR TITLE
release(vscode): v0.3.1 — fix CSP for WebAssembly

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Release v0.3.1\n\nPatch release to fix the CSP WebAssembly error in the canvas editor.\n\n### Changes\n- Bumped version from 0.3.0 → 0.3.1 in `package.json`\n- CSP fix (merged in PR #25): added `'wasm-unsafe-eval'` to `script-src`\n\nWill publish to VS Code Marketplace + Open VSX after merge."