### PR TITLE
fix(canvas): offset viewport centering for layers panel overlay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.2
+
+- **UX fix**: Canvas content now centers in the visible area to the right of the layers panel, instead of behind it — `zoomToFit`, `zoomToSelection`, and initial load all account for the 232px overlay
+- **UX**: Initial load now auto-centers content via `zoomToFit()` instead of starting at origin
+
 ### v0.8.1
 
 - **UX**: Spec View now strips type keywords (`group`, `rect`, `text`, `ellipse`, `path`, `frame`) from node declarations — `group @checkout_page {` renders as `@checkout_page {` in Code Mode when Spec View is active

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary

Canvas content now centers in the visible area to the right of the layers panel overlay, instead of behind it.

**Before:** Content centered using full container width — left portion hidden behind the 232px layers panel.
**After:** Content centered in the usable viewport area, fully visible.

### Changes
- `getLayersPanelWidth()` — dynamically reads the layers panel width
- `zoomToFit()` — uses usable width (`cw - panelW`) for fit calculation and centering
- `zoomToSelection()` (⌘1) — same offset applied
- Initial load now calls `zoomToFit()` so content starts properly centered

### Verification
- ✅ 89/89 TypeScript tests pass
- ✅ `cargo clippy/test/fmt` clean