### PR TITLE
feat: add first-class edges for user flows and wireframe connections

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -69,6 +69,24 @@ path @drawing {
 }
 ```
 
+### Edges (Connections)
+
+Visual connections between nodes with styled lines, arrowheads, and labels:
+
+```
+edge @login_to_dashboard {
+  from: @login_screen
+  to: @dashboard
+  label: "on success"
+  stroke: #10B981 2
+  arrow: end            # none | start | end | both
+  curve: smooth         # straight | smooth | step
+  use: flow_style       # style references work too
+}
+```
+
+Edges support `##` annotations and `use:` style references, just like nodes.
+
 ### Colors
 
 Hex format: `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -719,17 +719,15 @@ fn parse_edge_block(input: &mut &str) -> ModalResult<Edge> {
                     };
                 }
                 "use" => {
-                    use_styles
-                        .push(parse_identifier.map(NodeId::intern).parse_next(input)?);
+                    use_styles.push(parse_identifier.map(NodeId::intern).parse_next(input)?);
                 }
                 "opacity" => {
                     style.opacity = Some(parse_number.parse_next(input)?);
                 }
                 _ => {
-                    let _ = take_till::<_, _, ContextError>(
-                        0..,
-                        |c: char| c == '\n' || c == ';' || c == '}',
-                    )
+                    let _ = take_till::<_, _, ContextError>(0.., |c: char| {
+                        c == '\n' || c == ';' || c == '}'
+                    })
                     .parse_next(input);
                 }
             }

--- a/docs/design/userflow_onboarding.fd
+++ b/docs/design/userflow_onboarding.fd
@@ -1,0 +1,179 @@
+# FD v1
+# Onboarding User Flow — multi-step with error paths
+
+style screen {
+  fill: #FFFFFF
+  corner: 16
+}
+
+style screen_title {
+  fill: #1A1A2E
+  font: "Inter" 700 20
+}
+
+style flow_edge {
+  stroke: #6C5CE7 2
+}
+
+# ─── Screens ────────────────────────────────────────────────
+
+rect @landing {
+  ## "Marketing landing page"
+  ## status: done
+  ## tag: marketing
+  w: 200 h: 120
+  use: screen
+  text @landing_t "Landing Page" { use: screen_title }
+}
+
+rect @signup {
+  ## "Registration form"
+  ## accept: "collects name, email, password"
+  ## accept: "OAuth buttons for Google + GitHub"
+  ## status: done
+  w: 200 h: 120
+  use: screen
+  text @signup_t "Sign Up" { use: screen_title }
+}
+
+rect @verify_email {
+  ## "Email verification step"
+  ## accept: "shows 6-digit OTP input"
+  ## accept: "resend link after 60s cooldown"
+  ## status: in_progress
+  w: 200 h: 120
+  use: screen
+  text @verify_t "Verify Email" { use: screen_title }
+}
+
+rect @setup_profile {
+  ## "Profile setup — avatar, bio, preferences"
+  ## accept: "avatar upload with crop"
+  ## status: draft
+  w: 200 h: 120
+  use: screen
+  text @setup_t "Setup Profile" { use: screen_title }
+}
+
+rect @dashboard {
+  ## "Main application dashboard"
+  ## status: draft
+  ## tag: core
+  w: 200 h: 120
+  use: screen
+  text @dash_t "Dashboard" { use: screen_title }
+}
+
+rect @error_screen {
+  ## "Generic error state"
+  w: 160 h: 100
+  fill: #FEF2F2
+  corner: 12
+  text @error_t "Error" {
+    fill: #B91C1C
+    font: "Inter" 600 16
+  }
+}
+
+rect @resend_screen {
+  ## "Resend verification email"
+  w: 160 h: 100
+  fill: #FFFBEB
+  corner: 12
+  text @resend_t "Resend Email" {
+    fill: #92400E
+    font: "Inter" 600 14
+  }
+}
+
+# ─── Happy path ───────────────────────────────────────────────
+
+edge @cta_click {
+  ## "Primary CTA on landing"
+  from: @landing
+  to: @signup
+  label: "Get Started"
+  stroke: #6C5CE7 2
+  arrow: end
+}
+
+edge @signup_submit {
+  ## "Form submission"
+  ## accept: "validates all fields client-side first"
+  from: @signup
+  to: @verify_email
+  label: "submit"
+  stroke: #6C5CE7 2
+  arrow: end
+}
+
+edge @email_verified {
+  ## "OTP validated"
+  from: @verify_email
+  to: @setup_profile
+  label: "verified"
+  stroke: #10B981 2
+  arrow: end
+  curve: smooth
+}
+
+edge @profile_done {
+  ## "Profile setup complete"
+  from: @setup_profile
+  to: @dashboard
+  label: "complete"
+  stroke: #10B981 2
+  arrow: end
+  curve: smooth
+}
+
+# ─── Error paths ──────────────────────────────────────────────
+
+edge @signup_error {
+  ## "Registration failure"
+  ## accept: "shows inline field errors"
+  from: @signup
+  to: @error_screen
+  label: "validation fail"
+  stroke: #EF4444 1
+  arrow: end
+  curve: step
+}
+
+edge @verify_timeout {
+  ## "OTP expired or invalid"
+  from: @verify_email
+  to: @resend_screen
+  label: "expired"
+  stroke: #F59E0B 1
+  arrow: end
+  curve: step
+}
+
+edge @resend_retry {
+  ## "User requests new OTP"
+  from: @resend_screen
+  to: @verify_email
+  label: "resend"
+  stroke: #F59E0B 1
+  arrow: end
+}
+
+edge @error_retry {
+  ## "User corrects errors and resubmits"
+  from: @error_screen
+  to: @signup
+  label: "retry"
+  stroke: #6B7280 1
+  arrow: end
+}
+
+# ─── Layout ───────────────────────────────────────────────────
+
+@landing -> absolute: 40, 200
+@signup -> absolute: 300, 200
+@verify_email -> absolute: 560, 200
+@setup_profile -> absolute: 820, 200
+@dashboard -> absolute: 1080, 200
+@error_screen -> absolute: 300, 420
+@resend_screen -> absolute: 560, 420

--- a/docs/design/wireframe_login.fd
+++ b/docs/design/wireframe_login.fd
@@ -1,0 +1,149 @@
+# FD v1
+# Login Page Wireframe — with edge connections
+
+style bg_surface {
+  fill: #FFFFFF
+  corner: 12
+}
+
+style input_style {
+  fill: #F8F9FA
+  corner: 8
+}
+
+style label_style {
+  fill: #1A1A2E
+  font: "Inter" 500 14
+}
+
+# ─── Wireframe screens ────────────────────────────────────────
+
+group @login_page {
+  ## "Login page — main entry point"
+  ## status: done
+  layout: column gap=16 pad=32
+
+  text @title "Welcome Back" {
+    fill: #1A1A2E
+    font: "Inter" 700 28
+  }
+
+  rect @email_field {
+    ## "Email input field"
+    ## accept: "validates email format on blur"
+    w: 320 h: 48
+    use: input_style
+    text @email_placeholder "Email address" {
+      fill: #9CA3AF
+      font: "Inter" 400 14
+    }
+  }
+
+  rect @password_field {
+    ## "Password input field"
+    ## accept: "minimum 8 characters"
+    w: 320 h: 48
+    use: input_style
+    text @pw_placeholder "Password" {
+      fill: #9CA3AF
+      font: "Inter" 400 14
+    }
+  }
+
+  rect @login_btn {
+    ## "Primary login CTA"
+    ## accept: "disabled when fields empty"
+    ## accept: "shows loading spinner during auth"
+    w: 320 h: 48
+    fill: #6C5CE7
+    corner: 10
+    text @login_label "Sign In" {
+      fill: #FFFFFF
+      font: "Inter" 600 16
+    }
+    anim :hover {
+      fill: #5A4BD1
+      scale: 1.02
+      ease: spring 200ms
+    }
+  }
+
+  text @forgot "Forgot password?" {
+    fill: #6C5CE7
+    font: "Inter" 400 13
+  }
+}
+
+rect @error_toast {
+  ## "Error notification toast"
+  ## accept: "shows within 200ms of failed auth"
+  ## accept: "auto-dismiss after 5s"
+  w: 320 h: 56
+  fill: #FEF2F2
+  stroke: #EF4444 1
+  corner: 8
+  text @error_msg "Invalid credentials" {
+    fill: #B91C1C
+    font: "Inter" 500 14
+  }
+}
+
+rect @dashboard {
+  ## "Main dashboard — post-login"
+  ## status: in_progress
+  w: 400 h: 300
+  use: bg_surface
+  text @dash_title "Dashboard" {
+    fill: #1A1A2E
+    font: "Inter" 700 24
+  }
+}
+
+rect @reset_page {
+  ## "Password reset flow"
+  ## status: draft
+  w: 320 h: 200
+  use: bg_surface
+  text @reset_title "Reset Password" {
+    fill: #1A1A2E
+    font: "Inter" 700 20
+  }
+}
+
+# ─── Edges (data flow) ─────────────────────────────────────────
+
+edge @submit_flow {
+  ## "Form submission → API validation"
+  ## accept: "must complete within 3s"
+  from: @login_btn
+  to: @dashboard
+  label: "on success"
+  stroke: #10B981 2
+  arrow: end
+  curve: smooth
+}
+
+edge @error_flow {
+  ## "Failed authentication path"
+  from: @login_btn
+  to: @error_toast
+  label: "on failure"
+  stroke: #EF4444 2
+  arrow: end
+  curve: step
+}
+
+edge @forgot_flow {
+  from: @forgot
+  to: @reset_page
+  label: "click"
+  stroke: #6C5CE7 1
+  arrow: end
+}
+
+# ─── Layout ───────────────────────────────────────────────────
+
+@login_page -> center_in: canvas
+@error_toast -> absolute: 500, 80
+@dashboard -> absolute: 500, 200
+@reset_page -> absolute: 500, 540


### PR DESCRIPTION
## Summary

Adds first-class `edge` connections between nodes — enabling user flows, wireframes, and state machines in a single `.fd` file.

## Syntax

```fd
edge @login_to_dashboard {
  from: @login_screen
  to: @dashboard
  label: "on success"
  stroke: #10B981 2
  arrow: end
  curve: smooth
}
```

## Changes

### Core (`fd-core`)
- **model.rs** — `Edge` struct + `ArrowKind` (none/start/end/both) + `CurveKind` (straight/smooth/step)
- **parser.rs** — `parse_edge_block()` with full property support
- **emitter.rs** — `emit_edge()` with roundtrip fidelity

### Renderer (`fd-wasm`)
- **render2d.rs** — `draw_edges()` with arrowheads, labels, and curve modes

### Examples
- `docs/design/wireframe_login.fd` — login wireframe with success/error/navigation edges
- `docs/design/userflow_onboarding.fd` — 5-screen onboarding flow with happy path + error branches

### Tests
- 3 new roundtrip tests: `edge_basic`, `edge_styled`, `edge_with_annotations`
- All 107 tests pass, clippy clean