### PR TITLE
fix(vscode): fix spec view for both code and canvas modes

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Changes

- **Canvas Mode spec view fix**: Added `z-index: 5` to `#spec-overlay` CSS — it was buried behind other positioned elements, causing a blank spec view
- **Code Mode spec view**: Added editor decorations that hide style/animation/layout details when toggling to Spec mode, keeping only `#`/`##` comments, node/edge declarations, and braces visible
- **Unified toggle**: `fd.toggleViewMode` now works for both canvas and text editors simultaneously

## Tests

- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all`
- ✅ `cargo test --workspace`
- ✅ `pnpm run compile`