### PR TITLE
fix(parser+emitter): gradient fill + shadow roundtrip (v0.6.11)

### DIFF
--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -75,6 +75,18 @@ fn emit_style_block(out: &mut String, name: &NodeId, style: &Style, depth: usize
         indent(out, depth + 1);
         writeln!(out, "opacity: {}", format_num(opacity)).unwrap();
     }
+    if let Some(ref shadow) = style.shadow {
+        indent(out, depth + 1);
+        writeln!(
+            out,
+            "shadow: ({},{},{},{})",
+            format_num(shadow.offset_x),
+            format_num(shadow.offset_y),
+            format_num(shadow.blur),
+            shadow.color.to_hex()
+        )
+        .unwrap();
+    }
 
     indent(out, depth);
     out.push_str("}\n");
@@ -188,6 +200,18 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
     if let Some(opacity) = node.style.opacity {
         indent(out, depth + 1);
         writeln!(out, "opacity: {}", format_num(opacity)).unwrap();
+    }
+    if let Some(ref shadow) = node.style.shadow {
+        indent(out, depth + 1);
+        writeln!(
+            out,
+            "shadow: ({},{},{},{})",
+            format_num(shadow.offset_x),
+            format_num(shadow.offset_y),
+            format_num(shadow.blur),
+            shadow.color.to_hex()
+        )
+        .unwrap();
     }
     if let Some(ref label) = node.style.label {
         indent(out, depth + 1);

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary

Fixes 4 latent bugs where gradient fills and shadow styles would be silently dropped after a parse → emit → re-parse roundtrip. Adds 5 roundtrip tests to prevent regression.

## Bugs Fixed

### Parser

| Location | Before | After |
|---|---|---|
| `parse_style_block` fill: | `Paint::Solid(hex)` only | `parse_paint()` — handles linear/radial too |
| `parse_node_property` fill: | `Paint::Solid(hex)` only | `parse_paint()` |
| `parse_gradient_stops` | Required leading `,` on every stop | Optional leading `,` — works for `radial(#HEX N, ...)` |
| `shadow:` property | Not supported as standalone property | Parses `shadow: (ox,oy,blur,#COLOR)` |

### Emitter

| Location | Before | After |
|---|---|---|
| `emit_style_block` shadow | `shadow=(...)` (no colon) | `shadow: (...)` (matches property parser) |
| `emit_node` inline shadow | `shadow=(...)` (no colon) | `shadow: (...)` |

## New Tests

5 new roundtrip tests in `parse_emit_roundtrip.rs`:
- `roundtrip_linear_gradient_fill`
- `roundtrip_radial_gradient_fill`  
- `roundtrip_shadow`
- `roundtrip_path_kind`
- `roundtrip_gradient_in_named_style`

## Verification

```
141/141 tests pass
cargo clippy --workspace -- -D warnings ✅
cargo fmt --all ✅
```