### PR TITLE
fix(vscode): always reveal canvas when switching .fd tabs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.6.36
+
+- **R6.1**: Canvas is now always revealed when switching `.fd` tabs — opens a new canvas in the other column if none exists (previously only revealed existing canvas tabs)
+
 ### v0.6.35
 
 - **R6.1 fix**: Fixed canvas duplication bug where auto-reveal opened a second Canvas Mode in the text editor's column; now correctly finds the canvas tab's actual column and only reveals if not already active

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -2621,7 +2621,23 @@ export function activate(context: vscode.ExtensionContext) {
             return; // Found it — done
           }
         }
-        // No canvas tab exists — onDidOpenTextDocument will handle first opens
+
+        // No canvas tab exists — open one in the other column
+        const activeColumn = editor.viewColumn;
+        const allGroupColumns = vscode.window.tabGroups.all.map(
+          (g) => g.viewColumn
+        );
+        const resolved = resolveTargetColumn(activeColumn, allGroupColumns);
+        const targetColumn =
+          resolved === "beside" ? vscode.ViewColumn.Beside : resolved;
+
+        openedUris.add(key); // Mark so onDidOpenTextDocument won't duplicate
+        await vscode.commands.executeCommand(
+          "vscode.openWith",
+          editor.document.uri,
+          "fd.canvas",
+          { viewColumn: targetColumn, preserveFocus: true }
+        );
       }, 150);
     })
   );


### PR DESCRIPTION
## Fix\n\nEnsures canvas is always revealed when switching `.fd` tabs — opens a new canvas in the other column if none exists.\n\n### Changes\n- When `onDidChangeActiveTextEditor` detects an `.fd` file with no existing canvas tab, it now opens one in the other column using `resolveTargetColumn` + `preserveFocus: true`\n- Marks `openedUris` to prevent duplication with `onDidOpenTextDocument`\n\n### Tests\n- ✅ All passing (clippy, cargo test, 74 TS tests)