### PR TITLE
feat(spec): requirements summary panel in Spec mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.7.9
+
+- **NEW**: Spec Summary Panel — layers panel becomes requirements overview in Spec mode, showing all annotated nodes as cards with description, status/priority badges, accept criteria, and tags
+- **NEW**: Click-to-select in spec summary navigates to node on canvas + opens annotation editing card
+- **NEW**: Empty state guidance ("No spec annotations yet — Right-click a node → Add Annotation")
+- **UX**: Apple-style color-coded badges: draft=grey, in_progress=yellow, done=green, priority high=red/medium=orange/low=green
+
 ### v0.7.8
 
 - **NEW**: Smart alignment guides (R3.17) — magenta dashed guide lines appear during drag/resize when node edges or centers align with other nodes (Figma/Sketch behavior)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -815,6 +815,95 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       padding: 48px 0;
       font-size: 14px;
     }
+    .spec-empty-state {
+      text-align: center;
+      padding: 36px 16px;
+      color: var(--fd-text-secondary);
+    }
+    .spec-summary-card {
+      padding: 10px 12px;
+      margin: 4px 8px;
+      border-radius: 8px;
+      background: var(--fd-surface);
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+    .spec-summary-card:hover {
+      background: var(--fd-surface-hover);
+      border-color: var(--fd-border);
+    }
+    .spec-summary-card.selected {
+      border-color: var(--fd-accent);
+      background: var(--fd-accent-dim);
+    }
+    .spec-card-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 4px;
+    }
+    .spec-card-id {
+      font-weight: 600;
+      font-size: 12px;
+      color: var(--fd-accent);
+    }
+    .spec-card-kind {
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--fd-surface-hover);
+      color: var(--fd-text-secondary);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .spec-card-desc {
+      font-size: 12px;
+      color: var(--fd-text-primary);
+      line-height: 1.4;
+      margin-bottom: 6px;
+    }
+    .spec-card-badges {
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+      margin-bottom: 6px;
+    }
+    .spec-card-badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-weight: 600;
+    }
+    .spec-card-badge.status-draft { background: rgba(142,142,147,0.15); color: #8E8E93; }
+    .spec-card-badge.status-in_progress { background: rgba(255,159,10,0.15); color: #FF9F0A; }
+    .spec-card-badge.status-done { background: rgba(52,199,89,0.15); color: #34C759; }
+    .spec-card-badge.priority-high { background: rgba(255,59,48,0.15); color: #FF3B30; }
+    .spec-card-badge.priority-medium { background: rgba(255,159,10,0.15); color: #FF9F0A; }
+    .spec-card-badge.priority-low { background: rgba(52,199,89,0.15); color: #34C759; }
+    .spec-card-accepts {
+      margin-top: 4px;
+      padding-left: 2px;
+    }
+    .spec-card-accept-item {
+      font-size: 11px;
+      color: var(--fd-text-secondary);
+      padding: 1px 0;
+      line-height: 1.4;
+    }
+    .spec-card-tags {
+      display: flex;
+      gap: 4px;
+      flex-wrap: wrap;
+      margin-top: 4px;
+    }
+    .spec-card-tag {
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      background: var(--fd-accent-dim);
+      color: var(--fd-accent);
+    }
 
     /* ── Theme Toggle (Apple pill) ── */
     #theme-toggle-btn {


### PR DESCRIPTION
## Summary

**Spec Summary Panel** — the layers panel area transforms into a requirements overview when in Spec mode.

### UX Problem Solved
Previously, viewing requirements meant clicking tiny badge pins on each node individually. There was no way to see ALL specs at a glance.

### What Changed
- In **Spec mode**, the layers panel shows annotated nodes as **cards** with:
  - `@nodeId` + kind badge
  - Description text
  - Status badges (draft/in_progress/done) — color-coded
  - Priority badges (high/medium/low) — color-coded
  - Acceptance criteria with ✓ checkmarks
  - Tags as chips
- **Click a card** → selects node on canvas + opens annotation editing card
- **Empty state** guides new users: "Right-click a node → Add Annotation"

### CI: ✅ clippy, ✅ 168 Rust tests, ✅ 74 TS tests