### PR TITLE
fix(vscode): cursor-to-canvas selection sync for all lines in node block

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.30",
+  "version": "0.6.31",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary\n\nFixes cursor→canvas bidirectional selection sync so that clicking **anywhere inside a node block** in Code Mode selects the corresponding node in Canvas Mode, not just the `@node_id` declaration line.\n\n## Changes\n\n- **`fd-parse.ts`**: Added `findSymbolAtLine()` — walks the `FdSymbol` tree to find the deepest symbol containing the cursor line\n- **`extension.ts`**: Replaced simple `/@(\\w+)/` regex with `parseDocumentSymbols()` + `findSymbolAtLine()` lookup\n- **`fd-parse.test.ts`**: Added 9 test cases for `findSymbolAtLine`\n- **`package.json`**: Version bump 0.6.30 → 0.6.31\n\n## Test Results\n\n- ✅ `cargo clippy --workspace -- -D warnings` — pass\n- ✅ `cargo test --workspace` — 14/14 pass\n- ✅ `pnpm test` — 74/74 pass (including 9 new tests)