### PR TITLE
fix(canvas): reuse existing editor group instead of creating new panels

### DIFF
--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1807,11 +1807,23 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Small delay so the text editor settles first
       await new Promise((r) => setTimeout(r, 300));
+
+      // Find a reusable editor group: prefer an existing non-active column
+      // so we don't keep creating new Beside panels
+      const activeColumn = vscode.window.activeTextEditor?.viewColumn;
+      const visibleColumns = vscode.window.visibleTextEditors
+        .map((e) => e.viewColumn)
+        .filter((c): c is vscode.ViewColumn => c !== undefined);
+      const otherColumn = visibleColumns.find((c) => c !== activeColumn);
+
+      // Reuse the other group if it exists, otherwise open beside (creates one)
+      const targetColumn = otherColumn ?? vscode.ViewColumn.Beside;
+
       await vscode.commands.executeCommand(
         "vscode.openWith",
         doc.uri,
         "fd.canvas",
-        vscode.ViewColumn.Beside
+        targetColumn
       );
     })
   );


### PR DESCRIPTION
## Fix

When opening `.fd` files, the auto-open canvas logic used `ViewColumn.Beside` which **always creates a new editor group**. After opening multiple `.fd` files, you'd end up with many panels.

### Change
Instead of always using `Beside`, detect if a non-active editor group already exists and reuse it:
```typescript
const otherColumn = visibleColumns.find((c) => c !== activeColumn);
const targetColumn = otherColumn ?? vscode.ViewColumn.Beside;
```

Falls back to `Beside` only when a single editor group is open (first `.fd` file).

## Tests
- 117 pass, clippy clean, extension compiles