### PR TITLE
feat(sync): bidirectional selection sync between Code and Canvas modes

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -31,6 +31,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R2.2**: Text → Canvas: Source edits re-render the canvas in <16ms
 - **R2.3**: Incremental: Only re-parse/re-emit changed regions, not the entire document
 - **R2.4**: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
+- **R2.5**: Selection sync — clicking a node `@id` line in the text editor selects it on canvas; clicking a node on canvas reveals and highlights its `@id` line in the text editor
 
 ### R3: Human Editing (Canvas)
 
@@ -121,7 +122,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 | Tag                | Requirements                          |
 | ------------------ | ------------------------------------- |
-| selection          | R3.1, R3.16                           |
+| selection          | R2.5, R3.1, R3.16                     |
 | drawing            | R3.3, R3.15, R3.19                    |
 | pen / freehand     | R3.4, R3.22, R3.23                    |
 | pan                | R3.6, R3.10                           |

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -253,6 +253,9 @@ function setupPointerEvents() {
     canvas.releasePointerCapture(e.pointerId);
     // Update properties panel after interaction ends
     updatePropertiesPanel();
+    // Notify extension of canvas selection change (for Code ↔ Canvas sync)
+    const selectedId = fdCanvas.get_selected_id();
+    vscode.postMessage({ type: "nodeSelected", id: selectedId });
   });
 
   // ── Wheel / Trackpad scroll → pan ──
@@ -431,6 +434,12 @@ document.addEventListener("keydown", (e) => {
     case "showHelp":
       toggleShortcutHelp();
       break;
+  }
+
+  // Notify extension of selection changes from keyboard actions
+  if (result.changed || result.action === "deselect") {
+    const selectedId = fdCanvas.get_selected_id();
+    vscode.postMessage({ type: "nodeSelected", id: selectedId });
   }
 
   // Update cursor when tool changes via shortcut


### PR DESCRIPTION
## Summary\n\nImplements bidirectional selection sync between Code Mode and Canvas Mode (R2.5):\n\n- **Canvas → Code**: Clicking a node on canvas posts `nodeSelected` → extension finds `@id` line and reveals/highlights it with a 1.5s decoration\n- **Code → Canvas**: Already worked via cursor listener → `selectNode` message\n- **Loop prevention**: `suppressCursorSync` guard prevents feedback loop\n- **Keyboard support**: Also notifies on keyboard-driven selection changes (Escape, Delete)\n\n## Changes\n\n- `REQUIREMENTS.md`: Added R2.5 (selection sync)\n- `fd-vscode/webview/main.js`: Posts `nodeSelected` after pointer up and keyboard selection changes\n- `fd-vscode/src/extension.ts`: Handles `nodeSelected` — finds `@id` line, reveals, and highlights\n- `fd-vscode/package.json`: Bumped version to 0.6.17\n\n## Tests\n\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo test --workspace`\n- ✅ `cargo fmt --all`