### PR TITLE
refactor(format): replace ## annotations with spec node blocks

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -91,14 +91,14 @@ crates/
 > **Code mode prioritizes AI-agent readability and accuracy over token efficiency.**
 > Semantic naming is the single highest-impact factor for AI comprehension (arXiv 2510.02268).
 
-| Rule                        | Description                                                         |
-| --------------------------- | ------------------------------------------------------------------- |
-| **Semantic IDs**            | `@login_form` not `@rect_17` — intent over auto-generated names     |
-| **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300` — relationships > pixels    |
-| **Accurate comments**       | `#` for context — wrong comments hurt more than no comments         |
-| **Style reuse**             | Define `style` blocks, reference with `use:` — consistency > ad-hoc |
-| **Annotations for intent**  | `##` metadata (status, priority, accept) — structured > freeform    |
-| **Shorthand OK**            | `w:` / `h:` / `#FFF` are fine — unambiguous in context              |
+| Rule                        | Description                                                                |
+| --------------------------- | -------------------------------------------------------------------------- |
+| **Semantic IDs**            | `@login_form` not `@rect_17` — intent over auto-generated names            |
+| **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300` — relationships > pixels           |
+| **Accurate comments**       | `#` for context — wrong comments hurt more than no comments                |
+| **Style reuse**             | Define `style` blocks, reference with `use:` — consistency > ad-hoc        |
+| **Spec for intent**         | `spec { ... }` metadata (status, priority, accept) — structured > freeform |
+| **Shorthand OK**            | `w:` / `h:` / `#FFF` are fine — unambiguous in context                     |
 
 ### 🎨 Rendering Rules
 

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -250,18 +250,18 @@ pub struct AnimProperties {
 // ─── Annotations ─────────────────────────────────────────────────────────
 
 /// Structured annotation attached to a scene node.
-/// Parsed from `##` lines in the FD format.
+/// Parsed from `spec { ... }` blocks in the FD format.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Annotation {
-    /// Freeform description: `## "User auth entry point"`
+    /// Freeform description: `spec { "User auth entry point" }`
     Description(String),
-    /// Acceptance criterion: `## accept: "validates email on blur"`
+    /// Acceptance criterion: `spec { accept: "validates email on blur" }`
     Accept(String),
-    /// Status: `## status: draft`
+    /// Status: `spec { status: draft }`
     Status(String),
-    /// Priority: `## priority: high`
+    /// Priority: `spec { priority: high }`
     Priority(String),
-    /// Tag: `## tag: auth`
+    /// Tag: `spec { tag: auth }`
     Tag(String),
 }
 
