### PR TITLE
docs(workflow): enforce main branch protection via pre-push hook + /merge workflow

### DIFF
--- a/.agents/workflows/commit.md
+++ b/.agents/workflows/commit.md
@@ -6,31 +6,37 @@ description: Stage and commit changes to a feature branch (never main)
 
 // turbo-all
 
-1. Check current branch — never commit to `main`:
+1. **Activate pre-push hook** (one-time per clone — blocks accidental pushes to `main`):
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+2. Check current branch — never commit to `main`:
 
    ```bash
    git branch --show-current
    ```
 
-2. If on `main`, create and switch to a feature branch:
+3. If on `main`, create and switch to a feature branch:
 
    ```bash
    git checkout -b feat/<descriptive-name>
    ```
 
-3. Stage all changes:
+4. Stage all changes:
 
    ```bash
    git add -A
    ```
 
-4. Review what's staged:
+5. Review what's staged:
 
    ```bash
    git diff --cached --stat
    ```
 
-5. Commit with a conventional commit message:
+6. Commit with a conventional commit message:
 
    ```bash
    git commit -m "<type>(<scope>): <description>"
@@ -39,7 +45,7 @@ description: Stage and commit changes to a feature branch (never main)
    Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`
    Scopes: `core`, `render`, `editor`, `vscode`, `docs`, `ci`
 
-6. Push to remote:
+7. Push to remote:
    ```bash
    git push -u origin HEAD
    ```

--- a/.agents/workflows/merge.md
+++ b/.agents/workflows/merge.md
@@ -1,0 +1,42 @@
+---
+description: Merge an existing PR into main and sync local branch
+---
+
+# Merge Workflow
+
+> Use this after a PR has been created (via `/pr`) and is ready to merge.
+
+// turbo-all
+
+1. **Activate pre-push hook** (one-time per clone — blocks accidental direct pushes to main):
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+2. Verify the PR is ready (CI green, no blocking reviews):
+
+   ```bash
+   gh pr view <PR_NUMBER> --json state,statusCheckRollup
+   ```
+
+3. Merge the PR and delete the source branch:
+
+   ```bash
+   gh pr merge <PR_NUMBER> --merge --delete-branch
+   ```
+
+4. Sync local `main`:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+5. Confirm the merge commit appears in log:
+
+   ```bash
+   git log --oneline -5
+   ```
+
+6. Report merge status and commit SHA to the user.

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -1,40 +1,61 @@
 ---
-description: Create a Pull Request to merge feature branch into main
+description: Create a Pull Request and merge feature branch into main
 ---
 
 # PR Workflow
 
-1. Ensure all tests pass:
+// turbo-all
+
+1. **Activate pre-push hook** (one-time per clone):
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+2. Ensure all tests pass:
 
    ```bash
    cargo test --workspace
    ```
 
-2. Ensure code compiles with no warnings:
+3. Ensure code compiles with no warnings:
 
    ```bash
    cargo check --workspace 2>&1 | grep -E "warning|error" | head -20
    ```
 
-3. Check current branch:
+4. Check current branch — must NOT be `main`:
 
    ```bash
    git branch --show-current
    ```
 
-4. Push latest changes:
+5. Push latest changes:
 
    ```bash
    git push -u origin HEAD
    ```
 
-5. Create the PR using GitKraken MCP tool:
+6. Create the PR using GitKraken MCP tool:
    - `provider`: github
    - `repository_name`: fast-draft
-   - `repository_organization`: <org from git remote>
+   - `repository_organization`: khangnghiem
    - `source_branch`: current branch
    - `target_branch`: main
-   - `title`: conventional format like "feat(core): add FD parser"
+   - `title`: conventional format like `feat(core): add FD parser`
    - `body`: summary of changes, what was tested
 
-6. Report the PR URL to the user.
+7. Merge the PR and delete the branch:
+
+   ```bash
+   gh pr merge <PR_NUMBER> --merge --delete-branch
+   ```
+
+8. Sync local main:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+9. Report the PR URL and merge status to the user.

--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -51,55 +51,61 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 
 > Use this after `/yolo local` has passed.
 
-5. **Check branch** (never commit to main):
+5. **Activate pre-push hook** (one-time per clone — blocks accidental pushes to `main`):
+
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+6. **Check branch** (never commit to main):
 
    ```bash
    git branch --show-current
    ```
 
-6. If on `main`, create a feature branch:
+7. If on `main`, create a feature branch:
 
    ```bash
    git checkout -b feat/<descriptive-name>
    ```
 
