### PR TITLE
fix(sync): prevent code editor jump + fix double-click text editing

### DIFF
--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -235,6 +235,7 @@ group @settings {
 @slider_track -> absolute: 3401.04, 11038.97
 @toggle_sound -> absolute: 28.51, 340.51
 @toggle_notif -> absolute: 376.84, 708.79
-@toggle_dark -> absolute: 237.5, 834.9
+@toggle_dark -> absolute: 238.09, 834.82
 @_anon_34 -> absolute: 3129.49, 15512.29
+@profile_card -> absolute: 30.12, 527.12
 @_anon_29 -> absolute: 159.45, 287.16


### PR DESCRIPTION
## Fix canvas selection jump + double-click text editing

### Canvas jump fix
- Skip `syncTextToExtension` when text content unchanged
- Skip `applyEdit` in extension when text identical to document
- Deduplicate `nodeSelected` messages (only send when selection changes)
- Skip cursor/scroll if already on target line
- Increase `suppressCursorSync` window to 200ms

### Double-click text editing fix
- Suppress `nodeSelected` during inline editing to prevent focus stealing
- Delay blur→commit by 150ms to avoid premature textarea removal

### Verified
- ✅ `cargo test` — all pass
- ✅ `cargo clippy` — clean
- ✅ `cargo fmt` — clean
- ✅ `pnpm test` — 74/74