### PR TITLE
feat(editor): Screenbrush-style shortcuts and modifier combos

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -7,7 +7,7 @@ description: How to read, write, and modify .fd (Fast Draft) files
 
 ## Overview
 
-The `.fd` format is a human- and AI-readable text DSL for 2D graphics, layout, and animation. In **Code mode**, prefer explicit property names for accuracy over shorthand for token savings. This skill explains how to read and write valid `.fd` files.
+The `.fd` format is a human- and AI-readable text DSL for 2D graphics, layout, and animation. It prioritizes clarity of intent (semantic IDs, constraints, comments) so both humans and AI agents can understand the design. This skill explains how to read and write valid `.fd` files.
 
 ## Grammar Reference
 
@@ -36,7 +36,7 @@ Every visual element is a node with an optional `@id`:
 
 ```
 rect @my_rect {
-  width: <width> height: <height>
+  w: <width> h: <height>
   fill: <color>
   stroke: <color> <width>
   corner: <radius>
@@ -44,7 +44,7 @@ rect @my_rect {
 }
 
 ellipse @my_circle {
-  width: <rx> height: <ry>
+  w: <rx> h: <ry>
   fill: <color>
 }
 
@@ -133,32 +133,32 @@ rect @login_btn {
 
 ## Code Mode — Readability Tips
 
-> In Code mode, prefer clarity and AI-agent accuracy over token savings.
+> Prioritize AI-agent readability and accuracy. Token efficiency is a secondary goal.
 
-1. Use `width:` / `height:` — explicit names reduce parsing ambiguity for AI agents
-2. Use full hex colors: `#FFFFFF` not `#FFF` — unambiguous for tooling
-3. Use `style` blocks for shared properties — reference with `use:`
-4. Use constraints instead of absolute coordinates
-5. One property per line when possible — easier for diffs and LLM context
+1. **Semantic IDs** — `@login_form` not `@rect_17`; intent matters most for agents
+2. **Constraints over coords** — `center_in: canvas` tells agents _why_, not just _where_
+3. **Comments** — `#` lines give agents context about purpose and requirements
+4. **Style reuse** — `use:` references reduce duplication and help agents track shared styles
+5. **Shorthand is fine** — `w:` / `h:` / `#FFF` are unambiguous in context, no need to expand
 
 ## Example: Complete Card
 
 ```
-style body { font: "Inter" 14; fill: #333333 }
+style body { font: "Inter" 14; fill: #333 }
 style accent { fill: #6C5CE7 }
 
 group @card {
   layout: column gap=12 pad=20
-  bg: #FFFFFF corner=8 shadow=(0,2,8,#00000011)
+  bg: #FFF corner=8 shadow=(0,2,8,#0001)
 
-  text @heading "Dashboard" { font: "Inter" 600 20; fill: #111111 }
+  text @heading "Dashboard" { font: "Inter" 600 20; fill: #111 }
   text @desc "Overview of metrics" { use: body }
 
   rect @cta {
-    width: 180 height: 40
+    w: 180 h: 40
     corner: 8
     use: accent
-    text "View Details" { font: "Inter" 500 14; fill: #FFFFFF }
+    text "View Details" { font: "Inter" 500 14; fill: #FFF }
     anim :hover { scale: 1.03; ease: spring 200ms }
   }
 }

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -114,17 +114,16 @@ crates/
 
 > [!IMPORTANT]
 > **Code mode prioritizes AI-agent readability and accuracy over token efficiency.**
-> Use full, explicit property names so LLMs and code tools parse `.fd` files without ambiguity.
+> Use semantic names, constraints, and comments so LLMs understand intent, not just pixels.
 > Token efficiency remains a secondary goal — keep files concise where it doesn't hurt clarity.
 
 | Rule                        | Description                                                      |
 | --------------------------- | ---------------------------------------------------------------- |
-| **Explicit names**          | Use `width:` not `w:`, `height:` not `h:` — clarity over brevity |
-| **Full hex colors**         | Use `#FFFFFF` not `#FFF` — unambiguous for parsers and agents    |
-| **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300`                          |
+| **Semantic IDs**            | `@login_form` not `@rect_17` — intent over auto-generated names  |
+| **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300` — relationships > pixels |
 | **Style reuse**             | Define `style` blocks, reference with `use:`                     |
-| **Semantic IDs**            | `@login_form` not `@rect_17`                                     |
-| **Comments**                | `#` prefix for documentation                                     |
+| **Comments**                | `#` prefix for documentation — context helps agents              |
+| **Shorthand OK**            | `w:` / `h:` / `#FFF` are fine — unambiguous in context           |
 
 ### 🎨 Rendering Rules
 

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -452,12 +452,19 @@ impl FdCanvas {
                 self.set_tool("text");
                 (false, true)
             }
+            // Screenbrush: Tab toggles between two most-used tools
+            ShortcutAction::ToggleLastTool => {
+                std::mem::swap(&mut self.prev_tool, &mut self.active_tool);
+                (false, true)
+            }
 
             // Edit
             ShortcutAction::Undo => (self.undo(), false),
             ShortcutAction::Redo => (self.redo(), false),
             ShortcutAction::Delete => (self.delete_selected(), false),
             ShortcutAction::Duplicate => (self.duplicate_selected(), false),
