### PR TITLE
docs(workflow): explicitly add version bump step to /yolo pipeline

### DIFF
--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -54,40 +54,43 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
    git checkout -b feat/<descriptive-name>
    ```
 
-7. **Stage and commit**:
+7. **Bump Version** (if `fd-vscode/` was changed):
+   - Bump the `version` field in `fd-vscode/package.json` appropriately (patch/minor/major).
+
+8. **Stage and commit**:
 
    ```bash
    git add -A
    git commit -m "<type>(<scope>): <description>"
    ```
 
-8. **Push**:
+9. **Push**:
 
    ```bash
    git push -u origin HEAD
    ```
 
-9. **Create PR** using GitKraken MCP:
-   - `provider`: github
-   - `source_branch`: current branch
-   - `target_branch`: main
-   - Title in conventional format
-   - Body summarizing changes + test results
+10. **Create PR** using GitKraken MCP:
+    - `provider`: github
+    - `source_branch`: current branch
+    - `target_branch`: main
+    - Title in conventional format
+    - Body summarizing changes + test results
 
-10. **Merge PR** and clean up:
+11. **Merge PR** and clean up:
 
     ```bash
     gh pr merge <PR_NUMBER> --merge --delete-branch
     ```
 
-11. **Sync main**:
+12. **Sync main**:
 
     ```bash
     git checkout main
     git pull origin main
     ```
 
-12. **Build & Publish VS Code extension** (if `fd-vscode/` was changed):
+13. **Build & Publish VS Code extension** (if `fd-vscode/` was changed):
 
     ```bash
     cd fd-vscode && pnpm run compile
@@ -101,10 +104,10 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 
     > Skip publish if the change is local-only or version wasn't bumped.
 
-13. Report PR URL, merge status, and publish results to user.
+14. Report PR URL, merge status, and publish results to user.
 
 ---
 
 ## `/yolo` — Full Pipeline
 
-Runs **all steps 1–13** in sequence (local + deploy).
+Runs **all steps 1–14** in sequence (local + deploy).


### PR DESCRIPTION
Adds an explicit "Bump Version" step to the `/yolo` workflow before the commit phase.\n\nThis ensures that if `fd-vscode/` changes, the `version` in `package.json` is bumped (e.g., from `0.3.0` to `0.3.1`) and becomes part of the PR, leading to a smooth publish after the merge."