### PR TITLE
feat(vscode): add Tree View mode with Layers Panel and Outline integration

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -190,7 +190,7 @@
       },
       {
         "command": "fd.toggleViewMode",
-        "title": "FD: Toggle Design/Spec View",
+        "title": "FD: Toggle Design/Spec/Tree View",
         "icon": "$(list-unordered)"
       }
     ],


### PR DESCRIPTION
## Tree View: Layers Panel + Outline Integration

### Changes
- **3-way view toggle**: Design → Spec → Tree (canvas toolbar + `fd.toggleViewMode` command)
- **Layers Panel** (Option A): Figma-style sidebar in Canvas showing hierarchical node tree with icons, click-to-select, and text sync
- **DocumentSymbolProvider** (Option B): Powers VS Code's built-in Outline view (`⌘+Shift+O`) for `.fd` files
- **`parseDocumentSymbols()`**: Pure function in `fd-parse.ts` for hierarchical FD symbol parsing

### Test Results
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` 14/14 ✅
- `pnpm test` (Vitest) 59/59 ✅ (11 new `parseDocumentSymbols` tests)

### Files Changed
- `fd-vscode/src/fd-parse.ts` — `FdSymbol` interface + `parseDocumentSymbols()`
- `fd-vscode/src/fd-parse.test.ts` — 11 new tests
- `fd-vscode/src/extension.ts` — `FdDocumentSymbolProvider`, Tree button, Layers Panel CSS/HTML, 3-way toggle
- `fd-vscode/webview/main.js` — `parseLayerTree()`, `refreshLayersPanel()`, `renderLayerNode()`
- `fd-vscode/package.json` — version 0.6.27, updated command title