### PR TITLE
fix(canvas): swap theme toggle icon semantics

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Fix

Swap theme toggle icon semantics:
- **Light mode** → shows 🌙 (click to switch to dark)
- **Dark mode** → shows ☀️ (click to switch to light)

Updated R3.13 in REQUIREMENTS.md to document the icon behavior.

## CI
- ✅ clippy, fmt, test all pass