### PR TITLE
feat(spec): add spec view panel and markdown export

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -105,12 +105,27 @@
         "command": "fd.aiRefineAll",
         "title": "FD: AI Refine All Anonymous Nodes",
         "icon": "$(wand)"
+      },
+      {
+        "command": "fd.showSpecView",
+        "title": "FD: Show Spec View",
+        "icon": "$(checklist)"
+      },
+      {
+        "command": "fd.exportSpec",
+        "title": "FD: Export Spec to Markdown",
+        "icon": "$(markdown)"
       }
     ],
     "menus": {
       "editor/title": [
         {
           "command": "fd.showPreview",
+          "when": "resourceLangId == fd",
+          "group": "navigation"
+        },
+        {
+          "command": "fd.showSpecView",
           "when": "resourceLangId == fd",
           "group": "navigation"
         }

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1144,6 +1144,622 @@ class FdTreePreviewPanel {
   }
 }
 
+// ─── Spec View Panel ─────────────────────────────────────────────────────
+
+class FdSpecViewPanel {
+  public static currentPanel: FdSpecViewPanel | undefined;
+  private readonly panel: vscode.WebviewPanel;
+  private readonly context: vscode.ExtensionContext;
+  private disposables: vscode.Disposable[] = [];
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    context: vscode.ExtensionContext
+  ) {
+    this.panel = panel;
+    this.context = context;
+
+    this.update();
+
+    const changeSubscription = vscode.workspace.onDidChangeTextDocument(
+      (e: vscode.TextDocumentChangeEvent) => {
+        if (
+          vscode.window.activeTextEditor &&
+          e.document === vscode.window.activeTextEditor.document &&
+          e.document.languageId === "fd"
+        ) {
+          this.update();
+        }
+      }
+    );
+    this.disposables.push(changeSubscription);
+
+    const editorSubscription = vscode.window.onDidChangeActiveTextEditor(
+      () => {
+        this.update();
+      }
+    );
+    this.disposables.push(editorSubscription);
+
+    this.panel.onDidDispose(() => {
+      FdSpecViewPanel.currentPanel = undefined;
+      for (const d of this.disposables) d.dispose();
+    });
+  }
+
+  public static show(context: vscode.ExtensionContext): void {
+    if (FdSpecViewPanel.currentPanel) {
+      FdSpecViewPanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "fd.specView",
+      "FD Spec View",
+      vscode.ViewColumn.Beside,
+      { enableScripts: true }
+    );
+
+    FdSpecViewPanel.currentPanel = new FdSpecViewPanel(panel, context);
+  }
+
+  private update(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== "fd") return;
+
+    const text = editor.document.getText();
+    this.panel.webview.html = this.buildSpecHtml(text);
+  }
+
+  private buildSpecHtml(source: string): string {
+    const spec = this.parseSpec(source);
+    const nonce = getNonce();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style nonce="${nonce}">
+    body {
+      font-family: var(--vscode-font-family, 'Segoe UI', sans-serif);
+      font-size: 13px;
+      color: var(--vscode-foreground, #CDD6F4);
+      background: var(--vscode-editor-background, #1E1E2E);
+      padding: 16px;
+      line-height: 1.7;
+    }
+    h2 {
+      font-size: 15px;
+      color: var(--vscode-foreground, #CDD6F4);
+      margin: 0 0 12px;
+      font-weight: 600;
+      letter-spacing: 0.3px;
+    }
+    .spec-node {
+      margin-bottom: 14px;
+      padding: 10px 14px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 8px;
+      border-left: 3px solid var(--vscode-symbolIcon-classForeground, #89B4FA);
+    }
+    .spec-node.generic {
+      border-left-color: var(--vscode-symbolIcon-enumForeground, #CBA6F7);
+    }
+    .spec-node .node-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+    .node-id {
+      color: var(--vscode-symbolIcon-variableForeground, #F9E2AF);
+      font-weight: 600;
+      font-size: 14px;
+    }
+    .kind-badge {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      background: rgba(137,180,250,0.15);
+      color: var(--vscode-symbolIcon-classForeground, #89B4FA);
+    }
+    .kind-badge.spec {
+      background: rgba(203,166,247,0.15);
+      color: var(--vscode-symbolIcon-enumForeground, #CBA6F7);
+    }
+    .description {
+      color: var(--vscode-foreground, #CDD6F4);
+      font-style: italic;
+      margin: 4px 0;
+      padding-left: 2px;
+    }
+    .accept-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 6px;
+      margin: 3px 0;
+      color: var(--vscode-descriptionForeground, #A6ADC8);
+      font-size: 12px;
+    }
+    .accept-item::before {
+      content: "☐";
+      color: var(--vscode-symbolIcon-classForeground, #89B4FA);
+      flex-shrink: 0;
+    }
+    .meta-row {
+      display: flex;
+      gap: 8px;
+      margin-top: 6px;
+      flex-wrap: wrap;
+    }
+    .status-badge {
+      display: inline-block;
+      padding: 1px 8px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 600;
+    }
+    .status-draft { background: rgba(108,112,134,0.2); color: #6C7086; }
+    .status-in_progress { background: rgba(249,226,175,0.15); color: #F9E2AF; }
+    .status-done { background: rgba(166,227,161,0.15); color: #A6E3A1; }
+    .priority-badge {
+      display: inline-block;
+      padding: 1px 8px;
+      border-radius: 10px;
+      font-size: 10px;
+      font-weight: 600;
+    }
+    .priority-high { background: rgba(243,139,168,0.15); color: #F38BA8; }
+    .priority-medium { background: rgba(249,226,175,0.15); color: #F9E2AF; }
+    .priority-low { background: rgba(166,227,161,0.15); color: #A6E3A1; }
+    .tag-badge {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 4px;
+      font-size: 10px;
+      background: rgba(137,180,250,0.1);
+      color: var(--vscode-symbolIcon-classForeground, #89B4FA);
+    }
+    .children { margin-left: 16px; margin-top: 6px; }
+    .edge-item {
+      margin: 6px 0;
+      padding: 8px 12px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+      border-radius: 8px;
+      border-left: 3px solid var(--vscode-symbolIcon-stringForeground, #A6E3A1);
+      font-size: 12px;
+    }
+    .edge-label { color: var(--vscode-descriptionForeground, #A6ADC8); font-style: italic; }
+    .section-header {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      color: var(--vscode-descriptionForeground, #6C7086);
+      margin: 16px 0 8px;
+      font-weight: 600;
+    }
+    .empty-msg {
+      color: var(--vscode-descriptionForeground, #6C7086);
+      font-style: italic;
+      padding: 20px 0;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h2>📋 Spec View</h2>
+  ${spec}
+</body>
+</html>`;
+  }
+
+  private parseSpec(source: string): string {
+    const lines = source.split("\n");
+    let html = "";
+    const nodeStack: { indent: number; hasAnnotations: boolean }[] = [];
+    let pendingAnnotations: { type: string; value: string }[] = [];
+    let currentNodeId = "";
+    let currentNodeKind = "";
+    let insideNode = false;
+    let braceDepth = 0;
+
+    // Collect edges
+    const edges: { from: string; to: string; label: string; annotations: { type: string; value: string }[] }[] = [];
+    let currentEdge: { from: string; to: string; label: string; annotations: { type: string; value: string }[] } | null = null;
+    let insideEdge = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      // Track braces
+      const openBraces = (trimmed.match(/\{/g) || []).length;
+      const closeBraces = (trimmed.match(/\}/g) || []).length;
+
+      // Comment (single #)
+      if (trimmed.startsWith("#") && !trimmed.startsWith("##")) continue;
+
+      // Annotation line
+      if (trimmed.startsWith("##")) {
+        const ann = this.parseAnnotation(trimmed);
+        if (ann) {
+          if (insideEdge && currentEdge) {
+            currentEdge.annotations.push(ann);
+          } else {
+            pendingAnnotations.push(ann);
+          }
+        }
+        continue;
+      }
+
+      // Edge block
+      const edgeMatch = trimmed.match(/^edge\s+@(\w+)\s*\{/);
+      if (edgeMatch) {
+        insideEdge = true;
+        currentEdge = { from: "", to: "", label: "", annotations: [] };
+        braceDepth += openBraces - closeBraces;
+        continue;
+      }
+
+      if (insideEdge && currentEdge) {
+        const fromMatch = trimmed.match(/^from:\s*@(\w+)/);
+        const toMatch = trimmed.match(/^to:\s*@(\w+)/);
+        const labelMatch = trimmed.match(/^label:\s*"([^"]*)"/);
+        if (fromMatch) currentEdge.from = fromMatch[1];
+        if (toMatch) currentEdge.to = toMatch[1];
+        if (labelMatch) currentEdge.label = labelMatch[1];
+        braceDepth += openBraces - closeBraces;
+        if (trimmed === "}") {
+          insideEdge = false;
+          if (currentEdge.from && currentEdge.to) {
+            edges.push(currentEdge);
+          }
+          currentEdge = null;
+        }
+        continue;
+      }
+
+      // Closing brace
+      if (trimmed === "}") {
+        braceDepth -= 1;
+        if (insideNode && braceDepth <= (nodeStack.length > 0 ? nodeStack[nodeStack.length - 1].indent : 0)) {
+          // Flush current node
+          if (currentNodeId && pendingAnnotations.length > 0) {
+            html += this.renderSpecNode(currentNodeId, currentNodeKind, pendingAnnotations);
+          }
+          pendingAnnotations = [];
+          currentNodeId = "";
+          insideNode = nodeStack.length > 0;
+          nodeStack.pop();
+          if (nodeStack.length > 0) {
+            html += "</div>"; // close .children
+          }
+        }
+        continue;
+      }
+
+      // Node declaration (typed)
+      const nodeMatch = trimmed.match(
+        /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
+      );
+      if (nodeMatch) {
+        // Flush previous node
+        if (currentNodeId && pendingAnnotations.length > 0) {
+          html += this.renderSpecNode(currentNodeId, currentNodeKind, pendingAnnotations);
+          pendingAnnotations = [];
+        }
+        currentNodeKind = nodeMatch[1];
+        currentNodeId = nodeMatch[2];
+        insideNode = true;
+        if (trimmed.endsWith("{")) {
+          braceDepth += 1;
+          nodeStack.push({ indent: braceDepth, hasAnnotations: false });
+        }
+        continue;
+      }
+
+      // Generic node (@id { )
+      const genericMatch = trimmed.match(/^@(\w+)\s*\{/);
+      if (genericMatch) {
+        if (currentNodeId && pendingAnnotations.length > 0) {
+          html += this.renderSpecNode(currentNodeId, currentNodeKind, pendingAnnotations);
+          pendingAnnotations = [];
+        }
+        currentNodeKind = "spec";
+        currentNodeId = genericMatch[1];
+        insideNode = true;
+        braceDepth += 1;
+        nodeStack.push({ indent: braceDepth, hasAnnotations: false });
+        continue;
+      }
+
+      // Track braces for other lines
+      braceDepth += openBraces - closeBraces;
+    }
+
+    // Flush last node
+    if (currentNodeId && pendingAnnotations.length > 0) {
+      html += this.renderSpecNode(currentNodeId, currentNodeKind, pendingAnnotations);
+    }
+
+    // Edges
+    if (edges.length > 0) {
+      html += '<div class="section-header">Flows</div>';
+      for (const edge of edges) {
+        html += `<div class="edge-item"><strong>@${escapeHtml(edge.from)}</strong> → <strong>@${escapeHtml(edge.to)}</strong>`;
+        if (edge.label) {
+          html += ` <span class="edge-label">— ${escapeHtml(edge.label)}</span>`;
+        }
+        html += "</div>";
+        for (const ann of edge.annotations) {
+          if (ann.type === "description") {
+            html += `<div class="edge-item"><span class="description">${escapeHtml(ann.value)}</span></div>`;
+          }
+        }
+      }
+    }
+
+    return html || '<div class="empty-msg">No annotations found in this document.</div>';
+  }
+
+  private parseAnnotation(line: string): { type: string; value: string } | null {
+    const trimmed = line.replace(/^##\s*/, "");
+    const acceptMatch = trimmed.match(/^accept:\s*"([^"]*)"/);
+    if (acceptMatch) return { type: "accept", value: acceptMatch[1] };
+    const statusMatch = trimmed.match(/^status:\s*(\S+)/);
+    if (statusMatch) return { type: "status", value: statusMatch[1] };
+    const priorityMatch = trimmed.match(/^priority:\s*(\S+)/);
+    if (priorityMatch) return { type: "priority", value: priorityMatch[1] };
+    const tagMatch = trimmed.match(/^tag:\s*(.+)/);
+    if (tagMatch) return { type: "tag", value: tagMatch[1].trim() };
+    const descMatch = trimmed.match(/^"([^"]*)"/);
+    if (descMatch) return { type: "description", value: descMatch[1] };
+    return null;
+  }
+
+  private renderSpecNode(
+    id: string,
+    kind: string,
+    annotations: { type: string; value: string }[]
+  ): string {
+    const isGeneric = kind === "spec" || kind === "";
+    let html = `<div class="spec-node${isGeneric ? " generic" : ""}">`;
+    html += `<div class="node-header">`;
+    html += `<span class="node-id">@${escapeHtml(id)}</span>`;
+    html += `<span class="kind-badge${isGeneric ? " spec" : ""}">${escapeHtml(kind || "spec")}</span>`;
+    html += `</div>`;
+
+    const descriptions = annotations.filter((a) => a.type === "description");
+    const accepts = annotations.filter((a) => a.type === "accept");
+    const statuses = annotations.filter((a) => a.type === "status");
+    const priorities = annotations.filter((a) => a.type === "priority");
+    const tags = annotations.filter((a) => a.type === "tag");
+
+    for (const d of descriptions) {
+      html += `<div class="description">${escapeHtml(d.value)}</div>`;
+    }
+
+    for (const a of accepts) {
+      html += `<div class="accept-item">${escapeHtml(a.value)}</div>`;
+    }
+
+    if (statuses.length > 0 || priorities.length > 0 || tags.length > 0) {
+      html += '<div class="meta-row">';
+      for (const s of statuses) {
+        html += `<span class="status-badge status-${escapeHtml(s.value)}">${escapeHtml(s.value)}</span>`;
+      }
+      for (const p of priorities) {
+        html += `<span class="priority-badge priority-${escapeHtml(p.value)}">${escapeHtml(p.value)}</span>`;
+      }
+      for (const t of tags) {
+        for (const tag of t.value.split(",")) {
+          html += `<span class="tag-badge">${escapeHtml(tag.trim())}</span>`;
+        }
+      }
+      html += "</div>";
+    }
+
+    html += "</div>";
+    return html;
+  }
+}
+
+// ─── Spec Markdown Export ────────────────────────────────────────────────
+
+function exportSpecMarkdown(): void {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== "fd") {
+    vscode.window.showInformationMessage("Open a .fd file first to export spec.");
+    return;
+  }
+
+  const source = editor.document.getText();
+  const fileName = editor.document.fileName;
+  const baseName = fileName.replace(/\.fd$/, "");
+  const specPath = `${baseName}.spec.md`;
+
+  const lines = source.split("\n");
+  let md = `# Spec: ${fileName.split("/").pop()}\n\n`;
+  let currentAnnotations: { type: string; value: string }[] = [];
+  let currentNodeId = "";
+  let currentNodeKind = "";
+  let headingLevel = 2;
+  const depthStack: number[] = [];
+  let braceDepth = 0;
+  let insideEdge = false;
+  const edgeLines: string[] = [];
+  let edgeFrom = "";
+  let edgeTo = "";
+  let edgeLabel = "";
+  let edgeAnnotations: { type: string; value: string }[] = [];
+
+  const parseAnn = (line: string): { type: string; value: string } | null => {
+    const trimmed = line.replace(/^##\s*/, "");
+    const acceptMatch = trimmed.match(/^accept:\s*"([^"]*)"/);
+    if (acceptMatch) return { type: "accept", value: acceptMatch[1] };
+    const statusMatch = trimmed.match(/^status:\s*(\S+)/);
+    if (statusMatch) return { type: "status", value: statusMatch[1] };
+    const priorityMatch = trimmed.match(/^priority:\s*(\S+)/);
+    if (priorityMatch) return { type: "priority", value: priorityMatch[1] };
+    const tagMatch = trimmed.match(/^tag:\s*(.+)/);
+    if (tagMatch) return { type: "tag", value: tagMatch[1].trim() };
+    const descMatch = trimmed.match(/^"([^"]*)"/);
+    if (descMatch) return { type: "description", value: descMatch[1] };
+    return null;
+  };
+
+  const flushNode = () => {
+    if (!currentNodeId || currentAnnotations.length === 0) {
+      currentAnnotations = [];
+      currentNodeId = "";
+      return;
+    }
+    const hashes = "#".repeat(Math.min(headingLevel, 6));
+    md += `${hashes} @${currentNodeId} \`${currentNodeKind}\`\n\n`;
+    for (const ann of currentAnnotations) {
+      switch (ann.type) {
+        case "description":
+          md += `> ${ann.value}\n`;
+          break;
+        case "accept":
+          md += `- [ ] ${ann.value}\n`;
+          break;
+        case "status":
+          md += `- **Status:** ${ann.value}\n`;
+          break;
+        case "priority":
+          md += `- **Priority:** ${ann.value}\n`;
+          break;
+        case "tag":
+          md += `- **Tags:** ${ann.value}\n`;
+          break;
+      }
+    }
+    md += "\n";
+    currentAnnotations = [];
+    currentNodeId = "";
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith("#") && !trimmed.startsWith("##")) continue;
+
+    if (trimmed.startsWith("##")) {
+      const ann = parseAnn(trimmed);
+      if (ann) {
+        if (insideEdge) {
+          edgeAnnotations.push(ann);
+        } else {
+          currentAnnotations.push(ann);
+        }
+      }
+      continue;
+    }
+
+    // Edge
+    const edgeMatch = trimmed.match(/^edge\s+@(\w+)\s*\{/);
+    if (edgeMatch) {
+      flushNode();
+      insideEdge = true;
+      edgeFrom = "";
+      edgeTo = "";
+      edgeLabel = "";
+      edgeAnnotations = [];
+      braceDepth += 1;
+      continue;
+    }
+
+    if (insideEdge) {
+      const fromMatch = trimmed.match(/^from:\s*@(\w+)/);
+      const toMatch = trimmed.match(/^to:\s*@(\w+)/);
+      const labelMatch = trimmed.match(/^label:\s*"([^"]*)"/);
+      if (fromMatch) edgeFrom = fromMatch[1];
+      if (toMatch) edgeTo = toMatch[1];
+      if (labelMatch) edgeLabel = labelMatch[1];
+      if (trimmed === "}") {
+        insideEdge = false;
+        braceDepth -= 1;
+        let edgeMd = `- **@${edgeFrom}** → **@${edgeTo}**`;
+        if (edgeLabel) edgeMd += ` — ${edgeLabel}`;
+        edgeMd += "\n";
+        for (const ann of edgeAnnotations) {
+          if (ann.type === "description") edgeMd += `  > ${ann.value}\n`;
+          if (ann.type === "accept") edgeMd += `  - [ ] ${ann.value}\n`;
+        }
+        edgeLines.push(edgeMd);
+      }
+      continue;
+    }
+
+    // Closing brace
+    if (trimmed === "}") {
+      flushNode();
+      braceDepth -= 1;
+      if (depthStack.length > 0) {
+        depthStack.pop();
+        headingLevel = 2 + depthStack.length;
+      }
+      continue;
+    }
+
+    // Node declaration
+    const nodeMatch = trimmed.match(
+      /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
+    );
+    if (nodeMatch) {
+      flushNode();
+      currentNodeKind = nodeMatch[1];
+      currentNodeId = nodeMatch[2];
+      if (trimmed.endsWith("{")) {
+        braceDepth += 1;
+        depthStack.push(braceDepth);
+        headingLevel = 2 + depthStack.length - 1;
+      }
+      continue;
+    }
+
+    // Generic node
+    const genericMatch = trimmed.match(/^@(\w+)\s*\{/);
+    if (genericMatch) {
+      flushNode();
+      currentNodeKind = "spec";
+      currentNodeId = genericMatch[1];
+      braceDepth += 1;
+      depthStack.push(braceDepth);
+      headingLevel = 2 + depthStack.length - 1;
+      continue;
+    }
+  }
+
+  flushNode();
+
+  // Append edges
+  if (edgeLines.length > 0) {
+    md += "---\n\n## Flows\n\n";
+    for (const el of edgeLines) {
+      md += el;
+    }
+    md += "\n";
+  }
+
+  // Write file
+  const uri = vscode.Uri.file(specPath);
+  const encoder = new TextEncoder();
+  vscode.workspace.fs.writeFile(uri, encoder.encode(md)).then(() => {
+    vscode.workspace.openTextDocument(uri).then((doc) => {
+      vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside);
+    });
+    vscode.window.showInformationMessage(`Spec exported to ${specPath.split("/").pop()}`);
+  });
+}
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1213,6 +1829,20 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("fd.showPreview", () => {
       FdTreePreviewPanel.show(context);
+    })
+  );
+
+  // Register spec view command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("fd.showSpecView", () => {
+      FdSpecViewPanel.show(context);
+    })
+  );
+
+  // Register spec export command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("fd.exportSpec", () => {
+      exportSpecMarkdown();
     })
   );
 


### PR DESCRIPTION
## Summary

Two features for PM-friendly spec workflows:

### 1. Spec View Panel (VS Code)
- `FdSpecViewPanel` webview showing only `@id`, `##` annotations, hierarchy, and edges
- Hides all visual props (fill, stroke, dimensions, animations)
- Live-updates on text change
- Color-coded status badges, priority indicators, tag pills
- Command: `FD: Show Spec View` + editor title button

### 2. Spec Export to Markdown
- **Rust:** `emit_spec_markdown()` in `emitter.rs` — walks scene graph, outputs clean markdown
- **TypeScript:** `exportSpecMarkdown()` — regex-based extraction, writes `.spec.md` alongside `.fd` file
- Command: `FD: Export Spec to Markdown`

## Changes
- `crates/fd-core/src/emitter.rs` — `emit_spec_markdown()` + 3 tests
- `fd-vscode/src/extension.ts` — `FdSpecViewPanel` class + `exportSpecMarkdown()` + 2 command registrations
- `fd-vscode/package.json` — 2 new commands, spec view in editor/title menu, version bump 0.5.3

## Test Results
```
test result: ok. 117 passed; 0 failed
```
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅
- `cargo test --workspace` ✅ (117 tests)