### PR TITLE
fix(devex): disable GitLens inline blame in workspace and Codespace

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "gitlens.currentLine.enabled": false,
+        "gitlens.codeLens.enabled": false
+      }
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "gitlens.currentLine.enabled": false,
+  "gitlens.codeLens.enabled": false
+}


### PR DESCRIPTION
## Summary

Disables GitLens inline blame annotations that clutter the editor in Codespace.

### Changes
- `.vscode/settings.json` — disables GitLens current line blame and CodeLens for workspace
- `.devcontainer/devcontainer.json` — persists the same settings across Codespace sessions

No code changes, config-only.