### PR TITLE
fix(canvas): context-sensitive Group/Ungroup in context menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.3
+
+- **UX**: Group/Ungroup context menu items are now context-sensitive — Group disabled with <2 items selected, Ungroup disabled when selected node isn't a group (matches Figma/Sketch)
+
 ### v0.8.2
 
 - **UX fix**: Canvas content now centers in the visible area to the right of the layers panel, instead of behind it — `zoomToFit`, `zoomToSelection`, and initial load all account for the 232px overlay

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1520,6 +1520,10 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       background: var(--fd-accent);
       color: var(--fd-accent-fg);
     }
+    #context-menu .menu-item.disabled {
+      opacity: 0.35;
+      pointer-events: none;
+    }
     #context-menu .menu-item:hover .menu-shortcut {
       color: rgba(255,255,255,0.55);
     }

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1012,6 +1012,26 @@ function setupContextMenu() {
     const containerRect = container.getBoundingClientRect();
     menu.style.left = (e.clientX - containerRect.left) + "px";
     menu.style.top = (e.clientY - containerRect.top) + "px";
+
+    // Enable/disable Group and Ungroup based on selection
+    const selectedIds = JSON.parse(fdCanvas.get_selected_ids());
+    const groupBtn = document.getElementById("ctx-group");
+    const ungroupBtn = document.getElementById("ctx-ungroup");
+
+    // Group requires 2+ items selected
+    const canGroup = selectedIds.length >= 2;
+    groupBtn.classList.toggle("disabled", !canGroup);
+
+    // Ungroup requires exactly 1 selected item that is a group
+    let canUngroup = false;
+    if (selectedIds.length === 1) {
+      try {
+        const props = JSON.parse(fdCanvas.get_selected_node_props());
+        canUngroup = props.kind === "group";
+      } catch (_) { /* skip */ }
+    }
+    ungroupBtn.classList.toggle("disabled", !canUngroup);
+
     menu.classList.add("visible");
   });
 


### PR DESCRIPTION
## Summary

Group/Ungroup context menu items are now context-sensitive, matching Figma/Sketch behavior.

| Selection | Group | Ungroup |
|-----------|-------|---------|
| 0 items | ❌ disabled | ❌ disabled |
| 1 non-group | ❌ disabled | ❌ disabled |
| 1 group | ❌ disabled | ✅ enabled |
| 2+ items | ✅ enabled | ❌ disabled |

### Changes
- `.menu-item.disabled` CSS class (opacity + pointer-events: none)
- Context menu checks `get_selected_ids()` count and `get_selected_node_props().kind`
- Version bump to 0.8.3