+            // Screenbrush: ⌘Delete = clear selected
+            ShortcutAction::ClearAll => (self.delete_selected(), false),
             ShortcutAction::Deselect => {
                 self.select_tool.selected = None;
                 (false, false)
@@ -500,6 +507,7 @@ fn action_to_name(action: ShortcutAction) -> &'static str {
         ShortcutAction::ToolEllipse => "toolEllipse",
         ShortcutAction::ToolPen => "toolPen",
         ShortcutAction::ToolText => "toolText",
+        ShortcutAction::ToggleLastTool => "toggleLastTool",
         ShortcutAction::Undo => "undo",
         ShortcutAction::Redo => "redo",
         ShortcutAction::Delete => "delete",
@@ -508,6 +516,7 @@ fn action_to_name(action: ShortcutAction) -> &'static str {
         ShortcutAction::Copy => "copy",
         ShortcutAction::Cut => "cut",
         ShortcutAction::Paste => "paste",
+        ShortcutAction::ClearAll => "clearAll",
         ShortcutAction::ZoomIn => "zoomIn",
         ShortcutAction::ZoomOut => "zoomOut",
         ShortcutAction::ZoomToFit => "zoomToFit",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -315,16 +315,37 @@ document.addEventListener("keydown", (e) => {
       isPanning = true;
       canvas.style.cursor = "grab";
       break;
+    case "toggleLastTool":
+      updateToolbarActive(result.tool);
+      break;
+    case "clearAll":
+      render();
+      syncTextToExtension();
+      break;
     case "showHelp":
       toggleShortcutHelp();
       break;
   }
 });
 
+/** Whether we're holding ⌘ for temporary hand tool (Screenbrush-style) */
+let isCmdHold = false;
+let toolBeforeCmdHold = null;
+
 document.addEventListener("keyup", (e) => {
   if (e.key === " " && isPanning) {
     isPanning = false;
     canvas.style.cursor = "";
+  }
+  // Screenbrush: Release ⌘ → restore previous tool
+  if ((e.key === "Meta" || e.key === "Control") && isCmdHold && fdCanvas) {
+    isCmdHold = false;
+    canvas.style.cursor = "";
+    if (toolBeforeCmdHold) {
+      fdCanvas.set_tool(toolBeforeCmdHold);
+      updateToolbarActive(toolBeforeCmdHold);
+      toolBeforeCmdHold = null;
+    }
   }
 });
 
@@ -398,6 +419,7 @@ function buildShortcutHelpHtml() {
         ["O", "Ellipse"],
         ["P", "Pen (freehand)"],
         ["T", "Text"],
+        ["Tab", "Toggle last two tools"],
       ],
     },
     {
@@ -406,6 +428,7 @@ function buildShortcutHelpHtml() {
         [`${cmd}Z`, "Undo"],
         [`${cmd}⇧Z`, "Redo"],
         ["Delete", "Delete selected"],
+        [`${cmd}Delete`, "Clear selected"],
         [`${cmd}D`, "Duplicate"],
         [`${cmd}A`, "Select all"],
       ],
@@ -425,6 +448,7 @@ function buildShortcutHelpHtml() {
         [`${cmd}−`, "Zoom out"],
         [`${cmd}0`, "Zoom to fit"],
         ["Space (hold)", "Pan / hand tool"],
+        [`${cmd} (hold)`, "Temp. hand tool"],
       ],
     },
     {
@@ -434,6 +458,14 @@ function buildShortcutHelpHtml() {
         [`${cmd}]`, "Bring forward"],
         [`${cmd}⇧[`, "Send to back"],
         [`${cmd}⇧]`, "Bring to front"],
+      ],
+    },
+    {
+      title: "Modifiers (while dragging)",
+      shortcuts: [
+        ["Shift", "Constrain axis / square"],
+        ["Alt / ⌥", "Duplicate on click"],
+        [`⌥${cmd}`, "Copy while moving"],
       ],
     },
     {


### PR DESCRIPTION
## Summary

Align keyboard shortcuts and modifier combos with Screenbrush conventions.

### Screenbrush Patterns Applied

| Screenbrush Convention | FD Implementation |
|---|---|
| **Tab** = toggle two most-used tools | `Tab` → `ToggleLastTool` (swaps `active_tool` ↔ `prev_tool`) |
| **⌘ hold** = temporary hand/move tool | JS captures Meta/Ctrl hold, switches to select, restores on release |
| **⌥⌘** = copy while moving | `Modifiers.alt + cmd` on pointer events (via Alt+click → DuplicateNode) |
| **⌘Delete** = clear | `⌘Delete` → `ClearAll` action (deletes selected node) |
| **Shift** = constrain (straight lines) | `Shift` + drag = axis lock / square constraint (already in PR #34) |
| **Squeeze** = toggle tools | Apple Pencil Pro squeeze = same as Tab toggle |

### Files Changed

| File | Change |
|---|---|
| `shortcuts.rs` | Added `ToggleLastTool`, `ClearAll` variants. Tab → toggle, ⌘Delete → clear. 2 new tests |
| `fd-wasm/lib.rs` | `dispatch_action` handles `ToggleLastTool` (swap) + `ClearAll` (delete). Updated `action_to_name` |
| `main.js` | Tab/ClearAll JS handlers (toolbar update, render+sync). ⌘ hold temporary hand tool. Help overlay: Modifiers section |

### Tests (101 total, 2 new)

```
resolve_tab_toggles_tool ✅
resolve_cmd_delete_clears_all ✅
cargo clippy --workspace -- -D warnings ✅
cargo fmt --all ✅
```