### PR TITLE
docs: add import example to onboarding user flow

### DIFF
--- a/docs/design/userflow_onboarding.fd
+++ b/docs/design/userflow_onboarding.fd
@@ -1,5 +1,6 @@
 # FD v1
 # Onboarding User Flow — multi-step with error paths
+import "../../examples/design_system.fd" as ds
 
 style screen {
   fill: #FFFFFF


### PR DESCRIPTION
Adds `import "../../examples/design_system.fd" as ds` to `userflow_onboarding.fd`, demonstrating the namespaced import feature from PR #44 in a real example.\n\n✅ 124/124 tests pass, clippy clean