-7. **Bump Version** (if `fd-vscode/` was changed):
+8. **Bump Version** (if `fd-vscode/` was changed):
    - Bump the `version` field in `fd-vscode/package.json` appropriately (patch/minor/major).
 
-8. **Stage and commit**:
+9. **Stage and commit**:
 
    ```bash
    git add -A
    git commit -m "<type>(<scope>): <description>"
    ```
 
-9. **Push**:
+10. **Push**:
 
-   ```bash
-   git push -u origin HEAD
-   ```
+    ```bash
+    git push -u origin HEAD
+    ```
 
-10. **Create PR** using GitKraken MCP:
+11. **Create PR** using GitKraken MCP:
     - `provider`: github
     - `source_branch`: current branch
     - `target_branch`: main
     - Title in conventional format
     - Body summarizing changes + test results
 
-11. **Merge PR** and clean up:
+12. **Merge PR** and clean up:
 
     ```bash
     gh pr merge <PR_NUMBER> --merge --delete-branch
     ```
 
-12. **Sync main**:
+13. **Sync main**:
 
     ```bash
     git checkout main
     git pull origin main
     ```
 
-13. **Build & Publish VS Code extension** (if `fd-vscode/` was changed):
+14. **Build & Publish VS Code extension** (if `fd-vscode/` was changed):
 
     > ⚠️ **MANDATORY**: Read `.env` for `VSCE_PAT`, `VSX_PAT`, and `GEMINI_API_KEY` BEFORE publishing.
     > Never rely on interactive prompts — always pass tokens via flags.
@@ -121,7 +127,7 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
     > Skip publish if the change is local-only or version wasn't bumped.
     > **NEVER** publish to only one registry — both Marketplace AND Open VSX are required.
 
-14. Report PR URL, merge status, and publish results to user.
+15. Report PR URL, merge status, and publish results to user.
 
 ---
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# pre-push hook: block direct pushes to main
+# Part of FD project git safety rules (see GEMINI.md)
+
+protected_branch="main"
+
+while read local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "refs/heads/$protected_branch" ]]; then
+    echo ""
+    echo "❌  Direct push to '$protected_branch' is not allowed."
+    echo "    Create a feature branch and open a Pull Request instead."
+    echo ""
+    echo "    git checkout -b feat/your-feature"
+    echo "    git push origin feat/your-feature"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -64,6 +64,12 @@ Before modifying ANY file:
 > **NEVER stage or commit `.env`, `.env.*`, or any file containing secrets, tokens, or API keys.**
 > These are always git-ignored. If accidentally staged, run `git rm --cached .env` immediately.
 
+> [!CAUTION]
+> **Direct pushes to `main` are blocked by a pre-push git hook** (`.githooks/pre-push`).
+> This is enforced mechanically — not just advisory. You CANNOT push to `main` directly.
+> The `git config core.hooksPath .githooks` setting activates this for all clones that run it.
+> On a fresh clone, run: `git config core.hooksPath .githooks` to activate.
+
 **Branch Flow:**
 
 ```
@@ -157,7 +163,8 @@ crates/
 | `/test`   | Test generation                          | Write tests before code (TDD) |
 | `/build`  | Build + test workspace                   | Implementation + verification |
 | `/commit` | Stage + commit changes                   | After successful build        |
-| `/pr`     | Create Pull Request                      | Ready to merge to main        |
+| `/pr`     | Create PR + merge into main              | Ready to merge to main        |
+| `/merge`  | Merge an existing PR into main           | After PR is approved          |
 | `/debug`  | Systematic debugging                     | Bug investigation             |
 | `/yolo`   | Full pipeline (test→build→commit→pr)     | Small changes, feeling lucky  |
 


### PR DESCRIPTION
## Summary

Adds mechanical enforcement for the "never push to main" rule and updates all workflows to include PR creation, merging, and hook activation.

### Changes

- **`.githooks/pre-push`** — New tracked hook that hard-blocks `git push origin main` with a clear error message
- **`GEMINI.md`** — Added `[!CAUTION]` alert documenting the hook; added `/merge` to workflow table
- **`.agents/workflows/merge.md`** — New `/merge` workflow for merging PRs into main and syncing local branch  
- **`.agents/workflows/pr.md`** — Extended to include merge + sync steps after PR creation; added hook activation step
- **`.agents/workflows/commit.md`** — Added hook activation as first step
- **`.agents/workflows/yolo.md`** — Added hook activation step to deploy section

### Activation

On a fresh clone, run once to activate the hook:
```bash
git config core.hooksPath .githooks
```

### Tested

- Hook installed and executable at `.git/hooks/pre-push`
- `git config core.hooksPath .githooks` configured locally
