### PR TITLE
chore(release): bump fd-vscode to v0.6.16

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Bump fd-vscode version to 0.6.16 after publishing to VS Code Marketplace and Open VSX.