### PR TITLE
fix(canvas): use dynamic import for WASM glue to fix webview resolution

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Problem
Canvas still sometimes hangs on "Loading FD engine…" (follow-up 2 to #47).

## Root Cause
The static ES module import `import init, { FdCanvas } from "./wasm/fd_wasm.js"` in `main.js` fails silently in VS Code webviews because relative module resolution (`./...`) is not supported under the `vscode-webview://` resource scheme. When a static import fails, it kills the module immediately without entering `main()` or any `try/catch` block.

## Changes
- Replace static `import` with dynamic `import(window.wasmJsUrl)`. The `wasmJsUrl` is explicitly provided by `extension.ts` as a valid, absolute webview URI.
- Move `FdCanvas` assignment into the `main()` function scope.
- Bump extension version to `0.5.7`.

## Testing
- ✅ `cargo test --workspace` all pass
- ✅ Extension compiled cleanly (`pnpm run compile`)