### PR TITLE
feat(spec): 5 spec UX improvements — shortcut, filters, coverage, export, bulk

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## Completed Requirements
 
+### v0.8.0
+
+- **NEW**: ⌘I / Ctrl+I keyboard shortcut to add/edit spec annotation on selected node
+- **NEW**: Status filter tabs in Spec Summary (All / Draft / In Prog / Done) with per-filter counts
+- **NEW**: Spec coverage % indicator in header — shows annotated/total nodes ratio
+- **NEW**: Export spec report ↗ button — copies full markdown spec report to clipboard
+- **NEW**: Bulk status dropdown — set Draft/In Progress/Done on all visible specs at once
+- **UX**: Empty state message now mentions ⌘I shortcut
+
 ### v0.7.9
 
 - **NEW**: Spec Summary Panel — layers panel becomes requirements overview in Spec mode, showing all annotated nodes as cards with description, status/priority badges, accept criteria, and tags

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -904,6 +904,65 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       background: var(--fd-accent-dim);
       color: var(--fd-accent);
     }
+    .spec-header-actions {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+      margin-left: auto;
+    }
+    .spec-action-btn {
+      background: none;
+      border: 1px solid var(--fd-border);
+      border-radius: 4px;
+      color: var(--fd-text-secondary);
+      font-size: 12px;
+      padding: 2px 6px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .spec-action-btn:hover {
+      background: var(--fd-surface-hover);
+      color: var(--fd-text-primary);
+    }
+    .spec-bulk-status {
+      background: var(--fd-surface);
+      border: 1px solid var(--fd-border);
+      border-radius: 4px;
+      color: var(--fd-text-secondary);
+      font-size: 10px;
+      padding: 2px 4px;
+      cursor: pointer;
+    }
+    .spec-filter-tabs {
+      display: flex;
+      gap: 2px;
+      padding: 4px 8px;
+      border-bottom: 1px solid var(--fd-border);
+    }
+    .spec-filter-btn {
+      background: none;
+      border: none;
+      border-radius: 4px;
+      color: var(--fd-text-secondary);
+      font-size: 10px;
+      padding: 3px 8px;
+      cursor: pointer;
+      transition: all 0.15s;
+      white-space: nowrap;
+    }
+    .spec-filter-btn:hover {
+      background: var(--fd-surface-hover);
+    }
+    .spec-filter-btn.active {
+      background: var(--fd-accent-dim);
+      color: var(--fd-accent);
+      font-weight: 600;
+    }
+    .spec-filter-count {
+      opacity: 0.5;
+      font-size: 9px;
+      margin-left: 2px;
+    }
 
     /* ── Theme Toggle (Apple pill) ── */
     #theme-toggle-btn {


### PR DESCRIPTION
## Summary

5 spec UX improvements that transform the requirements editing experience.

### Features

| # | Feature | Description |
|---|---------|-------------|
| 1 | **⌘I Shortcut** | Opens annotation card for selected node — no right-click needed |
| 2 | **Filter Tabs** | All / Draft / In Prog / Done — filter specs by status with counts |
| 3 | **Coverage %** | Header shows annotated/total nodes ratio |
| 4 | **Export ↗** | Copies full markdown spec report to clipboard |
| 5 | **Bulk Status** | Dropdown sets Draft/In Progress/Done on all visible specs at once |

### CI: ✅ clippy, ✅ 168 Rust tests, ✅ 74 TS tests