### PR TITLE
feat(editor): make canvas the default custom editor

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -57,7 +57,7 @@
             "filenamePattern": "*.fd"
           }
         ],
-        "priority": "option"
+        "priority": "default"
       }
     ],
     "commands": [


### PR DESCRIPTION
This PR makes the custom editor the default priority for `.fd` files, automatically opening the canvas instead of text content. It also bumps the extension version to 0.3.2. All tests pass locally.