### PR TITLE
feat(editor): type-prefixed IDs and minimum default size for canvas shapes

### DIFF
--- a/crates/fd-core/src/id.rs
+++ b/crates/fd-core/src/id.rs
@@ -24,10 +24,15 @@ impl NodeId {
 
     /// Generate a unique anonymous ID (for nodes without explicit @id).
     pub fn anonymous() -> Self {
+        Self::with_prefix("_anon")
+    }
+
+    /// Generate a unique ID with a type prefix (e.g. `rect_1`, `ellipse_2`).
+    pub fn with_prefix(prefix: &str) -> Self {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        Self::intern(&format!("_anon_{n}"))
+        Self::intern(&format!("{prefix}_{n}"))
     }
 }
 


### PR DESCRIPTION
## Summary

Two UX improvements for canvas shape tools:

### 1. Type-prefixed IDs
Shapes created on canvas now get semantic IDs (`rect_0`, `ellipse_1`, `text_2`) instead of generic `_anon_N`. Added `NodeId::with_prefix()` method.

### 2. Minimum default size on click
Click-without-drag now creates a 100×100 shape instead of invisible 0×0. A `dragged` flag tracks whether the user actually moved the pointer — only applies default size when `!dragged`.

## Files Changed

- `crates/fd-core/src/id.rs` — Added `NodeId::with_prefix(prefix)` 
- `crates/fd-editor/src/tools.rs` — Type-prefixed IDs + dragged flag + default size on click

## Testing

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all` ✅