### PR TITLE
fix(vscode): refocus Code Mode after canvas reveal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.6.38
+
+- **R6.1**: Code Mode now always regains focus after canvas reveal — refocuses text editor after `vscode.openWith` since webview panels can steal focus despite `preserveFocus: true`
+
 ### v0.6.37
 
 - **R6.1 fix**: Consolidated canvas open/reveal into a single `onDidChangeActiveTextEditor` handler — eliminates race condition with `onDidOpenTextDocument`, and moves canvas to the other column if it ends up in the same column as the text editor

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Fix\n\nCode Mode now always regains focus after canvas reveal. Adds a refocus step (120ms delay + `showTextDocument`) after every `vscode.openWith` call, since webview panels can steal focus despite `preserveFocus: true`.\n\n### Tests\n- ✅ All passing (clippy, cargo test, 74 TS tests)