### PR TITLE
chore: bump fd-vscode to 0.6.8 for WASM rebuild

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Bumps version to 0.6.8 for publishing the WASM rebuild from PR #68 (v0.6.7 slot was already taken).