### PR TITLE
feat(canvas): zoom-to-selection, color swatches, selection bar, layer visibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.7.5
+
+- **NEW**: Zoom to selection — `⌘1` / `Ctrl+1` centers and zooms to fit the selected node
+- **NEW**: Color swatches palette — 12 preset colors + recent colors in properties panel (click to apply fill)
+- **NEW**: Selection info bar — bottom-center pill showing `@id · kind · W×H · (X, Y)` when a node is selected
+- **NEW**: Layer visibility toggle — eye icon (👁) on hover in layers panel, click to dim node to 15% opacity
+
 ### v0.7.4
 
 - **R3.21**: Grid overlay — toggleable dot grid (becomes line grid at high zoom) with adaptive spacing; keyboard shortcut `G` and toolbar ⊞ button; state persists across sessions

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -925,6 +925,81 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       display: block;
     }
 
+    /* ── Color Swatches (Sketch/Figma) ── */
+    .color-swatches {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      margin-top: 6px;
+    }
+    .color-swatch {
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
+      border: 1.5px solid var(--fd-border);
+      cursor: pointer;
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+    }
+    .color-swatch:hover {
+      transform: scale(1.15);
+      box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    }
+    .color-swatch:active {
+      transform: scale(0.95);
+    }
+    .color-swatch.active {
+      border-color: var(--fd-accent);
+      box-shadow: 0 0 0 2px var(--fd-input-focus);
+    }
+
+    /* ── Layer Visibility (Eye Icon) ── */
+    .layer-eye {
+      width: 20px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      cursor: pointer;
+      font-size: 10px;
+      color: var(--fd-text-tertiary);
+      opacity: 0;
+      transition: opacity 0.12s ease, color 0.12s ease;
+    }
+    .layer-item:hover .layer-eye,
+    .layer-eye.hidden-layer {
+      opacity: 1;
+    }
+    .layer-eye.hidden-layer {
+      color: var(--fd-accent);
+    }
+
+    /* ── Selection Info Bar ── */
+    #selection-bar {
+      display: none;
+      position: absolute;
+      bottom: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 5px 14px;
+      background: var(--fd-surface);
+      backdrop-filter: blur(20px) saturate(180%);
+      -webkit-backdrop-filter: blur(20px) saturate(180%);
+      border: 0.5px solid var(--fd-border);
+      border-radius: 20px;
+      box-shadow: var(--fd-shadow-md);
+      z-index: 15;
+      font-size: 11px;
+      color: var(--fd-text-secondary);
+      font-weight: 500;
+      white-space: nowrap;
+      font-family: 'SF Mono', SFMono-Regular, ui-monospace, monospace;
+      letter-spacing: -0.02em;
+    }
+    #selection-bar.visible {
+      display: block;
+    }
+
     /* ── Help & Status ── */
     #tool-help-btn {
       margin-left: auto;
@@ -1442,6 +1517,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     <div id="spec-overlay"></div>
     <div id="layers-panel"></div>
     <div id="minimap-container"><canvas id="minimap-canvas"></canvas></div>
+    <div id="selection-bar"></div>
     <div id="loading"><div class="loading-spinner"></div>Loading FD engine…</div>
     <!-- Properties Panel (Apple-style) -->
     <div id="props-panel">
@@ -1477,6 +1553,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
             <div class="props-field">
               <label>Fill</label>
               <input type="color" id="prop-fill" value="#CCCCCC">
+              <div class="color-swatches" id="fill-swatches"></div>
             </div>
             <div class="props-field">
               <label>Corner</label>


### PR DESCRIPTION
## Summary

4 more canvas improvements inspired by Figma/Sketch/Miro.

| Feature | How to use |
|---------|-----------|
| **Zoom to selection** | `⌘1` / `Ctrl+1` centers + zooms to fit selected node |
| **Color swatches** | 12 preset colors + recent colors in fill section of properties panel |
| **Selection info bar** | Bottom-center pill: `@id · kind · W×H · (X, Y)` |
| **Layer visibility toggle** | Eye icon (👁) on hover, click to dim to 15% opacity |

### CI
- ✅ `cargo clippy` — clean
- ✅ `cargo test` — all pass
- ✅ `pnpm test` — 74 tests pass