### PR TITLE
feat(ext): add extensionKind for VS Code Web/Codespace support

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -25,6 +25,9 @@
   "engines": {
     "vscode": "^1.85.0"
   },
+  "extensionKind": [
+    "workspace"
+  ],
   "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
## VS Code Web / Codespace Support

Adds `"extensionKind": ["workspace"]` to `package.json` so the extension activates correctly in VS Code Web (Codespaces).

### Verified
- ✅ E2e tested: canvas renders in Codespace via browser
- ✅ Commands registered (FD: Open Canvas Editor works)
- ✅ Layers panel, shapes, toolbar all functional