### PR TITLE
feat(canvas): implement zoom system (R3.20)

### DIFF
--- a/.agents/workflows/e2e.md
+++ b/.agents/workflows/e2e.md
@@ -1,0 +1,59 @@
+---
+description: E2E browser testing via GitHub Codespace
+---
+
+# E2E Testing Workflow
+
+> Open the project in a GitHub Codespace via Chrome and manually test the FD canvas editor.
+
+## Prerequisites
+
+- GitHub CLI (`gh`) authenticated with codespace scope
+- Run once: `gh auth refresh -h github.com -s codespace`
+
+## Steps
+
+1. **List available Codespaces**:
+
+   ```bash
+   gh codespace list
+   ```
+
+2. **Open in browser** (starts if stopped):
+
+   ```bash
+   gh codespace code -c <codespace-name> --web
+   ```
+
+3. **Open a `.fd` file** — e.g. `examples/demo.fd`
+
+4. **Open with Canvas editor** — Command Palette → "FD: Open Canvas Editor"
+
+5. **Test checklist**:
+
+   | Feature            | How to test                     | Expected                                        |
+   | ------------------ | ------------------------------- | ----------------------------------------------- |
+   | Draw rect          | Press R, click-drag on canvas   | Rectangle appears, tool switches back to Select |
+   | Draw ellipse       | Press O, click-drag             | Ellipse appears                                 |
+   | Pen draw           | Press P, draw freehand          | Smooth path appears                             |
+   | Text               | Press T, click on canvas, type  | Text node created                               |
+   | Select & move      | V, click node, drag             | Node moves, FD source updates                   |
+   | Pan                | Space+drag or middle-click drag | Canvas pans                                     |
+   | Zoom in/out        | ⌘+/⌘− or Ctrl+scroll            | Canvas zooms, indicator updates                 |
+   | Zoom to fit        | ⌘0                              | Content fills viewport                          |
+   | Pinch zoom         | Trackpad pinch                  | Smooth zoom at cursor                           |
+   | Reset zoom         | Click zoom indicator            | Returns to 100%                                 |
+   | Properties         | Select node, check right panel  | Fill, stroke, size shown                        |
+   | Inline edit        | Double-click text node          | Textarea appears                                |
+   | Undo/redo          | ⌘Z / ⌘⇧Z                        | Actions reverse                                 |
+   | Theme toggle       | Click 🌙 button                 | Dark/light switch                               |
+   | Keyboard shortcuts | Press ?                         | Help overlay shows                              |
+   | Code ↔ Canvas sync | Edit FD source, watch canvas    | Bidirectional updates                           |
+
+6. **Report** any bugs or visual issues found.
+
+## Tips
+
+- The Codespace needs ~30s to start if stopped
+- All keyboard shortcuts are listed in the `?` help overlay
+- Use ⌘ on Mac, Ctrl on Linux/Windows in the Codespace

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -624,6 +624,28 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       transform: scale(1.04);
     }
 
+    /* ── Zoom Indicator (Apple pill) ── */
+    #zoom-level {
+      padding: 3px 9px;
+      border: 1px solid var(--fd-border) !important;
+      border-radius: 20px;
+      background: var(--fd-segment-bg);
+      color: var(--fd-text-secondary);
+      font-size: 10px;
+      font-weight: 600;
+      font-family: 'SF Mono', SFMono-Regular, ui-monospace, monospace;
+      letter-spacing: -0.02em;
+      cursor: pointer;
+      transition: all 0.18s ease;
+      min-width: 42px;
+      text-align: center;
+    }
+    #zoom-level:hover {
+      background: var(--fd-accent-dim);
+      border-color: var(--fd-accent-border) !important;
+      color: var(--fd-accent);
+    }
+
     /* ── Help & Status ── */
     #tool-help-btn {
       margin-left: auto;
@@ -1078,6 +1100,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     </div>
     <div class="tool-sep"></div>
     <button class="tool-btn" id="theme-toggle-btn" title="Toggle light/dark canvas theme">🌙</button>
+    <button id="zoom-level" title="Zoom level (click to reset to 100%)">100%</button>
     <button class="tool-btn" id="tool-help-btn" title="Keyboard shortcuts">?</button>
     <span id="status">Loading WASM…</span>
   </div>


### PR DESCRIPTION
## Summary

Implements the **zoom system** for the FD canvas editor (R3.20 from REQUIREMENTS.md).

### Features
- **Pinch-to-zoom** on trackpad (Ctrl/⌘ + scroll wheel)
- **⌘+/⌘−** step zoom (1.25× per step)
- **⌘0** zoom-to-fit (calculates scene bounding box and centers)
- **Zoom level indicator** in toolbar — Apple-style pill showing current % (click to reset to 100%)
- All pointer coordinate conversions (8 locations) properly account for zoom level
- Inline text editor and drag-drop positions adjusted for zoom

### Files Changed
- `fd-vscode/webview/main.js` — Zoom state, render transform, coordinate conversions, helper functions
- `fd-vscode/src/extension.ts` — Toolbar HTML + CSS for zoom indicator
- `fd-vscode/package.json` — Version bump to 0.6.22
- `.agents/workflows/e2e.md` — New E2E testing workflow

### Verification
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace`
- ✅ `cargo fmt --all -- --check`
- ✅ `pnpm test` (41/41 tests pass)