### PR TITLE
chore(vscode): bump version to 0.6.32

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.31",
+  "version": "0.6.32",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump to 0.6.32 for publishing the cursor→canvas bidirectional selection fix.