### PR TITLE
fix(fd-vscode): fix canvas ID mismatch preventing WASM load

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1,7 +1,7 @@
 /**
- * FTD Webview — WASM loader + message bridge.
+ * FD Webview — WASM loader + message bridge.
  *
- * Loads the Rust WASM module, initializes the FtdCanvas, and bridges
+ * Loads the Rust WASM module, initializes the FdCanvas, and bridges
  * between the VS Code extension (postMessage) and the WASM engine.
  */
 
@@ -32,7 +32,7 @@ let contextMenuNodeId = null;
 // ─── Initialization ──────────────────────────────────────────────────────
 
 async function main() {
-  canvas = document.getElementById("ftd-canvas");
+  canvas = document.getElementById("fd-canvas");
   const loading = document.getElementById("loading");
   const status = document.getElementById("status");
 
@@ -79,8 +79,8 @@ async function main() {
     // Tell extension we're ready
     vscode.postMessage({ type: "ready" });
   } catch (err) {
-    console.error("FTD WASM init failed:", err);
-    if (loading) loading.textContent = "Failed to load FTD engine: " + err;
+    console.error("FD WASM init failed:", err);
+    if (loading) loading.textContent = "Failed to load FD engine: " + err;
   }
 }
 


### PR DESCRIPTION
## Bug Fix\n\nFixes \"Loading FD engine…\" showing forever when opening `.fd` files.\n\n### Root Cause\n\nDuring the FTD → FD rename, the canvas HTML element ID in `extension.ts` was updated to `fd-canvas`, but `webview/main.js` still referenced the old `ftd-canvas` ID. This caused `getElementById` to return `null`, crashing the WASM init silently.\n\n### Changes\n\n- **`fd-vscode/webview/main.js`**: Fix canvas element ID `ftd-canvas` → `fd-canvas`\n- **`fd-vscode/webview/main.js`**: Update stale FTD references in comments/error messages\n- **`fd-vscode/package.json`**: Bump version to 0.3.3\n\n### Verification\n\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo fmt --all` — clean\n- ✅ `cargo test --workspace` — 86/86 tests pass