### PR TITLE
feat(core): add frame node type and fix group auto-sizing

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -79,6 +79,17 @@ group @container {
   text @child2 "..." { ... }
 }
 
+frame @card {
+  w: <width> h: <height>
+  fill: <color>
+  corner: <radius>
+  clip: true          # optional — clips children to frame bounds
+  layout: column gap=<px> pad=<px>
+
+  # Children go here (nested nodes)
+  rect @child { ... }
+}
+
 path @drawing {
   # Path data (SVG-like commands) — future
 }

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -373,6 +373,15 @@ pub enum NodeKind {
     /// Group / frame — contains children.
     Group { layout: LayoutMode },
 
+    /// Frame — visible container with explicit size and optional clipping.
+    /// Like a Figma frame: has fill/stroke, declared dimensions, clips overflow.
+    Frame {
+        width: f32,
+        height: f32,
+        clip: bool,
+        layout: LayoutMode,
+    },
+
     /// Rectangle.
     Rect { width: f32, height: f32 },
 

--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -100,6 +100,7 @@ fn compute_inverse(engine: &SyncEngine, mutation: &GraphMutation) -> GraphMutati
                 .map(|n| match &n.kind {
                     fd_core::model::NodeKind::Rect { width, height } => (*width, *height),
                     fd_core::model::NodeKind::Ellipse { rx, ry } => (*rx * 2.0, *ry * 2.0),
+                    fd_core::model::NodeKind::Frame { width, height, .. } => (*width, *height),
                     _ => (0.0, 0.0),
                 })
                 .unwrap_or((0.0, 0.0));

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -116,6 +116,14 @@ impl SyncEngine {
                             *rx = width / 2.0;
                             *ry = height / 2.0;
                         }
+                        NodeKind::Frame {
+                            width: w,
+                            height: h,
+                            ..
+                        } => {
+                            *w = width;
+                            *h = height;
+                        }
                         _ => {}
                     }
                 }
