### PR TITLE
docs(workflow): add mandatory docs update step, update CHANGELOG and REQUIREMENTS

### DIFF
--- a/.agents/workflows/commit.md
+++ b/.agents/workflows/commit.md
@@ -24,19 +24,23 @@ description: Stage and commit changes to a feature branch (never main)
    git checkout -b feat/<descriptive-name>
    ```
 
-4. Stage all changes:
+4. **Update docs** (MANDATORY):
+   - `docs/CHANGELOG.md` — add entry for each meaningful change
+   - `REQUIREMENTS.md` — update if behavior changed or new feature added (check Requirement Index first)
+
+5. Stage all changes:
 
    ```bash
    git add -A
    ```
 
-5. Review what's staged:
+6. Review what's staged:
 
    ```bash
    git diff --cached --stat
    ```
 
-6. Commit with a conventional commit message:
+7. Commit with a conventional commit message:
 
    ```bash
    git commit -m "<type>(<scope>): <description>"
@@ -45,7 +49,7 @@ description: Stage and commit changes to a feature branch (never main)
    Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`
    Scopes: `core`, `render`, `editor`, `vscode`, `docs`, `ci`
 
-7. Push to remote:
+8. Push to remote:
    ```bash
    git push -u origin HEAD
    ```

--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -78,40 +78,44 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 8. **Bump Version** (if `fd-vscode/` was changed):
    - Bump the `version` field in `fd-vscode/package.json` appropriately (patch/minor/major).
 
-9. **Stage and commit**:
+9. **Update docs** (MANDATORY):
+   - `docs/CHANGELOG.md` — add entry under the current version section for each meaningful change
+   - `REQUIREMENTS.md` — update if behavior changed, new feature added, or requirement wording needs refinement (check the Requirement Index for overlap first)
 
-   ```bash
-   git add -A
-   git commit -m "<type>(<scope>): <description>"
-   ```
+10. **Stage and commit**:
 
-10. **Push**:
+    ```bash
+    git add -A
+    git commit -m "<type>(<scope>): <description>"
+    ```
+
+11. **Push**:
 
     ```bash
     git push -u origin HEAD
     ```
 
-11. **Create PR** using GitKraken MCP:
+12. **Create PR** using GitKraken MCP:
     - `provider`: github
     - `source_branch`: current branch
     - `target_branch`: main
     - Title in conventional format
     - Body summarizing changes + test results
 
-12. **Merge PR** and clean up:
+13. **Merge PR** and clean up:
 
     ```bash
     gh pr merge <PR_NUMBER> --merge --delete-branch
     ```
 
-13. **Sync main**:
+14. **Sync main**:
 
     ```bash
     git checkout main
     git pull origin main
     ```
 
-14. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
+15. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
 
     > ⚠️ **MANDATORY**: Read `.env` for `VSCE_PAT`, `VSX_PAT`, and `GEMINI_API_KEY` BEFORE publishing.
     > Never rely on interactive prompts — always pass tokens via flags.
@@ -133,10 +137,10 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
     > Skip publish if the change is local-only or version wasn't bumped.
     > **NEVER** publish to only one registry — both Marketplace AND Open VSX are required.
 
-15. Report PR URL, merge status, and publish results to user.
+16. Report PR URL, merge status, and publish results to user.
 
 ---
 
 ## `/yolo` — Full Pipeline
 
-Runs **all steps 1–14** in sequence (local + deploy).
+Runs **all steps 1–15** in sequence (local + deploy).

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -31,7 +31,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R2.2**: Text → Canvas: Source edits re-render the canvas in <16ms
 - **R2.3**: Incremental: Only re-parse/re-emit changed regions, not the entire document
 - **R2.4**: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
-- **R2.5**: Selection sync — clicking a node `@id` line in the text editor selects it on canvas; clicking a node on canvas reveals and highlights its `@id` line in the text editor
+- **R2.5**: Selection sync — clicking anywhere inside a node block in the text editor (not just the `@id` declaration line) selects it on canvas; clicking a node on canvas reveals and highlights its `@id` line in the text editor
 
 ### R3: Human Editing (Canvas)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.6.32
+
+- **R2.5 fix**: Cursor→canvas selection sync now works from any line inside a node block (property lines, style lines, animation lines), not just the `@id` declaration line — uses `findSymbolAtLine` symbol tree lookup instead of simple regex
+- **R3.14**: Layers panel restyled with Figma/Apple design language (sticky header, indent guides, chevron toggles, hover/selection states)
+- **Workflow**: `/yolo` and `/commit` workflows now include a mandatory docs update step before committing
+
 ### R1: File Format (`.fd`)
 
 - [x] **R1.1**: Token-efficient text DSL

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary\n\nAdds mandatory docs update step to `/yolo` and `/commit` workflows, and catches up documentation for v0.6.32 changes.\n\n## Changes\n\n- **`yolo.md`**: Added step 9 (mandatory docs update) before stage/commit; fixed step numbering\n- **`commit.md`**: Added step 4 (mandatory docs update) before staging\n- **`REQUIREMENTS.md`**: Refined R2.5 — selection sync now works from any line inside a node block\n- **`CHANGELOG.md`**: Added v0.6.32 section documenting the cursor→canvas fix and layers panel redesign\n- **`package.json`**: Version bump to 0.6.33\n\n## Test Results\n\n- ✅ `cargo clippy` — pass\n- ✅ `cargo test` — pass\n- ✅ `pnpm test` — 74/74 pass