### PR TITLE
fix(vscode): default focus on Code Mode when opening .fd files

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -2282,6 +2282,19 @@ export function activate(context: vscode.ExtensionContext) {
         "fd.canvas",
         targetColumn
       );
+
+      // Refocus the text editor so Code Mode has focus by default
+      await new Promise((r) => setTimeout(r, 100));
+      const textEditor = vscode.window.visibleTextEditors.find(
+        (e) => e.document.uri.toString() === key
+      );
+      if (textEditor) {
+        await vscode.window.showTextDocument(
+          textEditor.document,
+          textEditor.viewColumn,
+          false
+        );
+      }
     })
   );
   context.subscriptions.push(


### PR DESCRIPTION
## Summary\n\nWhen opening a `.fd` file from the explorer, the canvas panel auto-opens alongside the text editor but steals focus. This fix ensures the text editor (Code Mode) retains focus by default.\n\n### Changes\n- After the canvas panel opens via `onDidOpenTextDocument`, refocus the text editor with a small delay\n- Bump version to 0.6.26\n\n### Test Results\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo fmt --all -- --check` — clean\n- ✅ `cargo test --workspace` — 14 tests passed\n- ✅ `pnpm test` — 48 tests passed