@@ -130,6 +138,7 @@ impl SyncEngine {
                 let (w, h) = match &node.kind {
                     NodeKind::Rect { width, height } => (*width, *height),
                     NodeKind::Ellipse { rx, ry } => (rx * 2.0, ry * 2.0),
+                    NodeKind::Frame { width, height, .. } => (*width, *height),
                     _ => (0.0, 0.0),
                 };
                 let idx = self.graph.add_node(parent_idx, *node);

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -59,6 +59,10 @@ fn hover_node_id(id: &str, graph: Option<&SceneGraph>) -> Option<Hover> {
         fd_core::NodeKind::Root => "Root",
         fd_core::NodeKind::Generic => "Generic (placeholder)",
         fd_core::NodeKind::Group { .. } => "Group",
+        fd_core::NodeKind::Frame { width, height, .. } => {
+            let desc = format!("**Frame** — {}×{}", width, height);
+            return Some(make_hover(&desc));
+        }
         fd_core::NodeKind::Rect { width, height } => {
             let desc = format!("**Rect** — {}×{}", width, height);
             return Some(make_hover(&desc));
@@ -85,7 +89,10 @@ fn hover_keyword(word: &str) -> Option<Hover> {
     let info = match word {
         // Node types
         "group" => {
-            "**group** — Container node for child elements.\n\nSupports `layout:` for automatic arrangement of children."
+            "**group** — Logical container for child elements.\n\nInvisible on canvas. Supports `layout:` for automatic arrangement of children."
+        }
+        "frame" => {
+            "**frame** — Visible container with explicit size.\n\nLike a Figma frame: has fill/stroke, declared `w:` `h:`, optional `clip: true`.\nSupports `layout:` for automatic arrangement of children."
         }
         "rect" => {
             "**rect** — Rectangle shape.\n\nProperties: `w:` `h:` `fill:` `stroke:` `corner:` `opacity:`"

--- a/crates/fd-lsp/src/symbols.rs
+++ b/crates/fd-lsp/src/symbols.rs
@@ -43,6 +43,7 @@ pub fn compute_symbols(text: &str, graph: Option<&SceneGraph>) -> Vec<SymbolInfo
                     fd_core::NodeKind::Root => continue,
                     fd_core::NodeKind::Generic => "",
                     fd_core::NodeKind::Group { .. } => "group",
+                    fd_core::NodeKind::Frame { .. } => "frame",
                     fd_core::NodeKind::Rect { .. } => "rect",
                     fd_core::NodeKind::Ellipse { .. } => "ellipse",
                     fd_core::NodeKind::Path { .. } => "path",
@@ -58,7 +59,7 @@ pub fn compute_symbols(text: &str, graph: Option<&SceneGraph>) -> Vec<SymbolInfo
                         format!("{} @{}", kind_name, id_str)
                     },
                     kind: match kind_name {
-                        "group" => SymbolKind::NAMESPACE,
+                        "group" | "frame" => SymbolKind::NAMESPACE,
                         "text" => SymbolKind::STRING,
                         _ => SymbolKind::OBJECT,
                     },
@@ -83,7 +84,7 @@ pub fn compute_symbols(text: &str, graph: Option<&SceneGraph>) -> Vec<SymbolInfo
 /// Find all `@id` declarations and their line numbers.
 fn find_node_lines(text: &str) -> Vec<(String, usize)> {
     let mut results = Vec::new();
-    let node_keywords = ["group", "rect", "ellipse", "path", "text"];
+    let node_keywords = ["group", "frame", "rect", "ellipse", "path", "text"];
 
     for (i, line) in text.lines().enumerate() {
         let trimmed = line.trim();

--- a/crates/fd-render/src/hit.rs
+++ b/crates/fd-render/src/hit.rs
@@ -44,6 +44,12 @@ fn hit_test_node(
         return None;
     }
 
+    // Groups are invisible — only their children are clickable, not the group itself.
+    // (Group bounds auto-size to children, so clicking "empty space" should not select the group.)
+    if matches!(node.kind, NodeKind::Group { .. }) {
+        return None;
+    }
+
     if let Some(b) = bounds.get(&idx)
         && b.contains(px, py)
     {

--- a/crates/fd-render/src/paint.rs
+++ b/crates/fd-render/src/paint.rs
@@ -66,6 +66,11 @@ fn paint_node(
                 paint_rect(scene, nb, &style);
             }
         }
+
+        NodeKind::Frame { .. } => {
+            // Frames always render their background (like a visible container)
+            paint_rect(scene, nb, &style);
+        }
     }
 
     for child_idx in graph.children(idx) {

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -595,6 +595,11 @@ impl FdCanvas {
             NodeKind::Group { .. } => {
                 props.insert("kind".into(), "group".into());
             }
+            NodeKind::Frame { width, height, .. } => {
+                props.insert("kind".into(), "frame".into());
+                props.insert("width".into(), serde_json::json!(width));
+                props.insert("height".into(), serde_json::json!(height));
+            }
             NodeKind::Path { .. } => {
                 props.insert("kind".into(), "path".into());
             }
@@ -747,6 +752,7 @@ impl FdCanvas {
                     let (cur_w, cur_h) = match &node.kind {
                         NodeKind::Rect { width, height } => (*width, *height),
                         NodeKind::Ellipse { rx, ry } => (*rx * 2.0, *ry * 2.0),
+                        NodeKind::Frame { width, height, .. } => (*width, *height),
                         _ => return false,
                     };
                     let (new_w, new_h) = if key == "width" {
@@ -1020,6 +1026,7 @@ fn collect_node_tree(graph: &fd_core::SceneGraph, idx: fd_core::NodeIndex) -> se
         fd_core::NodeKind::Root => "root",
         fd_core::NodeKind::Generic => "generic",
         fd_core::NodeKind::Group { .. } => "group",
+        fd_core::NodeKind::Frame { .. } => "frame",
         fd_core::NodeKind::Rect { .. } => "rect",
         fd_core::NodeKind::Ellipse { .. } => "ellipse",
         fd_core::NodeKind::Path { .. } => "path",

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -137,6 +137,12 @@ fn render_node(
         NodeKind::Group { .. } => {
             draw_group_bg(ctx, node_bounds, &style);
         }
+        NodeKind::Frame { .. } => {
+            draw_rect(ctx, node_bounds, &style, is_selected);
+            if let Some(ref label) = style.label {
+                draw_shape_label(ctx, node_bounds, label, &style);
+            }
+        }
         NodeKind::Path { commands } => {
             draw_path(ctx, node_bounds, commands, &style, is_selected);
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.6.39
+
+- **R1.1**: New `frame` node type — visible container with declared `w:`/`h:`, optional `clip: true`, fill/stroke/corner, layout modes (column/row/grid)
+- **R1.1**: `group` nodes now auto-size to the union bounding box of their children (was hardcoded 200×200)
+- **R3.1**: Groups skip self-hit-testing (only children are clickable); frames are clickable via background
+
 ### v0.6.38
 
 - **R6.1**: Code Mode now always regains focus after canvas reveal — refocuses text editor after `vscode.openWith` since webview panels can steal focus despite `preserveFocus: true`

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -8,11 +8,6 @@ style step_title {
   font: "Inter" 700 28
 }
 
-rect @_anon_6 {
-  w: 100 h: 80
-  fill: #CCCCD9
-}
-
 # ─── Wizard container ───────────────────────────────────────────────────
 group @wizard {
   ## "Onboarding wizard — 4-step flow"
@@ -30,8 +25,79 @@ group @wizard {
     shadow: (0,8,40,#00000022)
     group @_anon_3 {
       layout: column gap=24 pad=40
+      rect @illustration {
+        ## "Step illustration — animated SVG"
+        ## accept: "subtle loop animation"
+        w: 400 h: 240
+        fill: #F0EDFC
+        corner: 16
+        ellipse @shape_1 {
+          w: 80 h: 80
+          fill: #6C5CE740
+          anim :enter {
+            opacity: 1
+            scale: 1
+            ease: spring 800ms
+          }
+        }
+        rect @shape_2 {
+          w: 100 h: 60
+          fill: #A29BFE40
+          corner: 12
+          anim :enter {
+            opacity: 1
+            ease: ease_out 600ms
+          }
+        }
+        ellipse @shape_3 {
+          w: 60 h: 60
+          fill: #00B89440
+          anim :enter {
+            opacity: 1
+            scale: 1
+            ease: spring 1000ms
+          }
+        }
+      }
+      text @s_title "Create your first draft" {
+        use: step_title
+      }
+      text @s_desc "Start with a blank canvas or choose from our templates to kickstart your design." {
+        use: step_desc
+      }
+      group @dots {
+        layout: row gap=8 pad=0
+        ellipse @dot_1 {
+          w: 10 h: 10
+          fill: #6C5CE7
+        }
+        ellipse @dot_2 {
+          w: 10 h: 10
+          fill: #E8E8EC
+        }
+        ellipse @dot_3 {
+          w: 10 h: 10
+          fill: #E8E8EC
+        }
+        ellipse @dot_4 {
+          w: 10 h: 10
+          fill: #E8E8EC
+        }
+      }
       group @buttons {
         layout: row gap=12 pad=0
+        rect @btn_skip {
+          w: 100 h: 48
+          corner: 10
+          text @_anon_4 "Skip" {
+            fill: #999999
+            font: "Inter" 500 15
+          }
+          anim :hover {
+            fill: #F5F5F7
+            ease: ease_out 150ms
+          }
+        }
         rect @btn_next {
           w: 280 h: 48
           fill: #6C5CE7
@@ -51,81 +117,16 @@ group @wizard {
             ease: ease_out 100ms
           }
         }
-        rect @btn_skip {
-          w: 100 h: 48
-          corner: 10
-          text @_anon_4 "Skip" {
-            fill: #999999
-            font: "Inter" 500 15
-          }
-          anim :hover {
-            fill: #F5F5F7
-            ease: ease_out 150ms
-          }
-        }
-      }
-      group @dots {
-        layout: row gap=8 pad=0
-        ellipse @dot_4 {
-          w: 10 h: 10
-          fill: #E8E8EC
-        }
-        ellipse @dot_3 {
-          w: 10 h: 10
-          fill: #E8E8EC
-        }
-        ellipse @dot_2 {
-          w: 10 h: 10
-          fill: #E8E8EC
-        }
-        ellipse @dot_1 {
-          w: 10 h: 10
-          fill: #6C5CE7
-        }
-      }
-      text @s_desc "Start with a blank canvas or choose from our templates to kickstart your design." {
-        use: step_desc
-      }
-      text @s_title "Create your first draft" {
-        use: step_title
-      }
-      rect @illustration {
-        ## "Step illustration — animated SVG"
-        ## accept: "subtle loop animation"
-        w: 400 h: 240
-        fill: #F0EDFC
-        corner: 16
-        ellipse @shape_3 {
-          w: 60 h: 60
-          fill: #00B89440
-          anim :enter {
-            opacity: 1
-            scale: 1
-            ease: spring 1000ms
-          }
-        }
-        rect @shape_2 {
-          w: 100 h: 60
-          fill: #A29BFE40
-          corner: 12
-          anim :enter {
-            opacity: 1
-            ease: ease_out 600ms
-          }
-        }
-        ellipse @shape_1 {
-          w: 80 h: 80
-          fill: #6C5CE740
-          anim :enter {
-            opacity: 1
-            scale: 1
-            ease: spring 800ms
-          }
-        }
       }
     }
   }
 }
 
-@wizard -> center_in: canvas
+rect @_anon_6 {
+  w: 100 h: 80
+  fill: #CCCCD9
+}
+
 @_anon_6 -> absolute: 486, 1140.92
+@wizard -> center_in: canvas
+@dots -> absolute: 370.85, 498.43

--- a/fd-vscode/src/fd-parse.ts
+++ b/fd-vscode/src/fd-parse.ts
@@ -140,7 +140,7 @@ export function parseSpecNodes(source: string): SpecResult {
 
     // Typed node: rect @foo { / group @foo {
     const nodeMatch = trimmed.match(
-      /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
+      /^(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
     );
     if (nodeMatch) {
       if (currentNodeId && pendingAnnotations.length > 0) {
@@ -207,7 +207,7 @@ export function computeSpecHideLines(lines: string[]): number[] {
 
   const keepPatterns = [
     /^\s*#/,                              // Comments and annotations
-    /^\s*(group|rect|ellipse|path|text)\s+@/, // Typed node declarations
+    /^\s*(group|frame|rect|ellipse|path|text)\s+@/, // Typed node declarations
     /^\s*@\w+\s*\{/,                      // Generic node declarations
     /^\s*edge\s+@/,                        // Edge declarations
     /^\s*from:\s*@/,                       // Edge from
@@ -396,7 +396,7 @@ export function parseDocumentSymbols(lines: string[]): FdSymbol[] {
 
     // Typed node: group/rect/ellipse/path/text @name ["label"] {
     const nodeMatch = trimmed.match(
-      /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?/
+      /^(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?/
     );
     if (nodeMatch) {
       const sym: FdSymbol = {

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1432,7 +1432,7 @@ function parseAnnotatedNodes(source) {
     }
 
     const nodeMatch = trimmed.match(
-      /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
+      /^(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/
     );
     if (nodeMatch) {
       if (currentNodeId && pendingAnnotations.length > 0) {
@@ -1473,6 +1473,7 @@ function parseAnnotatedNodes(source) {
 
 const LAYER_ICONS = {
   group: "◫",
+  frame: "▣",
   rect: "▢",
   ellipse: "○",
   path: "〜",
@@ -1523,7 +1524,7 @@ function parseLayerTree(source) {
 
     // Typed node
     const nodeMatch = trimmed.match(
-      /^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?/
+      /^(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?/
     );
     if (nodeMatch) {
       const node = {


### PR DESCRIPTION
## Summary

Adds `frame` as a new visible container node type (like Figma frames) and fixes `group` nodes to auto-size based on children bounds.

### Frame nodes
- New `NodeKind::Frame` with `width`, `height`, `clip`, and `layout` fields
- Parse/emit `frame` keyword with `clip: true|false` property
- Renders as visible rect with fill/stroke/corner support
- Clickable background, resizable, undo/redo support

### Group auto-sizing
- Groups now compute bounding box as union of children (was hardcoded 200×200)
- Groups skip self-hit-testing (only children are clickable)

### Files changed (17)
Updated across 5 crates (`fd-core`, `fd-render`, `fd-editor`, `fd-lsp`, `fd-wasm`) + VS Code extension (`main.js`, `fd-parse.ts`) + docs.

### Tests
- 4 new: `parse_frame`, `roundtrip_frame`, `layout_group_auto_bounds`, `layout_frame_declared_size`
- ✅ cargo test (68+ pass), clippy (0 warnings), fmt (clean), pnpm test (74 pass)