### PR TITLE
feat(vscode): Design/Spec view mode toggle in canvas toolbar (v0.6.9)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,13 +51,18 @@ Before modifying ANY file:
 
 ### 🔀 Git Workflow (MANDATORY)
 
-| Rule                     | Description                                             |
-| ------------------------ | ------------------------------------------------------- |
-| **Never commit to main** | All changes go through feature branches                 |
-| **Branch naming**        | `feat/`, `fix/`, `refactor/`, `test/`, `docs/` prefixes |
-| **PR required**          | All merges via Pull Request                             |
-| **CI must pass**         | Never force-push or bypass checks                       |
-| **Sync before branch**   | Always `git fetch origin main` before creating branches |
+| Rule                     | Description                                                     |
+| ------------------------ | --------------------------------------------------------------- |
+| **Never commit to main** | All changes go through feature branches                         |
+| **Branch naming**        | `feat/`, `fix/`, `refactor/`, `test/`, `docs/` prefixes         |
+| **PR required**          | All merges via Pull Request                                     |
+| **CI must pass**         | Never force-push or bypass checks                               |
+| **Sync before branch**   | Always `git fetch origin main` before creating branches         |
+| **Never commit secrets** | `.env`, tokens, passwords, and API keys must NEVER be committed |
+
+> [!CAUTION]
+> **NEVER stage or commit `.env`, `.env.*`, or any file containing secrets, tokens, or API keys.**
+> These are always git-ignored. If accidentally staged, run `git rm --cached .env` immediately.
 
 **Branch Flow:**
 

--- a/crates/fd-wasm/Cargo.toml
+++ b/crates/fd-wasm/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 web-sys = { workspace = true, features = [
     "CanvasRenderingContext2d",
+    "CanvasGradient",
     "HtmlCanvasElement",
     "console",
 ] }

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -187,12 +187,22 @@
         "command": "fd.exportSpec",
         "title": "FD: Export Spec to Markdown",
         "icon": "$(markdown)"
+      },
+      {
+        "command": "fd.toggleViewMode",
+        "title": "FD: Toggle Design/Spec View",
+        "icon": "$(list-unordered)"
       }
     ],
     "menus": {
       "editor/title": [
         {
           "command": "fd.showPreview",
+          "when": "resourceLangId == fd",
+          "group": "navigation"
+        },
+        {
+          "command": "fd.toggleViewMode",
           "when": "resourceLangId == fd",
           "group": "navigation"
         },


### PR DESCRIPTION
## Summary

Adds a **Design | Spec** segmented view toggle to the canvas toolbar, unified within the main canvas webview.

### Changes

**Canvas Toolbar (`extension.ts`)**
- New `Design | Spec` segmented control button in toolbar (Design is default)
- In **Spec View**: canvas hides; spec overlay shows node IDs, `## annotations`, acceptance criteria, status/priority/tag badges, edges, and a compact chip list of unannotated nodes
- Spec overlay updates live as the `.fd` document changes
- Apple design token CSS for all new elements (`.view-toggle`, `.view-btn`, `#spec-overlay`)

**Client-Side Spec Parser (`main.js`)**
- Full spec parsing ported to client-side JS — no extension roundtrip, no latency
- `buildSpecView()` handles typed nodes, generic nodes, edge blocks, `## annotations`
- `setViewMode()` / `refreshSpecView()` / `setupViewToggle()` all added

**Command (`extension.ts` + `package.json`)**
- `fd.toggleViewMode` command registered with `editor/title` menu entry
- `FdEditorProvider.activePanel` tracks the active canvas for command routing

### Tests
- ✅ `cargo clippy --workspace` clean
- ✅ `cargo fmt --all` clean  
- ✅ `cargo test --workspace` all pass
- ✅ `tsc --noEmit` clean (v0.6.9)