### PR TITLE
refactor(vscode): remove Tree from view toggle, make layers panel always visible

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary

Like Figma/Sketch, the layers panel is now **always visible** on the left side of the canvas instead of requiring a separate Tree View mode toggle. The view mode toggle is simplified to **Design ↔ Spec** only.

## Changes

- Remove `tree` from Design → Spec → Tree toggle cycle (now **Design ↔ Spec**)
- Remove Tree button from canvas toolbar
- Layers panel always displayed (`display: block` by default)
- Auto-refresh layers on every render and text update
- Simplify view mode types from `"design"|"spec"|"tree"` to `"design"|"spec"`
- Bump version `0.6.28` → `0.6.29`

## Test Results

- ✅ `cargo clippy` — 0 warnings
- ✅ `cargo test` — 14/14 passed
- ✅ `pnpm test` — 65/65 passed