@@ -367,7 +367,7 @@ pub enum NodeKind {
     Root,
 
     /// Generic placeholder — no visual shape assigned yet.
-    /// Used for spec-only nodes: `@login_btn { ## "CTA" }`
+    /// Used for spec-only nodes: `@login_btn { spec "CTA" }`
     Generic,
 
     /// Group / frame — contains children.
@@ -416,7 +416,7 @@ pub struct SceneNode {
     /// Animations attached to this node.
     pub animations: SmallVec<[AnimKeyframe; 2]>,
 
-    /// Structured annotations (`##` lines).
+    /// Structured annotations (`spec { ... }` block).
     pub annotations: Vec<Annotation>,
 
     /// Line comments (`# text`) that appeared before this node in the source.

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -544,8 +544,10 @@ rect @box {
 rect @box {
   w: 100
   h: 50
-  ## "A test box"
-  ## status: draft
+  spec {
+    "A test box"
+    status: draft
+  }
 }
 "#;
         let viewport = Viewport {
@@ -577,10 +579,10 @@ rect @box {
             Annotation::Description("Updated description".into())
         );
 
-        // Verify text re-emitted with new ## lines
-        assert!(engine.text.contains("## \"Updated description\""));
-        assert!(engine.text.contains("## status: done"));
-        assert!(engine.text.contains("## accept: \"all tests pass\""));
+        // Verify text re-emitted with spec blocks
+        assert!(engine.text.contains("\"Updated description\""));
+        assert!(engine.text.contains("status: done"));
+        assert!(engine.text.contains("accept: \"all tests pass\""));
     }
 
     #[test]
@@ -589,8 +591,10 @@ rect @box {
 rect @card {
   w: 200
   h: 100
-  ## "Card component"
-  ## priority: high
+  spec {
+    "Card component"
+    priority: high
+  }
 }
 "#;
         let viewport = Viewport {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.7.0 (**BREAKING**)
+
+- **R1.9**: Replaced `##` annotation syntax with `spec` node blocks — `spec "desc"` (inline) and `spec { ... }` (block form). Updated parser, emitter, tree-sitter grammar, VS Code extension, and all 13 example files.
+- **GEMINI.md**: Updated FD Format Rules table to reflect `spec` syntax.
+
 ### v0.6.41
 
 - **R1.1 fix**: Fixed Group/Ungroup undo/redo — `GroupNodes` now initializes `ResolvedBounds` so subsequent `MoveNode` doesn't clobber constraints to `(0,0)`
@@ -57,7 +62,7 @@
 - [x] **R1.6**: Git-friendly plain text
 - [x] **R1.7**: Comments via `#` prefix
 - [x] **R1.8**: Human-readable and AI-writable
-- [x] **R1.9**: Structured annotations (`##`)
+- [x] **R1.9**: Structured annotations (`spec` blocks)
 - [x] **R1.10**: First-class edges
 - [x] **R1.11**: Edge trigger animations
 - [x] **R1.12**: Edge flow animations

--- a/examples/animations.fd
+++ b/examples/animations.fd
@@ -18,7 +18,7 @@ group @hover_demos {
       w: 140 h: 100
       corner: 12
       fill: #6C5CE7
-      ## "Scale animation"
+      spec "Scale animation"
 
       text "Scale" { font: "Inter" 600 14; fill: #FFF }
 
@@ -71,7 +71,7 @@ group @hover_demos {
       w: 140 h: 100
       corner: 12
       fill: #A29BFE
-      ## "Press-down squish for tactile feedback"
+      spec "Press-down squish for tactile feedback"
 
       text "Squish" { font: "Inter" 600 14; fill: #FFF }
 
@@ -108,9 +108,11 @@ group @hover_demos {
   group @enter_row {
     layout: row gap=20 pad=0
 
-    ## "Triggered when element enters viewport"
-    ## accept: "plays once on scroll into view"
-    ## tag: animation, ux
+    spec {
+      "Triggered when element enters viewport"
+      accept: "plays once on scroll into view"
+      tag: animation, ux
+    }
 
     # Fade in on enter
     rect @fade_enter {
@@ -219,7 +221,7 @@ group @hover_demos {
       corner: 16
       fill: #6C5CE7
       bg: #6C5CE7 corner=16 shadow=(0,4,20,#6C5CE740)
-      ## "Hover: scale + color + shadow lift"
+      spec "Hover: scale + color + shadow lift"
 
       text "Lift & Glow" { font: "Inter" 600 15; fill: #FFF }
 
@@ -231,7 +233,7 @@ group @hover_demos {
       corner: 16
       fill: #00B894
       bg: #00B894 corner=16 shadow=(0,4,20,#00B89440)
-      ## "Press: squish + dim"
+      spec "Press: squish + dim"
 
       text "Squish & Dim" { font: "Inter" 600 15; fill: #FFF }
 
@@ -244,7 +246,7 @@ group @hover_demos {
       corner: 16
       fill: #FF6B6B
       bg: #FF6B6B corner=16 shadow=(0,4,20,#FF6B6B40)
-      ## "Hover + press combo"
+      spec "Hover + press combo"
 
       text "Full Feedback" { font: "Inter" 600 15; fill: #FFF }
 

--- a/examples/checkout_flow.fd
+++ b/examples/checkout_flow.fd
@@ -1,7 +1,7 @@
 # FD v1
 # Product requirements document — annotated wireframe with full specs
 
-## "E-commerce checkout flow — MVP scope"
+spec "E-commerce checkout flow — MVP scope"
 
 style label { font: "Inter" 14; fill: #333 }
 style muted { font: "Inter" 12; fill: #999 }
@@ -11,43 +11,47 @@ style muted { font: "Inter" 12; fill: #999 }
 group @checkout_page {
   layout: column gap=20 pad=32
 
-  ## "Checkout flow — 3-step wizard"
-  ## accept: "cart review → shipping → payment"
-  ## accept: "back button returns to previous step"
-  ## accept: "progress indicator shows current step"
-  ## status: in_progress
-  ## priority: high
-  ## tag: checkout, mvp, revenue
+  spec {
+    "Checkout flow — 3-step wizard"
+    accept: "cart review → shipping → payment"
+    accept: "back button returns to previous step"
+    accept: "progress indicator shows current step"
+    status: in_progress
+    priority: high
+    tag: checkout, mvp, revenue
+  }
 
   # ─── Progress bar ────────────────────────────────────────────────
 
   group @progress {
     layout: row gap=0 pad=0
 
-    ## "Step indicator — 3 steps"
-    ## accept: "completed steps are highlighted"
-    ## accept: "current step shows active color"
-    ## status: draft
+    spec {
+      "Step indicator — 3 steps"
+      accept: "completed steps are highlighted"
+      accept: "current step shows active color"
+      status: draft
+    }
 
     rect @step_1 {
       w: 140 h: 4
       fill: #6C5CE7
       corner: 2
-      ## "Step 1: Cart — completed"
+      spec "Step 1: Cart — completed"
     }
 
     rect @step_2 {
       w: 140 h: 4
       fill: #6C5CE7
       corner: 2
-      ## "Step 2: Shipping — active"
+      spec "Step 2: Shipping — active"
     }
 
     rect @step_3 {
       w: 140 h: 4
       fill: #E8E8EC
       corner: 2
-      ## "Step 3: Payment — pending"
+      spec "Step 3: Payment — pending"
     }
   }
 
@@ -58,12 +62,14 @@ group @checkout_page {
   group @form {
     layout: column gap=12 pad=0
 
-    ## "Shipping address form"
-    ## accept: "autofill from saved addresses"
-    ## accept: "address validation via Google Maps API"
-    ## accept: "international address format support"
-    ## priority: high
-    ## tag: form, ux
+    spec {
+      "Shipping address form"
+      accept: "autofill from saved addresses"
+      accept: "address validation via Google Maps API"
+      accept: "international address format support"
+      priority: high
+      tag: form, ux
+    }
 
     group @name_row {
       layout: row gap=12 pad=0
@@ -72,8 +78,10 @@ group @checkout_page {
         w: 200 h: 48
         corner: 8
         stroke: #E8E8EC 1
-        ## "First name — required"
-        ## accept: "min 2 characters"
+        spec {
+          "First name — required"
+          accept: "min 2 characters"
+        }
 
         text "First name" { use: muted }
       }
@@ -82,8 +90,10 @@ group @checkout_page {
         w: 200 h: 48
         corner: 8
         stroke: #E8E8EC 1
-        ## "Last name — required"
-        ## accept: "min 2 characters"
+        spec {
+          "Last name — required"
+          accept: "min 2 characters"
+        }
 
         text "Last name" { use: muted }
       }
@@ -93,9 +103,11 @@ group @checkout_page {
       w: 412 h: 48
       corner: 8
       stroke: #E8E8EC 1
-      ## "Street address — required"
-      ## accept: "autocomplete suggestions on typing"
-      ## priority: high
+      spec {
+        "Street address — required"
+        accept: "autocomplete suggestions on typing"
+        priority: high
+      }
 
       text "Street address" { use: muted }
     }
@@ -104,7 +116,7 @@ group @checkout_page {
       w: 412 h: 48
       corner: 8
       stroke: #E8E8EC 1
-      ## "Apt/Suite — optional"
+      spec "Apt/Suite — optional"
 
       text "Apt, suite, etc. (optional)" { use: muted }
     }
@@ -116,7 +128,7 @@ group @checkout_page {
         w: 200 h: 48
         corner: 8
         stroke: #E8E8EC 1
-        ## "City — required"
+        spec "City — required"
 
         text "City" { use: muted }
       }
@@ -125,8 +137,10 @@ group @checkout_page {
         w: 96 h: 48
         corner: 8
         stroke: #E8E8EC 1
-        ## "State — dropdown"
-        ## accept: "shows state list for US addresses"
+        spec {
+          "State — dropdown"
+          accept: "shows state list for US addresses"
+        }
 
         text "State" { use: muted }
       }
@@ -135,8 +149,10 @@ group @checkout_page {
         w: 96 h: 48
         corner: 8
         stroke: #E8E8EC 1
-        ## "ZIP — required"
-        ## accept: "validates format per country"
+        spec {
+          "ZIP — required"
+          accept: "validates format per country"
+        }
 
         text "ZIP" { use: muted }
       }
@@ -150,11 +166,13 @@ group @checkout_page {
     corner: 12
     fill: #F8F9FA
     stroke: #E8E8EC 1
-    ## "Collapsible order summary panel"
-    ## accept: "shows item thumbnails, quantities, prices"
-    ## accept: "updates total on coupon apply"
-    ## priority: medium
-    ## tag: checkout
+    spec {
+      "Collapsible order summary panel"
+      accept: "shows item thumbnails, quantities, prices"
+      accept: "updates total on coupon apply"
+      priority: medium
+      tag: checkout
+    }
 
     group { layout: column gap=8 pad=20
       text "Order Summary" { font: "Inter" 600 16; fill: #1A1A2E }
@@ -176,7 +194,7 @@ group @checkout_page {
       w: 120 h: 48
       corner: 10
       stroke: #E8E8EC 1
-      ## "Back to cart"
+      spec "Back to cart"
 
       text "Back" { font: "Inter" 500 15; fill: #333 }
 
@@ -187,10 +205,12 @@ group @checkout_page {
       w: 280 h: 48
       corner: 10
       fill: #6C5CE7
-      ## "Continue to payment"
-      ## accept: "validates all fields before proceeding"
-      ## accept: "disabled when required fields incomplete"
-      ## priority: high
+      spec {
+        "Continue to payment"
+        accept: "validates all fields before proceeding"
+        accept: "disabled when required fields incomplete"
+        priority: high
+      }
 
       text "Continue to Payment" { font: "Inter" 600 15; fill: #FFF }
 

--- a/examples/constraints.fd
+++ b/examples/constraints.fd
@@ -6,7 +6,7 @@
 group @hero {
   layout: column gap=16 pad=40
 
-  ## "Hero section — demonstrates center_in constraint"
+  spec "Hero section — demonstrates center_in constraint"
 
   text @hero_title "Welcome to FD" { font: "Inter" 800 48; fill: #1A1A2E }
   text @hero_sub "The token-efficient design format" {
@@ -31,7 +31,7 @@ rect @tooltip_target {
   corner: 8
   fill: #F5F5F7
   stroke: #E8E8EC 1
-  ## "Anchor element for tooltip"
+  spec "Anchor element for tooltip"
 
   text "Hover me" { font: "Inter" 500 14; fill: #333 }
 }
@@ -40,7 +40,7 @@ rect @tooltip {
   w: 200 h: 44
   corner: 8
   fill: #1A1A2E
-  ## "Tooltip — positioned via offset constraint"
+  spec "Tooltip — positioned via offset constraint"
 
   text "I'm 20px right, 60px down" { font: "Inter" 13; fill: #FFF }
 
@@ -53,7 +53,7 @@ rect @full_width_bg {
   w: 800 h: 120
   fill: #F8F9FA
   corner: 0
-  ## "Background that fills parent width with 24px padding"
+  spec "Background that fills parent width with 24px padding"
 
   group { layout: row gap=16 pad=24
     text "This panel uses fill_parent with 24px inset" {
@@ -69,8 +69,10 @@ rect @fab {
   corner: 28
   fill: #6C5CE7
   bg: #6C5CE7 corner=28 shadow=(0,4,16,#6C5CE760)
-  ## "Floating action button — fixed bottom-right"
-  ## accept: "persists across scroll"
+  spec {
+    "Floating action button — fixed bottom-right"
+    accept: "persists across scroll"
+  }
 
   text "+" { font: "Inter" 700 24; fill: #FFF }
 

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -51,7 +51,7 @@ group @settings {
     group @_anon_26 {
       layout: row gap=14 pad=16
       ellipse @user_avatar {
-        ## "User profile photo"
+        spec "User profile photo"
         w: 48 h: 48
         fill: #6C5CE7
       }
@@ -86,7 +86,7 @@ group @settings {
         }
       }
       rect @switch_on {
-        ## "Toggle — ON state"
+        spec "Toggle — ON state"
         w: 44 h: 24
         fill: #6C5CE7
         corner: 12
@@ -116,7 +116,7 @@ group @settings {
         }
       }
       rect @switch_off {
-        ## "Toggle — OFF state"
+        spec "Toggle — OFF state"
         w: 44 h: 24
         fill: #3D3D5C
         corner: 12
@@ -184,7 +184,7 @@ group @settings {
             corner: 2
           }
           ellipse @slider_thumb {
-            ## "Draggable thumb"
+            spec "Draggable thumb"
             w: 16 h: 16
             fill: #FFFFFF
             anim :press {
@@ -205,9 +205,11 @@ group @settings {
     font: "Inter" 600 13
   }
   rect @btn_delete {
-    ## "Destructive action — delete account"
-    ## accept: "confirmation dialog before proceeding"
-    ## priority: high
+    spec {
+      "Destructive action — delete account"
+      accept: "confirmation dialog before proceeding"
+      priority: high
+    }
     w: 344 h: 48
     fill: #E1705520
     stroke: #E17055 1

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -13,26 +13,30 @@ style accent {
 group @login_form {
   layout: column gap=16 pad=32
 
-  ## "User authentication entry point"
-  ## accept: "email + password fields visible"
-  ## accept: "sign-in button triggers auth flow"
-  ## status: draft
+  spec {
+    "User authentication entry point"
+    accept: "email + password fields visible"
+    accept: "sign-in button triggers auth flow"
+    status: draft
+  }
 
   text @title "Welcome Back" {
     use: base_text
     font: "Inter" 600 24
     fill: #1A1A2E
-    ## "Brand greeting — sets emotional tone"
+    spec "Brand greeting — sets emotional tone"
   }
 
   rect @email_field {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Email input field"
-    ## accept: "validates email format on blur"
-    ## accept: "shows error state with red border"
-    ## priority: high
+    spec {
+      "Email input field"
+      accept: "validates email format on blur"
+      accept: "shows error state with red border"
+      priority: high
+    }
 
     text @email_hint "Email" {
       use: base_text
@@ -44,8 +48,10 @@ group @login_form {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Password input field"
-    ## accept: "minimum 8 characters"
+    spec {
+      "Password input field"
+      accept: "minimum 8 characters"
+    }
 
     text @pass_hint "Password" {
       use: base_text
@@ -57,10 +63,12 @@ group @login_form {
     w: 280 h: 48
     corner: 10
     use: accent
-    ## "Primary CTA — triggers login API call"
-    ## accept: "disabled state when fields empty"
-    ## accept: "loading spinner during auth"
-    ## status: in_progress
+    spec {
+      "Primary CTA — triggers login API call"
+      accept: "disabled state when fields empty"
+      accept: "loading spinner during auth"
+      status: in_progress
+    }
 
     text @btn_label "Sign In" {
       font: "Inter" 600 16

--- a/examples/design_system.fd
+++ b/examples/design_system.fd
@@ -52,7 +52,7 @@ group @color_palette {
     font: "Inter" 700 28
   }
   group @primary_row {
-    ## "Primary brand colors"
+    spec "Primary brand colors"
     layout: row gap=12 pad=0
     rect @swatch_primary {
       w: 80 h: 80
@@ -81,7 +81,7 @@ group @color_palette {
     }
   }
   group @neutral_row {
-    ## "Neutral & surface colors"
+    spec "Neutral & surface colors"
     layout: row gap=12 pad=0
     rect @swatch_white {
       w: 80 h: 80
@@ -147,13 +147,15 @@ group @color_palette {
     font: "Inter" 700 28
   }
   group @buttons {
-    ## "Button component variants"
-    ## accept: "all buttons must have visible focus rings"
-    ## accept: "minimum 44px touch target"
-    ## tag: a11y, components
+    spec {
+      "Button component variants"
+      accept: "all buttons must have visible focus rings"
+      accept: "minimum 44px touch target"
+      tag: a11y, components
+    }
     layout: row gap=16 pad=0
     rect @btn_primary {
-      ## "Primary action button"
+      spec "Primary action button"
       w: 160 h: 48
       use: primary
       corner: 10
@@ -172,7 +174,7 @@ group @color_palette {
       }
     }
     rect @btn_secondary {
-      ## "Secondary action button"
+      spec "Secondary action button"
       w: 160 h: 48
       fill: #FFFFFF
       stroke: #6C5CE7 2
@@ -192,7 +194,7 @@ group @color_palette {
       }
     }
     rect @btn_ghost {
-      ## "Ghost / text-only button"
+      spec "Ghost / text-only button"
       w: 160 h: 48
       fill: #00000000
       corner: 10
@@ -206,7 +208,7 @@ group @color_palette {
       }
     }
     rect @btn_danger {
-      ## "Destructive action button"
+      spec "Destructive action button"
       w: 160 h: 48
       use: danger
       corner: 10
@@ -228,7 +230,7 @@ group @color_palette {
   group @inputs {
     layout: column gap=12 pad=0
     rect @input_default {
-      ## "Default text input"
+      spec "Default text input"
       w: 320 h: 48
       fill: #FFFFFF
       stroke: #E8E8EC 1
@@ -239,8 +241,10 @@ group @color_palette {
       }
     }
     rect @input_focus {
-      ## "Focused input state"
-      ## status: done
+      spec {
+        "Focused input state"
+        status: done
+      }
       w: 320 h: 48
       fill: #FFFFFF
       stroke: #6C5CE7 2
@@ -251,8 +255,10 @@ group @color_palette {
       }
     }
     rect @input_error {
-      ## "Error input state"
-      ## accept: "red border + error message below"
+      spec {
+        "Error input state"
+        accept: "red border + error message below"
+      }
       w: 320 h: 48
       fill: #FFF6F4
       stroke: #E17055 2

--- a/examples/grid_gallery.fd
+++ b/examples/grid_gallery.fd
@@ -15,12 +15,14 @@ group @gallery {
     font: "Inter" 400 16
   }
   group @grid {
-    ## "Responsive image grid"
-    ## accept: "images lazy-load with blur-up"
-    ## tag: layout, grid
+    spec {
+      "Responsive image grid"
+      accept: "images lazy-load with blur-up"
+      tag: layout, grid
+    }
     layout: grid cols=2 gap=16 pad=0
     rect @photo_1 {
-      ## "Sunset landscape"
+      spec "Sunset landscape"
       w: 260 h: 200
       fill: #FF6B6B
       corner: 12
@@ -34,7 +36,7 @@ group @gallery {
       }
     }
     rect @photo_2 {
-      ## "Ocean view"
+      spec "Ocean view"
       w: 260 h: 200
       fill: #4ECDC4
       corner: 12
@@ -48,7 +50,7 @@ group @gallery {
       }
     }
     rect @photo_3 {
-      ## "Mountain trail"
+      spec "Mountain trail"
       w: 260 h: 200
       fill: #6C5CE7
       corner: 12
@@ -62,7 +64,7 @@ group @gallery {
       }
     }
     rect @photo_4 {
-      ## "Desert dunes"
+      spec "Desert dunes"
       w: 260 h: 200
       fill: #FFE66D
       corner: 12
@@ -77,7 +79,7 @@ group @gallery {
       }
     }
     rect @photo_5 {
-      ## "City skyline"
+      spec "City skyline"
       w: 260 h: 200
       fill: #A29BFE
       corner: 12
@@ -91,7 +93,7 @@ group @gallery {
       }
     }
     rect @photo_6 {
-      ## "Cherry blossoms"
+      spec "Cherry blossoms"
       w: 260 h: 200
       fill: #FD79A8
       corner: 12
@@ -105,7 +107,7 @@ group @gallery {
       }
     }
     rect @photo_7 {
-      ## "Forest canopy"
+      spec "Forest canopy"
       w: 260 h: 200
       fill: #00B894
       corner: 12
@@ -119,7 +121,7 @@ group @gallery {
       }
     }
     rect @photo_8 {
-      ## "Autumn leaves"
+      spec "Autumn leaves"
       w: 260 h: 200
       fill: #E17055
       corner: 12
@@ -133,7 +135,7 @@ group @gallery {
       }
     }
     rect @photo_9 {
-      ## "Starry night"
+      spec "Starry night"
       w: 260 h: 200
       fill: #74B9FF
       corner: 12

--- a/examples/mobile_app.fd
+++ b/examples/mobile_app.fd
@@ -15,10 +15,12 @@ style caption {
 
 # ─── Bottom navigation ──────────────────────────────────────────────────
 group @bottom_nav {
-  ## "Bottom tab bar — iOS-style"
-  ## accept: "haptic feedback on tap"
-  ## status: done
-  ## tag: navigation
+  spec {
+    "Bottom tab bar — iOS-style"
+    accept: "haptic feedback on tap"
+    status: done
+    tag: navigation
+  }
   layout: row gap=0 pad=12
   rect @tab_profile {
     w: 75 h: 44
@@ -85,10 +87,12 @@ group @bottom_nav {
 
 # ─── Feed post ───────────────────────────────────────────────────────────
 group @post_1 {
-  ## "Social feed post card"
-  ## accept: "double-tap to like"
-  ## accept: "swipe right for actions"
-  ## tag: feed, engagement
+  spec {
+    "Social feed post card"
+    accept: "double-tap to like"
+    accept: "swipe right for actions"
+    tag: feed, engagement
+  }
   layout: column gap=8 pad=0
   group @post_text {
     layout: column gap=4 pad=16
@@ -124,9 +128,11 @@ group @post_1 {
     }
   }
   rect @post_image {
-    ## "Post image — loaded from CDN"
-    ## accept: "lazy-loaded with blur placeholder"
-    ## priority: high
+    spec {
+      "Post image — loaded from CDN"
+      accept: "lazy-loaded with blur placeholder"
+      priority: high
+    }
     w: 375 h: 375
     fill: #F0F0F5
   }
@@ -151,10 +157,12 @@ group @post_1 {
 
 # ─── Story bubbles ───────────────────────────────────────────────────────
 group @stories {
-  ## "Horizontal story carousel"
-  ## accept: "scrollable beyond viewport"
-  ## status: in_progress
-  ## priority: medium
+  spec {
+    "Horizontal story carousel"
+    accept: "scrollable beyond viewport"
+    status: in_progress
+    priority: medium
+  }
   layout: row gap=12 pad=16
   ellipse @story_4 {
     w: 64 h: 64
@@ -202,9 +210,11 @@ group @stories {
 group @header {
   layout: row gap=0 pad=16
   ellipse @avatar {
-    ## "User profile picture"
-    ## accept: "tapping opens profile sheet"
-    ## tag: navigation
+    spec {
+      "User profile picture"
+      accept: "tapping opens profile sheet"
+      tag: navigation
+    }
     w: 36 h: 36
     fill: #6C5CE7
     anim :press {

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -10,13 +10,15 @@ style step_title {
 
 # ─── Wizard container ───────────────────────────────────────────────────
 group @wizard {
-  ## "Onboarding wizard — 4-step flow"
-  ## accept: "skip button on every step"
-  ## accept: "progress dots show current step"
-  ## accept: "swipe gestures on mobile"
-  ## status: in_progress
-  ## priority: high
-  ## tag: onboarding, ux, retention
+  spec {
+    "Onboarding wizard — 4-step flow"
+    accept: "skip button on every step"
+    accept: "progress dots show current step"
+    accept: "swipe gestures on mobile"
+    status: in_progress
+    priority: high
+    tag: onboarding, ux, retention
+  }
   layout: column gap=0 pad=0
   rect @step_card {
     w: 480 h: 520
@@ -26,8 +28,10 @@ group @wizard {
     group @_anon_3 {
       layout: column gap=24 pad=40
       rect @illustration {
-        ## "Step illustration — animated SVG"
-        ## accept: "subtle loop animation"
+        spec {
+          "Step illustration — animated SVG"
+          accept: "subtle loop animation"
+        }
         w: 400 h: 240
         fill: #F0EDFC
         corner: 16

--- a/examples/pricing_page.fd
+++ b/examples/pricing_page.fd
@@ -23,11 +23,13 @@ style subhead {
 }
 
 group @pricing {
-  ## "Pricing section — conversion-critical"
-  ## accept: "A/B test popular badge placement"
-  ## accept: "annual toggle saves 20%"
-  ## priority: high
-  ## tag: conversion, revenue
+  spec {
+    "Pricing section — conversion-critical"
+    accept: "A/B test popular badge placement"
+    accept: "annual toggle saves 20%"
+    priority: high
+    tag: conversion, revenue
+  }
   layout: column gap=40 pad=48
   group @header {
     layout: column gap=8 pad=0
@@ -41,9 +43,11 @@ group @pricing {
   group @cards {
     layout: row gap=23 pad=0
     rect @tier_free {
-      ## "Free tier — acquisition funnel entry"
-      ## accept: "no credit card required"
-      ## status: done
+      spec {
+        "Free tier — acquisition funnel entry"
+        accept: "no credit card required"
+        status: done
+      }
       w: 300 h: 480
       fill: #FFFFFF
       stroke: #E8E8EC 1
@@ -103,11 +107,13 @@ group @pricing {
       }
     }
     rect @tier_pro {
-      ## "Pro tier — primary conversion target"
-      ## accept: "most popular badge visible"
-      ## accept: "pre-selected on page load"
-      ## priority: high
-      ## status: in_progress
+      spec {
+        "Pro tier — primary conversion target"
+        accept: "most popular badge visible"
+        accept: "pre-selected on page load"
+        priority: high
+        status: in_progress
+      }
       w: 320 h: 520
       fill: #FFFFFF
       stroke: #6C5CE7 2
@@ -182,17 +188,19 @@ group @pricing {
       }
     }
     rect @tier_enterprise {
-      ## "Enterprise tier — high-value leads"
-      ## accept: "custom quote form"
-      ## status: draft
-      ## tag: sales
+      spec {
+        "Enterprise tier — high-value leads"
+        accept: "custom quote form"
+        status: draft
+        tag: sales
+      }
       w: 300 h: 480
       fill: #FFFFFF
       stroke: #E8E8EC 1
       corner: 16
       shadow: (0,2,12,#00000011)
       group @_anon_52 {
-        ## "???"
+        spec "???"
         layout: column gap=16 pad=28
         text @_anon_53 "Enterprise" {
           fill: #6B7280

--- a/examples/userflow_onboarding.fd
+++ b/examples/userflow_onboarding.fd
@@ -19,54 +19,64 @@ style flow_edge {
 # ─── Screens ────────────────────────────────────────────────
 
 rect @landing {
-  ## "Marketing landing page"
-  ## status: done
-  ## tag: marketing
+  spec {
+    "Marketing landing page"
+    status: done
+    tag: marketing
+  }
   w: 200 h: 120
   use: screen
   text @landing_t "Landing Page" { use: screen_title }
 }
 
 rect @signup {
-  ## "Registration form"
-  ## accept: "collects name, email, password"
-  ## accept: "OAuth buttons for Google + GitHub"
-  ## status: done
+  spec {
+    "Registration form"
+    accept: "collects name, email, password"
+    accept: "OAuth buttons for Google + GitHub"
+    status: done
+  }
   w: 200 h: 120
   use: screen
   text @signup_t "Sign Up" { use: screen_title }
 }
 
 rect @verify_email {
-  ## "Email verification step"
-  ## accept: "shows 6-digit OTP input"
-  ## accept: "resend link after 60s cooldown"
-  ## status: in_progress
+  spec {
+    "Email verification step"
+    accept: "shows 6-digit OTP input"
+    accept: "resend link after 60s cooldown"
+    status: in_progress
+  }
   w: 200 h: 120
   use: screen
   text @verify_t "Verify Email" { use: screen_title }
 }
 
 rect @setup_profile {
-  ## "Profile setup — avatar, bio, preferences"
-  ## accept: "avatar upload with crop"
-  ## status: draft
+  spec {
+    "Profile setup — avatar, bio, preferences"
+    accept: "avatar upload with crop"
+    status: draft
+  }
   w: 200 h: 120
   use: screen
   text @setup_t "Setup Profile" { use: screen_title }
 }
 
 rect @dashboard {
-  ## "Main application dashboard"
-  ## status: draft
-  ## tag: core
+  spec {
+    "Main application dashboard"
+    status: draft
+    tag: core
+  }
   w: 200 h: 120
   use: screen
   text @dash_t "Dashboard" { use: screen_title }
 }
 
 rect @error_screen {
-  ## "Generic error state"
+  spec "Generic error state"
   w: 160 h: 100
   fill: #FEF2F2
   corner: 12
@@ -77,7 +87,7 @@ rect @error_screen {
 }
 
 rect @resend_screen {
-  ## "Resend verification email"
+  spec "Resend verification email"
   w: 160 h: 100
   fill: #FFFBEB
   corner: 12
@@ -90,7 +100,7 @@ rect @resend_screen {
 # ─── Happy path ───────────────────────────────────────────────
 
 edge @cta_click {
-  ## "Primary CTA on landing"
+  spec "Primary CTA on landing"
   from: @landing
   to: @signup
   label: "Get Started"
@@ -99,8 +109,10 @@ edge @cta_click {
 }
 
 edge @signup_submit {
-  ## "Form submission"
-  ## accept: "validates all fields client-side first"
+  spec {
+    "Form submission"
+    accept: "validates all fields client-side first"
+  }
   from: @signup
   to: @verify_email
   label: "submit"
@@ -109,7 +121,7 @@ edge @signup_submit {
 }
 
 edge @email_verified {
-  ## "OTP validated"
+  spec "OTP validated"
   from: @verify_email
   to: @setup_profile
   label: "verified"
@@ -119,7 +131,7 @@ edge @email_verified {
 }
 
 edge @profile_done {
-  ## "Profile setup complete"
+  spec "Profile setup complete"
   from: @setup_profile
   to: @dashboard
   label: "complete"
@@ -131,8 +143,10 @@ edge @profile_done {
 # ─── Error paths ──────────────────────────────────────────────
 
 edge @signup_error {
-  ## "Registration failure"
-  ## accept: "shows inline field errors"
+  spec {
+    "Registration failure"
+    accept: "shows inline field errors"
+  }
   from: @signup
   to: @error_screen
   label: "validation fail"
@@ -142,7 +156,7 @@ edge @signup_error {
 }
 
 edge @verify_timeout {
-  ## "OTP expired or invalid"
+  spec "OTP expired or invalid"
   from: @verify_email
   to: @resend_screen
   label: "expired"
@@ -152,7 +166,7 @@ edge @verify_timeout {
 }
 
 edge @resend_retry {
-  ## "User requests new OTP"
+  spec "User requests new OTP"
   from: @resend_screen
   to: @verify_email
   label: "resend"
@@ -161,7 +175,7 @@ edge @resend_retry {
 }
 
 edge @error_retry {
-  ## "User corrects errors and resubmits"
+  spec "User corrects errors and resubmits"
   from: @error_screen
   to: @signup
   label: "retry"

--- a/examples/wireframe_login.fd
+++ b/examples/wireframe_login.fd
@@ -19,8 +19,10 @@ style label_style {
 # ─── Wireframe screens ────────────────────────────────────────
 
 group @login_page {
-  ## "Login page — main entry point"
-  ## status: done
+  spec {
+    "Login page — main entry point"
+    status: done
+  }
   layout: column gap=16 pad=32
 
   text @title "Welcome Back" {
@@ -29,8 +31,10 @@ group @login_page {
   }
 
   rect @email_field {
-    ## "Email input field"
-    ## accept: "validates email format on blur"
+    spec {
+      "Email input field"
+      accept: "validates email format on blur"
+    }
     w: 320 h: 48
     use: input_style
     text @email_placeholder "Email address" {
@@ -40,8 +44,10 @@ group @login_page {
   }
 
   rect @password_field {
-    ## "Password input field"
-    ## accept: "minimum 8 characters"
+    spec {
+      "Password input field"
+      accept: "minimum 8 characters"
+    }
     w: 320 h: 48
     use: input_style
     text @pw_placeholder "Password" {
@@ -51,9 +57,11 @@ group @login_page {
   }
 
   rect @login_btn {
-    ## "Primary login CTA"
-    ## accept: "disabled when fields empty"
-    ## accept: "shows loading spinner during auth"
+    spec {
+      "Primary login CTA"
+      accept: "disabled when fields empty"
+      accept: "shows loading spinner during auth"
+    }
     w: 320 h: 48
     fill: #6C5CE7
     corner: 10
@@ -75,9 +83,11 @@ group @login_page {
 }
 
 rect @error_toast {
-  ## "Error notification toast"
-  ## accept: "shows within 200ms of failed auth"
-  ## accept: "auto-dismiss after 5s"
+  spec {
+    "Error notification toast"
+    accept: "shows within 200ms of failed auth"
+    accept: "auto-dismiss after 5s"
+  }
   w: 320 h: 56
   fill: #FEF2F2
   stroke: #EF4444 1
@@ -89,8 +99,10 @@ rect @error_toast {
 }
 
 rect @dashboard {
-  ## "Main dashboard — post-login"
-  ## status: in_progress
+  spec {
+    "Main dashboard — post-login"
+    status: in_progress
+  }
   w: 400 h: 300
   use: bg_surface
   text @dash_title "Dashboard" {
@@ -100,8 +112,10 @@ rect @dashboard {
 }
 
 rect @reset_page {
-  ## "Password reset flow"
-  ## status: draft
+  spec {
+    "Password reset flow"
+    status: draft
+  }
   w: 320 h: 200
   use: bg_surface
   text @reset_title "Reset Password" {
@@ -113,8 +127,10 @@ rect @reset_page {
 # ─── Edges (data flow) ─────────────────────────────────────────
 
 edge @submit_flow {
-  ## "Form submission → API validation"
-  ## accept: "must complete within 3s"
+  spec {
+    "Form submission → API validation"
+    accept: "must complete within 3s"
+  }
   from: @login_btn
   to: @dashboard
   label: "on success"
@@ -124,7 +140,7 @@ edge @submit_flow {
 }
 
 edge @error_flow {
-  ## "Failed authentication path"
+  spec "Failed authentication path"
   from: @login_btn
   to: @error_toast
   label: "on failure"

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.6.40",
+  "version": "0.7.0",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/fd-parse.test.ts
+++ b/fd-vscode/src/fd-parse.test.ts
@@ -16,42 +16,42 @@ import {
 
 describe("parseAnnotation", () => {
   it("parses accept annotation", () => {
-    expect(parseAnnotation('## accept: "user can log in"')).toEqual({
+    expect(parseAnnotation('accept: "user can log in"')).toEqual({
       type: "accept",
       value: "user can log in",
     });
   });
 
   it("parses status annotation", () => {
-    expect(parseAnnotation("## status: done")).toEqual({
+    expect(parseAnnotation("status: done")).toEqual({
       type: "status",
       value: "done",
     });
   });
 
   it("parses priority annotation", () => {
-    expect(parseAnnotation("## priority: high")).toEqual({
+    expect(parseAnnotation("priority: high")).toEqual({
       type: "priority",
       value: "high",
     });
   });
 
   it("parses tag annotation", () => {
-    expect(parseAnnotation("## tag: conversion, revenue")).toEqual({
+    expect(parseAnnotation("tag: conversion, revenue")).toEqual({
       type: "tag",
       value: "conversion, revenue",
     });
   });
 
   it("parses description annotation", () => {
-    expect(parseAnnotation('## "Login form — main CTA"')).toEqual({
+    expect(parseAnnotation('"Login form — main CTA"')).toEqual({
       type: "description",
       value: "Login form — main CTA",
     });
   });
 
   it("returns null for unrecognized annotations", () => {
-    expect(parseAnnotation("## some random text")).toBeNull();
+    expect(parseAnnotation("some random text")).toBeNull();
   });
 
   it("returns null for regular comments", () => {
@@ -86,7 +86,7 @@ describe("parseSpecNodes", () => {
   });
 
   it("extracts a typed node with annotations", () => {
-    const source = `rect @card {\n  ## "Main card"\n  ## accept: "visible on load"\n  ## status: done\n  fill: #FFF\n}`;
+    const source = `rect @card {\n  spec {\n    "Main card"\n    accept: "visible on load"\n    status: done\n  }\n  fill: #FFF\n}`;
     const result = parseSpecNodes(source);
     expect(result.nodes).toHaveLength(1);
     expect(result.nodes[0].id).toBe("card");
@@ -106,7 +106,7 @@ describe("parseSpecNodes", () => {
   });
 
   it("extracts a generic node", () => {
-    const source = `@login_flow {\n  ## "User login flow"\n  ## priority: high\n}`;
+    const source = `@login_flow {\n  spec {\n    "User login flow"\n    priority: high\n  }\n}`;
     const result = parseSpecNodes(source);
     expect(result.nodes).toHaveLength(1);
     expect(result.nodes[0]).toEqual({
@@ -132,7 +132,7 @@ describe("parseSpecNodes", () => {
   });
 
   it("extracts edges with annotations", () => {
-    const source = `edge @flow1 {\n  ## "Critical path"\n  from: @a\n  to: @b\n}`;
+    const source = `edge @flow1 {\n  spec "Critical path"\n  from: @a\n  to: @b\n}`;
     const result = parseSpecNodes(source);
     expect(result.edges).toHaveLength(1);
     expect(result.edges[0].annotations).toEqual([
@@ -143,7 +143,7 @@ describe("parseSpecNodes", () => {
   it("handles multiple nodes and edges together", () => {
     const source = [
       "rect @btn {\n  fill: #333\n}",
-      "text @label \"Hello\" {\n  ## \"Primary label\"\n}",
+      "text @label \"Hello\" {\n  spec \"Primary label\"\n}",
       "edge @flow {\n  from: @btn\n  to: @label\n}",
     ].join("\n");
     const result = parseSpecNodes(source);
@@ -209,9 +209,11 @@ describe("computeSpecHideLines", () => {
   it("keeps comments and annotations", () => {
     const lines = [
       "# This is a comment",
-      '## "Description"',
-      '## accept: "criterion"',
-      "## status: done",
+      'spec {',
+      '  "Description"',
+      '  accept: "criterion"',
+      "  status: done",
+      '}',
     ];
     expect(computeSpecHideLines(lines)).toEqual([]);
   });
@@ -325,7 +327,7 @@ describe("computeSpecFoldRanges", () => {
   it("handles realistic multi-node structure", () => {
     const lines = [
       "group @nav {",        // 0 - kept
-      "  ## \"Navigation\"",  // 1 - kept
+      "  spec \"Navigation\"",  // 1 - kept
       "  layout: row gap=8", // 2 - hidden
       "  rect @btn1 {",      // 3 - kept
       "    w: 50 h: 30",     // 4 - hidden
@@ -533,7 +535,7 @@ describe("parseDocumentSymbols", () => {
   });
 
   it("parses generic node", () => {
-    const lines = ["@login_flow {", "  ## \"User login\"", "}"];
+    const lines = ["@login_flow {", '  spec "User login"', "}"];
     const result = parseDocumentSymbols(lines);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("@login_flow");

--- a/tree-sitter-fd/grammar.js
+++ b/tree-sitter-fd/grammar.js
@@ -20,32 +20,39 @@ module.exports = grammar({
                     $.style_block,
                     $.node_declaration,
                     $.constraint_line,
-                    $.annotation,
+                    $.spec_block,
                 ),
             ),
 
         // ─── Comments ────────────────────────────────────────────
         comment: (_$) => token(prec(-1, seq("#", /[^#\n][^\n]*/))),
 
-        // ─── Annotations ─────────────────────────────────────────
-        annotation: ($) =>
+        // ─── Spec Block ─────────────────────────────────────────
+        spec_block: ($) =>
             seq(
-                "##",
-                optional(
-                    choice($.annotation_typed, $.string, $.annotation_text),
+                "spec",
+                choice(
+                    $.string, // Inline: spec "description"
+                    seq("{", repeat($.spec_item), "}"), // Block: spec { ... }
                 ),
             ),
 
-        annotation_typed: ($) =>
-            seq(
-                field("key", $.annotation_keyword),
-                ":",
-                field("value", choice($.string, $.annotation_text)),
+        spec_item: ($) =>
+            choice(
+                $.spec_typed,
+                $.string,
             ),
 
-        annotation_text: (_$) => /[^\n]+/,
+        spec_typed: ($) =>
+            seq(
+                field("key", $.spec_keyword),
+                ":",
+                field("value", choice($.string, $.spec_text)),
+            ),
 
-        annotation_keyword: (_$) =>
+        spec_text: (_$) => /[^\n}]+/,
+
+        spec_keyword: (_$) =>
             choice("accept", "status", "priority", "tag"),
 
         // ─── Style Block ─────────────────────────────────────────
@@ -76,7 +83,7 @@ module.exports = grammar({
                 $.property,
                 $.node_declaration,
                 $.anim_block,
-                $.annotation,
+                $.spec_block,
             ),
 
         // ─── Properties ──────────────────────────────────────────

--- a/tree-sitter-fd/queries/highlights.scm
+++ b/tree-sitter-fd/queries/highlights.scm
@@ -17,9 +17,9 @@
 ; ─── Properties ────────────────────────────────────────────
 (property_name) @property
 
-; ─── Annotations ───────────────────────────────────────────
-"##" @attribute
-(annotation_keyword) @attribute
+; ─── Spec Blocks ───────────────────────────────────────────
+"spec" @keyword
+(spec_keyword) @attribute
 
 ; ─── Animation trigger ─────────────────────────────────────
 (anim_trigger


### PR DESCRIPTION
## Breaking Change: `##` → `spec` blocks

Replaces `##` annotation syntax with first-class `spec` node blocks.

### New Syntax
```fd
# Inline (single description):
spec "Primary CTA"

# Block (multiple annotations):
spec {
  "Description"
  accept: "validates email"
  status: in_progress
  priority: high
  tag: auth
}
```

### Files Changed (25 files, +657/-375)
- **Rust core**: `model.rs`, `parser.rs`, `emitter.rs`, `sync.rs`
- **Tree-sitter**: `grammar.js`, `highlights.scm`
- **VS Code ext**: `fd-parse.ts`, `extension.ts`, `main.js`, `fd-parse.test.ts`
- **Examples**: All 13 `.fd` files
- **Docs**: `GEMINI.md`, `CHANGELOG.md`

### Test Results
| Check | Result |
|-------|--------|
| `cargo test` | ✅ 32/32 |
| `pnpm test` | ✅ 74/74 |
| `cargo clippy` | ✅ Clean |
| `cargo fmt` | ✅ Clean |