### PR TITLE
fix(canvas): fix acquireVsCodeApi called twice + explicit WASM URL

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -172,6 +172,14 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
         "fd_wasm.js"
       )
     );
+    const wasmBinaryUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this.context.extensionUri,
+        "webview",
+        "wasm",
+        "fd_wasm_bg.wasm"
+      )
+    );
     const mainJsUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this.context.extensionUri, "webview", "main.js")
     );
@@ -778,11 +786,14 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
 
   <script nonce="${nonce}">
     window.initialText = \`${initialText}\`;
+    window.wasmBinaryUrl = "${wasmBinaryUri}";
+    window.wasmJsUrl = "${wasmJsUri}";
+    window.vscodeApi = acquireVsCodeApi();
   </script>
   <script nonce="${nonce}">
     // ─── AI Refine toolbar + context menu handlers ─────────
     (function() {
-      const vscodeApi = acquireVsCodeApi();
+      const vscodeApi = window.vscodeApi;
       let selectedNodeId = null;
 
       // Listen for selection changes from canvas

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -8,8 +8,8 @@
 // Import WASM module (built by wasm-pack)
 import init, { FdCanvas } from "./wasm/fd_wasm.js";
 
-// VS Code API
-const vscode = acquireVsCodeApi();
+// VS Code API (shared — already acquired in inline script)
+const vscode = window.vscodeApi;
 
 /** @type {FdCanvas | null} */
 let fdCanvas = null;
@@ -37,8 +37,9 @@ async function main() {
   const status = document.getElementById("status");
 
   try {
-    // Initialize WASM
-    await init();
+    // Initialize WASM — pass explicit URL so it works in VS Code webviews
+    // (import.meta.url resolution fails under vscode-webview:// scheme)
+    await init(window.wasmBinaryUrl || undefined);
 
     // Set up canvas
     const container = document.getElementById("canvas-container");


### PR DESCRIPTION
## Problem
Canvas still shows "Loading FD engine…" forever (follow-up to #47).

## Root Causes Found
1. **`acquireVsCodeApi()` called twice** — The inline AI Refine script called it first, then `main.js` module called it again. VS Code only allows ONE call — the second throws `Error: acquireVsCodeApi can only be called once`, killing the entire module before `main()` runs.
2. **WASM URL unresolvable** — `init()` was called without args, so the glue used `import.meta.url` to resolve `fd_wasm_bg.wasm`. Under the `vscode-webview://` scheme, this `fetch()` hangs silently.

## Changes
- Call `acquireVsCodeApi()` once in globals `<script>`, store on `window.vscodeApi`
- Both inline script and `main.js` module reuse `window.vscodeApi`
- Pass `window.wasmBinaryUrl` (webview-resolved URI) to `init()` explicitly
- Bump version to `0.5.6`

## Testing
- ✅ `cargo clippy --workspace` clean
- ✅ `cargo test --workspace` all pass
- ✅ Extension compiles (`pnpm run compile`)