### PR TITLE
fix(vscode): reuse existing panel for canvas instead of creating 3rd panel

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/fd-parse.test.ts
+++ b/fd-vscode/src/fd-parse.test.ts
@@ -6,6 +6,7 @@ import {
   findAnonNodeIds,
   stripMarkdownFences,
   escapeHtml,
+  resolveTargetColumn,
 } from "./fd-parse";
 
 // ─── parseAnnotation ─────────────────────────────────────────────────────
@@ -353,5 +354,37 @@ describe("escapeHtml", () => {
     expect(escapeHtml('<a href="x">&')).toBe(
       "&lt;a href=&quot;x&quot;&gt;&amp;"
     );
+  });
+});
+
+// ─── resolveTargetColumn ─────────────────────────────────────────────────
+
+describe("resolveTargetColumn", () => {
+  it("returns beside when only one group matches active column", () => {
+    expect(resolveTargetColumn(1, [1])).toBe("beside");
+  });
+
+  it("returns the other column when two groups exist", () => {
+    expect(resolveTargetColumn(1, [1, 2])).toBe(2);
+  });
+
+  it("returns column 1 when active is column 2", () => {
+    expect(resolveTargetColumn(2, [1, 2])).toBe(1);
+  });
+
+  it("returns first non-active column with three groups", () => {
+    expect(resolveTargetColumn(1, [1, 2, 3])).toBe(2);
+  });
+
+  it("returns beside when active column is undefined and single group", () => {
+    expect(resolveTargetColumn(undefined, [1])).toBe(1);
+  });
+
+  it("returns beside when no groups exist", () => {
+    expect(resolveTargetColumn(undefined, [])).toBe("beside");
+  });
+
+  it("returns the group column when active column is not in groups", () => {
+    expect(resolveTargetColumn(1, [2])).toBe(2);
   });
 });

--- a/fd-vscode/src/fd-parse.ts
+++ b/fd-vscode/src/fd-parse.ts
@@ -284,6 +284,26 @@ export function stripMarkdownFences(text: string): string {
   return result.trim();
 }
 
+// ─── Panel Column Resolution ─────────────────────────────────────────────
+
+/**
+ * Determine which ViewColumn to open the canvas panel in.
+ *
+ * When two editor groups already exist, returns the column of the
+ * non-active group so the canvas reuses it instead of creating a 3rd panel.
+ *
+ * @param activeColumn  The ViewColumn of the active text editor (may be undefined).
+ * @param allGroupColumns  ViewColumns of ALL editor groups (from `tabGroups.all`).
+ * @returns A numeric column to reuse, or `"beside"` to create a new panel.
+ */
+export function resolveTargetColumn(
+  activeColumn: number | undefined,
+  allGroupColumns: number[]
+): number | "beside" {
+  const otherColumn = allGroupColumns.find((c) => c !== activeColumn);
+  return otherColumn ?? "beside";
+}
+
 // ─── HTML Escaping ───────────────────────────────────────────────────────
 
 /** Escape HTML special characters. */


### PR DESCRIPTION
## Problem\nWhen two editor panels are already open, opening an `.fd` file creates a 3rd panel for Canvas Mode instead of reusing the existing other panel.\n\n## Root Cause\nThe auto-open canvas logic used `visibleTextEditors` which only returns text editors, not webview panels (like Canvas). When 2 panels exist (text + canvas), the code couldn't see the canvas column and `ViewColumn.Beside` created a 3rd panel.\n\n## Fix\n- Replace `visibleTextEditors` with `tabGroups.all` (includes all editor groups: text, webview, custom editors)\n- Extract pure `resolveTargetColumn()` function into `fd-parse.ts` for testability\n- Add 7 unit tests covering all column resolution scenarios\n\n## Tests\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo test --workspace` — 14/14 passed\n- ✅ `pnpm test` — 48/48 passed (7 new resolveTargetColumn tests)"