### PR TITLE
feat: add edge animations (trigger + flow) and generic nodes

### DIFF
--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -176,6 +176,7 @@ fn intrinsic_size(node: &SceneNode) -> (f32, f32) {
         }
         NodeKind::Group { .. } => (200.0, 200.0), // Groups size to content eventually
         NodeKind::Path { .. } => (100.0, 100.0),  // Computed from path bounds
+        NodeKind::Generic => (120.0, 40.0),       // Placeholder label box
         NodeKind::Root => (0.0, 0.0),
     }
 }

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -311,6 +311,24 @@ pub struct Edge {
     pub arrow: ArrowKind,
     pub curve: CurveKind,
     pub annotations: Vec<Annotation>,
+    pub animations: SmallVec<[AnimKeyframe; 2]>,
+    pub flow: Option<FlowAnim>,
+}
+
+/// Flow animation kind — continuous motion along the edge path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FlowKind {
+    /// A glowing dot traveling from → to on a loop.
+    Pulse,
+    /// Marching dashes along the edge (stroke-dashoffset animation).
+    Dash,
+}
+
+/// A flow animation attached to an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FlowAnim {
+    pub kind: FlowKind,
+    pub duration_ms: u32,
 }
 
 /// Group layout mode (for children arrangement).
@@ -334,6 +352,10 @@ pub enum LayoutMode {
 pub enum NodeKind {
     /// Root of the document.
     Root,
+
+    /// Generic placeholder — no visual shape assigned yet.
+    /// Used for spec-only nodes: `@login_btn { ## "CTA" }`
+    Generic,
 
     /// Group / frame — contains children.
     Group { layout: LayoutMode },

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -57,6 +57,7 @@ fn hover_node_id(id: &str, graph: Option<&SceneGraph>) -> Option<Hover> {
 
     let kind_str = match &node.kind {
         fd_core::NodeKind::Root => "Root",
+        fd_core::NodeKind::Generic => "Generic (placeholder)",
         fd_core::NodeKind::Group { .. } => "Group",
         fd_core::NodeKind::Rect { width, height } => {
             let desc = format!("**Rect** — {}×{}", width, height);

--- a/crates/fd-render/src/paint.rs
+++ b/crates/fd-render/src/paint.rs
@@ -28,6 +28,9 @@ fn paint_node(graph: &SceneGraph, idx: NodeIndex, bounds: &HashMap<NodeIndex, Re
 
     match &node.kind {
         NodeKind::Root => {}
+        NodeKind::Generic => {
+            // Placeholder nodes have no visual shape to paint
+        }
         NodeKind::Rect { .. } => {
             log::trace!(
                 "PAINT rect @{} at ({}, {}) {}x{}",

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -463,6 +463,9 @@ impl FdCanvas {
             NodeKind::Path { .. } => {
                 props.insert("kind".into(), "path".into());
             }
+            NodeKind::Generic => {
+                props.insert("kind".into(), "generic".into());
+            }
             NodeKind::Root => {
                 props.insert("kind".into(), "root".into());
             }
@@ -847,6 +850,7 @@ fn collect_node_tree(graph: &fd_core::SceneGraph, idx: fd_core::NodeIndex) -> se
     let node = &graph.graph[idx];
     let kind_str = match &node.kind {
         fd_core::NodeKind::Root => "root",
+        fd_core::NodeKind::Generic => "generic",
         fd_core::NodeKind::Group { .. } => "group",
         fd_core::NodeKind::Rect { .. } => "rect",
         fd_core::NodeKind::Ellipse { .. } => "ellipse",

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -49,6 +49,9 @@ fn render_node(
 
     match &node.kind {
         NodeKind::Root => {}
+        NodeKind::Generic => {
+            draw_generic_placeholder(ctx, node_bounds, node.id.as_str());
+        }
         NodeKind::Rect { .. } => {
             draw_rect(ctx, node_bounds, &style, is_selected);
         }
@@ -216,6 +219,36 @@ fn draw_path_placeholder(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, sty
         &wasm_bindgen::JsValue::from_f64(4.0),
     ));
     ctx.stroke_rect(x, y, w, h);
+    ctx.restore();
+}
+
+/// Draw a generic placeholder node — dashed border with @id label.
+fn draw_generic_placeholder(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, id: &str) {
+    let (x, y, w, h) = (b.x as f64, b.y as f64, b.width as f64, b.height as f64);
+    ctx.save();
+
+    // Dashed border
+    ctx.set_stroke_style_str("#6B7280");
+    ctx.set_line_width(1.0);
+    let _ = ctx.set_line_dash(&js_sys::Array::of2(
+        &wasm_bindgen::JsValue::from_f64(4.0),
+        &wasm_bindgen::JsValue::from_f64(4.0),
+    ));
+    rounded_rect_path(ctx, x, y, w, h, 6.0);
+    ctx.stroke();
+
+    // Background fill (subtle)
+    ctx.set_fill_style_str("rgba(107, 114, 128, 0.08)");
+    ctx.fill();
+
+    // @id label centered
+    ctx.set_font("11px Inter, system-ui, sans-serif");
+    ctx.set_fill_style_str("#9CA3AF");
+    ctx.set_text_align("center");
+    ctx.set_text_baseline("middle");
+    let label = format!("@{}", id);
+    let _ = ctx.fill_text(&label, x + w / 2.0, y + h / 2.0);
+
     ctx.restore();
 }
 


### PR DESCRIPTION
## Summary

Adds trigger-based animations and flow animations to edges, plus generic node support.

### Edge Animations

**Trigger-based** (same system as node animations):
```fd
edge @link {
  from: @a to: @b
  anim :hover {
    opacity: 0.5
    ease: ease_out 200ms
  }
}
```

**Flow animations** (new — continuous motion along edge path):
```fd
edge @data_flow {
  from: @api to: @db
  flow: pulse 800ms   # glowing dot traveling along path
  # or
  flow: dash 400ms    # marching dashes
}
```

### Changes
- **model.rs** — `FlowKind` (Pulse/Dash), `FlowAnim`, `animations`/`flow` on `Edge`, generic `NodeKind`
- **parser.rs** — `anim :trigger {}` + `flow: kind Nms` in edges, generic node parsing
- **emitter.rs** — roundtrip emission + 3 new tests
- **render2d.rs** — `draw_generic_placeholder` for nodes without explicit kind

All 113 tests pass, clippy clean.