### PR TITLE
chore: bump fd-vscode version to 0.6.1

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Bump fd-vscode version from 0.6.0 to 0.6.1 for republishing with WASM rebuild + theme toggle improvements.