### PR TITLE
fix(editor): position shapes at click location on canvas

### DIFF
--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -123,6 +123,8 @@ impl SyncEngine {
             GraphMutation::AddNode { parent_id, node } => {
                 let parent_idx = self.graph.index_of(parent_id).unwrap_or(self.graph.root);
                 self.graph.add_node(parent_idx, *node);
+                // Re-resolve layout so the new node's Absolute constraint is applied
+                self.bounds = resolve_layout(&self.graph, self.viewport);
             }
             GraphMutation::RemoveNode { id } => {
                 if let Some(idx) = self.graph.index_of(id) {

--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -221,13 +221,14 @@ impl Tool for RectTool {
                 let id = NodeId::anonymous();
                 self.current_id = Some(id);
 
-                let node = SceneNode::new(
+                let mut node = SceneNode::new(
                     id,
                     NodeKind::Rect {
                         width: 0.0,
                         height: 0.0,
                     },
                 );
+                node.constraints.push(Constraint::Absolute { x: *x, y: *y });
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),
@@ -374,7 +375,8 @@ impl Tool for EllipseTool {
                 let id = NodeId::anonymous();
                 self.current_id = Some(id);
 
-                let node = SceneNode::new(id, NodeKind::Ellipse { rx: 0.0, ry: 0.0 });
+                let mut node = SceneNode::new(id, NodeKind::Ellipse { rx: 0.0, ry: 0.0 });
+                node.constraints.push(Constraint::Absolute { x: *x, y: *y });
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),


### PR DESCRIPTION
## Summary

Fixes the bug where drawing a rectangle or ellipse on the canvas places it at the top-left (0,0) instead of where the user clicked.

## Root Cause

`RectTool` and `EllipseTool` created `SceneNode` without any positioning constraint. The layout solver (`LayoutMode::Free`) defaults children to parent origin, so new shapes always appeared at (0,0). The `TextTool` already worked correctly because it attached `Constraint::Absolute { x, y }`.

## Changes

- **`crates/fd-editor/src/tools.rs`**: Added `Constraint::Absolute { x, y }` to `RectTool` and `EllipseTool` on `PointerDown`
- **`crates/fd-editor/src/sync.rs`**: Re-resolve layout bounds immediately after `AddNode` so the new shape renders at the correct position on the first frame

## Testing

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅ (all tests pass)
- `cargo fmt --all` ✅