### PR TITLE
fix(vscode): prevent canvas duplication when revealing on tab switch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.6.35
+
+- **R6.1 fix**: Fixed canvas duplication bug where auto-reveal opened a second Canvas Mode in the text editor's column; now correctly finds the canvas tab's actual column and only reveals if not already active
+
 ### v0.6.34
 
 - **R6.1**: Auto-reveal canvas — switching to an `.fd` file tab now automatically reveals (or opens) the Canvas Mode panel in the other editor column without stealing focus

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Fix\n\nFixes canvas duplication where auto-reveal opened a second Canvas Mode in the text editor's column instead of revealing the existing one.\n\n### Root Cause\nThe `onDidChangeActiveTextEditor` handler called `vscode.openWith` without specifying a `ViewColumn`, causing VS Code to default to the active column (where the text editor lives), replacing it with a second canvas.\n\n### Fix\n- Find the canvas tab's actual group/column via `tabGroups` API\n- Only reveal if it's not already the active tab in its group (`!canvasTab.isActive`)\n- Pass the correct `viewColumn` to `vscode.openWith` to prevent column misplacement\n- Removed redundant fallback branch (first-time opens handled by `onDidOpenTextDocument`)\n\n### Tests\n- ✅ `cargo clippy` — 0 warnings\n- ✅ `cargo test` — all passed\n- ✅ `pnpm test` — 74 passed