### PR TITLE
feat(render): implement R5.8 edge flow animations (v0.6.13)

### DIFF
--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -230,7 +230,10 @@ rect @box {
     #[test]
     fn undo_resize_restores_original_size() {
         let input = "rect @panel {\n  w: 200 h: 100\n}\n";
-        let viewport = Viewport { width: 800.0, height: 600.0 };
+        let viewport = Viewport {
+            width: 800.0,
+            height: 600.0,
+        };
         let mut engine = SyncEngine::from_text(input, viewport).unwrap();
         let mut stack = CommandStack::new(100);
 
@@ -260,12 +263,20 @@ rect @box {
     fn undo_set_style_restores_original_fill() {
         use fd_core::model::{Color, Paint, Style};
         let input = "rect @btn {\n  w: 80 h: 40\n  fill: #FF0000\n}\n";
-        let viewport = Viewport { width: 800.0, height: 600.0 };
+        let viewport = Viewport {
+            width: 800.0,
+            height: 600.0,
+        };
         let mut engine = SyncEngine::from_text(input, viewport).unwrap();
         let mut stack = CommandStack::new(100);
 
         let new_style = Style {
-            fill: Some(Paint::Solid(Color { r: 0.0, g: 0.0, b: 1.0, a: 1.0 })),
+            fill: Some(Paint::Solid(Color {
+                r: 0.0,
+                g: 0.0,
+                b: 1.0,
+                a: 1.0,
+            })),
             ..Style::default()
         };
 
@@ -281,7 +292,13 @@ rect @box {
         // After undo fill should be back to red (#FF0000)
         stack.undo(&mut engine);
         let node = engine.graph.get_by_id(NodeId::intern("btn")).unwrap();
-        match node.style.fill.as_ref().and_then(|p| if let Paint::Solid(c) = p { Some(c) } else { None }) {
+        match node.style.fill.as_ref().and_then(|p| {
+            if let Paint::Solid(c) = p {
+                Some(c)
+            } else {
+                None
+            }
+        }) {
             Some(c) => assert_eq!(c.r, 1.0, "red channel should be 1.0 (original red fill)"),
             None => panic!("fill should be Some(Solid) after undo"),
         }
@@ -290,7 +307,10 @@ rect @box {
     #[test]
     fn new_execute_clears_redo_stack() {
         let input = "rect @box {\n  w: 100 h: 50\n}\n";
-        let viewport = Viewport { width: 800.0, height: 600.0 };
+        let viewport = Viewport {
+            width: 800.0,
+            height: 600.0,
+        };
         let mut engine = SyncEngine::from_text(input, viewport).unwrap();
         let mut stack = CommandStack::new(100);
 
@@ -307,13 +327,19 @@ rect @box {
 
         // New action should clear redo stack
         stack.execute(&mut engine, move_box(), "Move 2");
-        assert!(!stack.can_redo(), "redo stack should be cleared after new execute");
+        assert!(
+            !stack.can_redo(),
+            "redo stack should be cleared after new execute"
+        );
     }
 
     #[test]
     fn stack_respects_max_depth() {
         let input = "rect @box {\n  w: 100 h: 50\n}\n";
-        let viewport = Viewport { width: 800.0, height: 600.0 };
+        let viewport = Viewport {
+            width: 800.0,
+            height: 600.0,
+        };
         let mut engine = SyncEngine::from_text(input, viewport).unwrap();
         let max = 3;
         let mut stack = CommandStack::new(max);
@@ -340,4 +366,3 @@ rect @box {
         assert_eq!(undo_count, max, "undo depth should be capped at max_depth");
     }
 }
-

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -87,7 +87,7 @@ impl FdCanvas {
     }
 
     /// Render the scene to a Canvas2D context.
-    pub fn render(&self, ctx: &CanvasRenderingContext2d) {
+    pub fn render(&self, ctx: &CanvasRenderingContext2d, time_ms: f64) {
         let selected_ids: Vec<String> = self
             .select_tool
             .selected
@@ -108,6 +108,7 @@ impl FdCanvas {
             &selected_ids,
             &theme,
             self.select_tool.marquee_rect,
+            time_ms,
         );
     }
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -82,8 +82,8 @@ async function main() {
       fdCanvas.set_text(window.initialText);
     }
 
-    // Initial render
-    render();
+    // Start animation loop (covers flow animation + initial render)
+    startAnimLoop();
 
     // Hide loading overlay
     if (loading) loading.style.display = "none";
@@ -118,8 +118,29 @@ function render() {
   const dpr = window.devicePixelRatio || 1;
   ctx.save();
   ctx.setTransform(dpr, 0, 0, dpr, panX * dpr, panY * dpr);
-  fdCanvas.render(ctx);
+  fdCanvas.render(ctx, performance.now());
   ctx.restore();
+}
+
+/** Animation loop ID for flow animations (pulse/dash edges). */
+let animFrameId = null;
+
+/** Start the animation loop for continuous flow animation rendering. */
+function startAnimLoop() {
+  if (animFrameId !== null) return; // already running
+  function loop() {
+    render();
+    animFrameId = requestAnimationFrame(loop);
+  }
+  animFrameId = requestAnimationFrame(loop);
+}
+
+/** Stop the animation loop (e.g. when canvas is hidden). */
+function stopAnimLoop() {
+  if (animFrameId !== null) {
+    cancelAnimationFrame(animFrameId);
+    animFrameId = null;
+  }
 }
 
 // ─── Pointer Events ──────────────────────────────────────────────────────


### PR DESCRIPTION
Implements R5.8 edge flow animations, which visually indicate the direction and flow of data/events along edges.

## Changes:
- `fd-wasm/src/render2d.rs`: Implementation of `draw_flow_animation` for `FlowKind::Pulse` (traveling dot) and `FlowKind::Dash` (marching dashes).
- `fd-wasm/src/render2d.rs`, `fd-wasm/src/lib.rs`: Added `time_ms` parameter recursively down to `draw_edges` for computing animation phase.
- `fd-vscode/webview/main.js`: Updates `render()` to pass `performance.now()` into `fdCanvas.render()`.
- `fd-vscode/webview/main.js`: Setup `requestAnimationFrame` loop that auto-starts upon WASM initialization, achieving continuous smooth animated flow strokes.
- Removed duplicate `#[allow(clippy::too_many_arguments)]` from `render_scene`. Added the same allow rule to `draw_flow_animation`.

Also bumps `fd-vscode` to **v0.6.13**.

All tests pass and formatting/lint is clean.