### PR TITLE
docs(workflow): add e2e gate before publishing when WASM rebuilt

### DIFF
--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -126,6 +126,8 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
     wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm
     ```
 
+    > 🛑 **If WASM was rebuilt**: Run `/e2e` in a Codespace to verify canvas renders before publishing.
+
     Then compile TypeScript:
 
     ```bash


### PR DESCRIPTION
Adds a 🛑 gate in /yolo: run /e2e in a Codespace to verify canvas renders before publishing when WASM was rebuilt.