### PR TITLE
refactor: deprecate ## annotations, unify under spec blocks

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -101,9 +101,11 @@ Nodes without a shape type — for spec-only requirements, wireframing, and prog
 
 ```
 @login_btn {
-  ## "Primary CTA — triggers login API call"
-  ## accept: "disabled when fields empty"
-  ## status: in_progress
+  spec {
+    "Primary CTA — triggers login API call"
+    accept: "disabled when fields empty"
+    status: in_progress
+  }
   fill: #FFFFFF
   corner: 8
 }
@@ -114,8 +116,8 @@ Generic nodes can be nested inside groups:
 ```
 group @form {
   layout: column gap=16 pad=32
-  @email_input { ## "Email field" }
-  @password_input { ## "Password field" }
+  @email_input { spec "Email field" }
+  @password_input { spec "Password field" }
 }
 ```
 
@@ -137,7 +139,7 @@ edge @login_to_dashboard {
 }
 ```
 
-Edges support `##` annotations and `use:` style references, just like nodes.
+Edges support `spec` annotations and `use:` style references, just like nodes.
 
 ### Colors
 
@@ -178,28 +180,41 @@ Easing: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `spring`
 @node_id -> fill_parent: 16
 ```
 
-### Annotations
+### Annotations (spec)
 
-Structured metadata attached to nodes via `##` lines. Unlike `#` comments (which are discarded), annotations are parsed, stored on the scene graph, and survive round-trips.
+Structured metadata attached to nodes and edges via `spec` blocks. Unlike `#` comments (which are discarded), annotations are parsed, stored on the scene graph, and survive round-trips.
+
+**Inline form** (single description):
 
 ```
 rect @login_btn {
-  ## "Primary CTA — triggers login API call"
-  ## accept: "disabled state when fields empty"
-  ## status: in_progress
-  ## priority: high
-  ## tag: auth, mvp
+  spec "Primary CTA — triggers login API call"
   w: 280 h: 48
 }
 ```
 
-| Syntax               | Kind        | Purpose                        |
-| -------------------- | ----------- | ------------------------------ |
-| `## "text"`          | Description | What this node is/does         |
-| `## accept: "text"`  | Accept      | Acceptance criterion           |
-| `## status: value`   | Status      | `draft`, `in_progress`, `done` |
-| `## priority: value` | Priority    | `high`, `medium`, `low`        |
-| `## tag: value`      | Tag         | Categorization labels          |
+**Block form** (multiple annotations):
+
+```
+rect @login_btn {
+  spec {
+    "Primary CTA — triggers login API call"
+    accept: "disabled state when fields empty"
+    status: in_progress
+    priority: high
+    tag: auth, mvp
+  }
+  w: 280 h: 48
+}
+```
+
+| Syntax            | Kind        | Purpose                        |
+| ----------------- | ----------- | ------------------------------ |
+| `"text"`          | Description | What this node is/does         |
+| `accept: "text"`  | Accept      | Acceptance criterion           |
+| `status: value`   | Status      | `draft`, `in_progress`, `done` |
+| `priority: value` | Priority    | `high`, `medium`, `low`        |
+| `tag: value`      | Tag         | Categorization labels          |
 
 ## Code Mode — Readability Tips
 
@@ -209,7 +224,7 @@ rect @login_btn {
 1. **Semantic IDs** — `@login_form` not `@rect_17`; the #1 factor for AI comprehension
 2. **Constraints over coords** — `center_in: canvas` tells agents _why_, not just _where_; LLMs reason better with relationships than absolute positions
 3. **Accurate comments** — `#` lines help, but wrong comments actively hurt AI; keep them correct or remove them
-4. **Annotations** — `## status: in_progress` gives AI structured metadata it can reliably parse, unlike freeform comments
+4. **Spec blocks** — `spec { status: in_progress }` gives AI structured metadata it can reliably parse, unlike freeform comments
 5. **Style reuse** — `use:` references enforce consistency; consistent codebases produce better AI-generated code
 6. **Shorthand is fine** — `w:` / `h:` / `#FFF` are unambiguous in context, no need to expand
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -16,8 +16,8 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.6**: Git-friendly plain text — line-oriented diffs work well
 - **R1.7**: Comments via `#` prefix
 - **R1.8**: Human-readable and AI-writable without special tooling
-- **R1.9**: Structured annotations (`##`) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
-- **R1.10**: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `##` annotations for user flows, wireframes, and state machines
+- **R1.9**: Structured annotations (`spec` blocks) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
+- **R1.10**: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `spec` annotations for user flows, wireframes, and state machines
 - **R1.11**: Edge trigger animations — edges support `anim :hover { ... }` blocks identical to nodes
 - **R1.12**: Edge flow animations — `flow: pulse Nms` (traveling dot) and `flow: dash Nms` (marching dashes) for visualizing data flow direction
 - **R1.13**: Generic nodes — `@id { ... }` without explicit kind keyword for abstract/placeholder elements
@@ -48,7 +48,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.11**: Per-tool cursor feedback (crosshair for drawing, text cursor for text, default for select)
 - **R3.12**: Annotation pins: Visual badge dots on annotated nodes with inline edit card
 - **R3.13**: Light/dark theme toggle — canvas defaults to light mode with a toolbar toggle button (🌙 in light → switch to dark, ☀️ in dark → switch to light); preference persists across sessions via VS Code state
-- **R3.14**: View mode toggle — **Design | Spec** segmented control in the canvas toolbar (Design default); Spec View hides the canvas and shows a scrollable overlay of node IDs, `##` annotations, acceptance criteria, status/priority/tag badges, unannotated node chips, and edges; overlay updates live as the `.fd` source changes; also accessible via `FD: Toggle Design/Spec View` command in the editor title bar and Command Palette
+- **R3.14**: View mode toggle — **Design | Spec** segmented control in the canvas toolbar (Design default); Spec View hides the canvas and shows a scrollable overlay of node IDs, `spec` annotations, acceptance criteria, status/priority/tag badges, unannotated node chips, and edges; overlay updates live as the `.fd` source changes; also accessible via `FD: Toggle Design/Spec View` command in the editor title bar and Command Palette
 - **R3.15**: Live preview: Dashed outline ghost of shape during drag-to-create (rect, ellipse); live smooth curve during pen draw (no jagged LineTo visible to user)
 - **R3.16**: Resize handles: 8-point resize grips (4 corners + 4 edge midpoints) on selected shapes; directional cursors (`nwse-resize`, `nesw-resize`, `ew-resize`, `ns-resize`) on hover
 - **R3.17**: Smart guides: Alignment snapping with visual guide lines — snap to center, edges, and equal spacing of nearby nodes; hold Ctrl/⌘ to temporarily disable snapping
@@ -65,9 +65,9 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R4.2**: Semantic node names (`@login_form`, `@submit_btn`) help AI understand intent
 - **R4.3**: Style inheritance reduces repetition — AI only specifies overrides
 - **R4.4**: Constraints describe relationships ("center in canvas") not pixel positions
-- **R4.5**: Annotations (`##`) give AI structured metadata — acceptance criteria, status, priority, tags — on the visual element itself
+- **R4.5**: Annotations (`spec` blocks) give AI structured metadata — acceptance criteria, status, priority, tags — on the visual element itself
 - **R4.6**: Edges let AI reason about flows and transitions between screens
-- **R4.7**: Spec-view export — generate markdown report of `##` annotations (requirements, status, acceptance criteria) from any `.fd` file
+- **R4.7**: Spec-view export — generate markdown report of `spec` annotations (requirements, status, acceptance criteria) from any `.fd` file
 - **R4.8**: AI node refinement — restyle selected nodes and replace anonymous IDs (`_anon_N`) with semantic names via configurable AI provider
 - **R4.9**: Multi-provider AI — per-provider API keys (`fd.ai.geminiApiKey`, `fd.ai.openaiApiKey`, `fd.ai.anthropicApiKey`), custom model selection per provider, and support for Gemini, OpenAI, Anthropic, Ollama (local), and OpenRouter (multi-model gateway)
 - **R4.10**: Auto-format pipeline — `format_document` via LSP; lint diagnostics (anonymous IDs, duplicate `use:`, unused styles) + configurable dedup/hoist transforms via `fd.format.*` settings

--- a/crates/fd-core/tests/fixtures/login_form.fd
+++ b/crates/fd-core/tests/fixtures/login_form.fd
@@ -13,26 +13,30 @@ style accent {
 group @login_form {
   layout: column gap=16 pad=32
 
-  ## "User authentication entry point"
-  ## accept: "email + password fields visible"
-  ## accept: "sign-in button triggers auth flow"
-  ## status: draft
+  spec {
+    "User authentication entry point"
+    accept: "email + password fields visible"
+    accept: "sign-in button triggers auth flow"
+    status: draft
+  }
 
   text @title "Welcome Back" {
     use: base_text
     font: "Inter" 600 24
     fill: #1A1A2E
-    ## "Brand greeting — sets emotional tone"
+    spec "Brand greeting — sets emotional tone"
   }
 
   rect @email_field {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Email input field"
-    ## accept: "validates email format on blur"
-    ## accept: "shows error state with red border"
-    ## priority: high
+    spec {
+      "Email input field"
+      accept: "validates email format on blur"
+      accept: "shows error state with red border"
+      priority: high
+    }
 
     text @email_hint "Email" {
       use: base_text
@@ -44,8 +48,10 @@ group @login_form {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Password input field"
-    ## accept: "minimum 8 characters"
+    spec {
+      "Password input field"
+      accept: "minimum 8 characters"
+    }
 
     text @pass_hint "Password" {
       use: base_text
@@ -57,10 +63,12 @@ group @login_form {
     w: 280 h: 48
     corner: 10
     use: accent
-    ## "Primary CTA — triggers login API call"
-    ## accept: "disabled state when fields empty"
-    ## accept: "loading spinner during auth"
-    ## status: in_progress
+    spec {
+      "Primary CTA — triggers login API call"
+      accept: "disabled state when fields empty"
+      accept: "loading spinner during auth"
+      status: in_progress
+    }
 
     text @btn_label "Sign In" {
       font: "Inter" 600 16

--- a/crates/fd-editor/tests/fixtures/login_form.fd
+++ b/crates/fd-editor/tests/fixtures/login_form.fd
@@ -13,26 +13,30 @@ style accent {
 group @login_form {
   layout: column gap=16 pad=32
 
-  ## "User authentication entry point"
-  ## accept: "email + password fields visible"
-  ## accept: "sign-in button triggers auth flow"
-  ## status: draft
+  spec {
+    "User authentication entry point"
+    accept: "email + password fields visible"
+    accept: "sign-in button triggers auth flow"
+    status: draft
+  }
 
   text @title "Welcome Back" {
     use: base_text
     font: "Inter" 600 24
     fill: #1A1A2E
-    ## "Brand greeting — sets emotional tone"
+    spec "Brand greeting — sets emotional tone"
   }
 
   rect @email_field {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Email input field"
-    ## accept: "validates email format on blur"
-    ## accept: "shows error state with red border"
-    ## priority: high
+    spec {
+      "Email input field"
+      accept: "validates email format on blur"
+      accept: "shows error state with red border"
+      priority: high
+    }
 
     text @email_hint "Email" {
       use: base_text
@@ -44,8 +48,10 @@ group @login_form {
     w: 280 h: 44
     corner: 8
     stroke: #DDDDDD 1
-    ## "Password input field"
-    ## accept: "minimum 8 characters"
+    spec {
+      "Password input field"
+      accept: "minimum 8 characters"
+    }
 
     text @pass_hint "Password" {
       use: base_text
@@ -57,10 +63,12 @@ group @login_form {
     w: 280 h: 48
     corner: 10
     use: accent
-    ## "Primary CTA — triggers login API call"
-    ## accept: "disabled state when fields empty"
-    ## accept: "loading spinner during auth"
-    ## status: in_progress
+    spec {
+      "Primary CTA — triggers login API call"
+      accept: "disabled state when fields empty"
+      accept: "loading spinner during auth"
+      status: in_progress
+    }
 
     text @btn_label "Sign In" {
       font: "Inter" 600 16

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.5
+
+- **BREAKING**: Removed all `##` annotation syntax from `.fd` files — unified under `spec` blocks (`spec "desc"` inline / `spec { ... }` block form). The parser already treated `##` as plain comments, so annotations using `##` were silently lost during parsing. All 7 affected `.fd` files (2 test fixtures + 5 design docs) migrated.
+- **DOCS**: Updated `REQUIREMENTS.md`, `SKILL.md` to reference `spec` blocks instead of `##`
+
 ### v0.8.4
 
 - **NEW**: Multi-ungroup — selecting 2+ items where some are groups now enables Ungroup, which dissolves all selected groups at once (Figma behavior)

--- a/docs/design/01_format_overview.fd
+++ b/docs/design/01_format_overview.fd
@@ -31,9 +31,11 @@ style tag_chip {
 # ─── Section 1: Node Types (R1.2, R1.13) ────────────────────────────────
 
 group @node_types {
-  ## "All supported node types in FD"
-  ## status: done
-  ## tag: format, core
+  spec {
+    "All supported node types in FD"
+    status: done
+    tag: format, core
+  }
   layout: column gap=24 pad=32
 
   text @sec1_title "Node Types" { font: "Inter" 800 28; fill: #1A1A2E }
@@ -43,7 +45,7 @@ group @node_types {
 
     # Rectangle node
     rect @demo_rect {
-      ## "rect — rectangular shape with fill, stroke, corner"
+      spec "rect — rectangular shape with fill, stroke, corner"
       w: 200 h: 120
       use: card_bg
       stroke: #E8E8EC 1
@@ -59,7 +61,7 @@ group @node_types {
 
     # Ellipse node
     rect @demo_ellipse_card {
-      ## "ellipse — circular/oval shape"
+      spec "ellipse — circular/oval shape"
       w: 200 h: 120
       use: card_bg
       stroke: #E8E8EC 1
@@ -76,7 +78,7 @@ group @node_types {
 
     # Text node
     rect @demo_text_card {
-      ## "text — inline text label with font control"
+      spec "text — inline text label with font control"
       w: 200 h: 120
       use: card_bg
       stroke: #E8E8EC 1
@@ -92,7 +94,7 @@ group @node_types {
 
     # Group node
     rect @demo_group_card {
-      ## "group — container with layout (column/row/grid)"
+      spec "group — container with layout (column/row/grid)"
       w: 200 h: 120
       use: card_bg
       stroke: #E8E8EC 1
@@ -108,8 +110,10 @@ group @node_types {
 
     # Path node
     rect @demo_path_card {
-      ## "path — freeform vector drawing (future)"
-      ## status: draft
+      spec {
+        "path — freeform vector drawing (future)"
+        status: draft
+      }
       w: 200 h: 120
       use: card_bg
       stroke: #E8E8EC 1
@@ -124,7 +128,7 @@ group @node_types {
 
     # Generic node (R1.13)
     rect @demo_generic_card {
-      ## "generic — @id { } without shape keyword"
+      spec "generic — @id { } without shape keyword"
       w: 200 h: 120
       fill: #FFFFFF
       stroke: #6C5CE7 2
@@ -143,11 +147,13 @@ group @node_types {
 # ─── Section 2: Annotations (R1.9) ──────────────────────────────────────
 
 group @annotations_section {
-  ## "Structured metadata via ## syntax"
-  ## status: done
+  spec {
+    "Structured metadata via spec blocks"
+    status: done
+  }
   layout: column gap=16 pad=32
 
-  text @sec2_title "Annotations (##)" { font: "Inter" 800 28; fill: #1A1A2E }
+  text @sec2_title "Annotations (spec)" { font: "Inter" 800 28; fill: #1A1A2E }
 
   group @anno_examples {
     layout: column gap=12 pad=0
@@ -156,35 +162,35 @@ group @annotations_section {
       w: 420 h: 44
       fill: #F8F9FA
       corner: 8
-      text "## \"description text\"" { font: "JetBrains Mono" 400 13; fill: #6C5CE7 }
+      text "spec \"description text\"" { font: "JetBrains Mono" 400 13; fill: #6C5CE7 }
     }
 
     rect @anno_accept {
       w: 420 h: 44
       fill: #F8F9FA
       corner: 8
-      text "## accept: \"validation criterion\"" { font: "JetBrains Mono" 400 13; fill: #10B981 }
+      text "accept: \"validation criterion\"" { font: "JetBrains Mono" 400 13; fill: #10B981 }
     }
 
     rect @anno_status {
       w: 420 h: 44
       fill: #F8F9FA
       corner: 8
-      text "## status: draft | in_progress | done" { font: "JetBrains Mono" 400 13; fill: #F59E0B }
+      text "status: draft | in_progress | done" { font: "JetBrains Mono" 400 13; fill: #F59E0B }
     }
 
     rect @anno_priority {
       w: 420 h: 44
       fill: #F8F9FA
       corner: 8
-      text "## priority: high | medium | low" { font: "JetBrains Mono" 400 13; fill: #EF4444 }
+      text "priority: high | medium | low" { font: "JetBrains Mono" 400 13; fill: #EF4444 }
     }
 
     rect @anno_tag {
       w: 420 h: 44
       fill: #F8F9FA
       corner: 8
-      text "## tag: auth, mvp, a11y" { font: "JetBrains Mono" 400 13; fill: #8B5CF6 }
+      text "tag: auth, mvp, a11y" { font: "JetBrains Mono" 400 13; fill: #8B5CF6 }
     }
   }
 }
@@ -192,8 +198,10 @@ group @annotations_section {
 # ─── Section 3: Animations (R1.5) ───────────────────────────────────────
 
 group @animations_section {
-  ## "Trigger-based property animations"
-  ## status: done
+  spec {
+    "Trigger-based property animations"
+    status: done
+  }
   layout: column gap=16 pad=32
 
   text @sec3_title "Animations" { font: "Inter" 800 28; fill: #1A1A2E }
@@ -231,8 +239,10 @@ group @animations_section {
 # ─── Section 4: Constraints (R1.3) ──────────────────────────────────────
 
 group @constraints_section {
-  ## "Layout via constraints, not coordinates"
-  ## status: done
+  spec {
+    "Layout via constraints, not coordinates"
+    status: done
+  }
   layout: column gap=12 pad=32
 
   text @sec4_title "Constraints" { font: "Inter" 800 28; fill: #1A1A2E }

--- a/docs/design/02_bidi_sync.fd
+++ b/docs/design/02_bidi_sync.fd
@@ -31,7 +31,7 @@ rect @_anon_30 {
 }
 
 group @perf_badges {
-  ## "Non-functional requirements for sync latency"
+  spec "Non-functional requirements for sync latency"
   layout: row gap=16 pad=0
   rect @badge_roundtrip {
     w: 200 h: 48
@@ -63,9 +63,11 @@ group @perf_badges {
 }
 
 rect @canvas {
-  ## "Canvas — GPU-rendered interactive view"
-  ## accept: "R5.1: Vello + wgpu, 60 FPS"
-  ## status: done
+  spec {
+    "Canvas — GPU-rendered interactive view"
+    accept: "R5.1: Vello + wgpu, 60 FPS"
+    status: done
+  }
   w: 260 h: 140
   use: box_orange
   fill: #F59E0B
@@ -92,10 +94,12 @@ rect @canvas {
 }
 
 rect @scene_graph {
-  ## "SceneGraph — single source of truth (DAG)"
-  ## accept: "R2.4: conflict-free single authoritative graph"
-  ## status: done
-  ## priority: high
+  spec {
+    "SceneGraph — single source of truth (DAG)"
+    accept: "R2.4: conflict-free single authoritative graph"
+    status: done
+    priority: high
+  }
   w: 260 h: 140
   use: box_green
   fill: #10B981
@@ -122,10 +126,12 @@ rect @scene_graph {
 }
 
 rect @fd_text {
-  ## "FD Text — the .fd source file"
-  ## accept: "line-oriented, git-friendly diffs"
-  ## status: done
-  ## tag: core
+  spec {
+    "FD Text — the .fd source file"
+    accept: "line-oriented, git-friendly diffs"
+    status: done
+    tag: core
+  }
   w: 260 h: 140
   use: box_primary
   fill: #6C5CE7
@@ -177,8 +183,10 @@ text @title "Bidirectional Sync Architecture" {
 @_anon_29 -> absolute: 694.32, 234.5
 @_anon_30 -> absolute: 694.77, 460.38
 edge @text_to_graph {
-  ## "R2.2: Text → Canvas: source edits re-render in <16ms"
-  ## accept: "incremental re-parse, not full document"
+  spec {
+    "R2.2: Text → Canvas: source edits re-render in <16ms"
+    accept: "incremental re-parse, not full document"
+  }
   from: @fd_text
   to: @scene_graph
   label: "parse()"
@@ -187,7 +195,7 @@ edge @text_to_graph {
   curve: smooth
 }
 edge @graph_to_text {
-  ## "R2.1: Canvas → Text: visual edits update source in <16ms"
+  spec "R2.1: Canvas → Text: visual edits update source in <16ms"
   from: @scene_graph
   to: @fd_text
   label: "emit()"
@@ -196,7 +204,7 @@ edge @graph_to_text {
   curve: smooth
 }
 edge @graph_to_canvas {
-  ## "Layout solver resolves constraints → absolute coords"
+  spec "Layout solver resolves constraints → absolute coords"
   from: @scene_graph
   to: @canvas
   label: "layout() + paint()"
@@ -205,7 +213,7 @@ edge @graph_to_canvas {
   curve: smooth
 }
 edge @canvas_to_graph {
-  ## "User interactions (drag, resize) mutate graph directly"
+  spec "User interactions (drag, resize) mutate graph directly"
   from: @canvas
   to: @scene_graph
   label: "tool events"

--- a/docs/design/03_canvas_tools.fd
+++ b/docs/design/03_canvas_tools.fd
@@ -31,9 +31,11 @@ text @subtitle "R3: Human editing via direct manipulation on GPU canvas" {
 # ─── Tool Palette ────────────────────────────────────────────────────────
 
 group @tool_palette {
-  ## "R3.3: Creation tools with keyboard shortcuts"
-  ## status: done
-  ## tag: canvas, interaction
+  spec {
+    "R3.3: Creation tools with keyboard shortcuts"
+    status: done
+    tag: canvas, interaction
+  }
   layout: column gap=12 pad=24
   bg: #F8F9FA corner=16 shadow=(0,2,12,#0001)
 
@@ -44,8 +46,10 @@ group @tool_palette {
 
     # Select tool
     rect @tool_select {
-      ## "R3.1: Click to select, multi-select, lasso"
-      ## status: done
+      spec {
+        "R3.1: Click to select, multi-select, lasso"
+        status: done
+      }
       w: 260 h: 52
       use: tool_card
       stroke: #6C5CE7 2
@@ -62,7 +66,7 @@ group @tool_palette {
 
     # Rectangle tool
     rect @tool_rect {
-      ## "R3.3: Rectangle creation tool"
+      spec "R3.3: Rectangle creation tool"
       w: 260 h: 52
       use: tool_card
       stroke: #E8E8EC 1
@@ -79,7 +83,7 @@ group @tool_palette {
 
     # Ellipse tool
     rect @tool_ellipse {
-      ## "R3.3: Ellipse/circle creation tool"
+      spec "R3.3: Ellipse/circle creation tool"
       w: 260 h: 52
       use: tool_card
       stroke: #E8E8EC 1
@@ -96,9 +100,11 @@ group @tool_palette {
 
     # Pen tool
     rect @tool_pen {
-      ## "R3.4: Freehand pen with pressure sensitivity"
-      ## accept: "Apple Pencil Pro support"
-      ## status: in_progress
+      spec {
+        "R3.4: Freehand pen with pressure sensitivity"
+        accept: "Apple Pencil Pro support"
+        status: in_progress
+      }
       w: 260 h: 52
       use: tool_card
       stroke: #E8E8EC 1
@@ -115,7 +121,7 @@ group @tool_palette {
 
     # Text tool
     rect @tool_text {
-      ## "R3.3: Text insertion tool"
+      spec "R3.3: Text insertion tool"
       w: 260 h: 52
       use: tool_card
       stroke: #E8E8EC 1
@@ -135,8 +141,10 @@ group @tool_palette {
 # ─── Manipulation capabilities ───────────────────────────────────────────
 
 group @manipulation {
-  ## "R3.2: Drag, resize, rotate with modifiers"
-  ## status: done
+  spec {
+    "R3.2: Drag, resize, rotate with modifiers"
+    status: done
+  }
   layout: column gap=16 pad=24
   bg: #FFF corner=16 shadow=(0,2,12,#0001)
 
@@ -190,8 +198,10 @@ group @manipulation {
 # ─── Canvas controls ────────────────────────────────────────────────────
 
 group @canvas_controls {
-  ## "R3.6: Pan, zoom, grid snap"
-  ## status: done
+  spec {
+    "R3.6: Pan, zoom, grid snap"
+    status: done
+  }
   layout: column gap=12 pad=24
   bg: #FFF corner=16 shadow=(0,2,12,#0001)
 
@@ -226,9 +236,11 @@ group @canvas_controls {
 # ─── Undo/Redo ──────────────────────────────────────────────────────────
 
 group @undo_redo {
-  ## "R3.7: Full command stack across text + canvas"
-  ## status: done
-  ## priority: high
+  spec {
+    "R3.7: Full command stack across text + canvas"
+    status: done
+    priority: high
+  }
   layout: row gap=16 pad=24
   bg: #FFF corner=16 shadow=(0,2,12,#0001)
 

--- a/docs/design/04_architecture.fd
+++ b/docs/design/04_architecture.fd
@@ -31,10 +31,12 @@ text @subtitle "Layered crate architecture — Rust core, WASM bridge, platform 
 # ─── Layer 1: fd-core ────────────────────────────────────────────────────
 
 rect @core {
-  ## "fd-core — data model, parser, emitter, layout solver"
-  ## status: done
-  ## priority: high
-  ## tag: core
+  spec {
+    "fd-core — data model, parser, emitter, layout solver"
+    status: done
+    priority: high
+    tag: core
+  }
   w: 400 h: 180
   use: crate_box
   bg: #1A1A2E corner=16 shadow=(0,4,24,#00000040)
@@ -72,9 +74,11 @@ rect @core {
 # ─── Layer 2: fd-render ──────────────────────────────────────────────────
 
 rect @render {
-  ## "fd-render — GPU 2D renderer + hit testing"
-  ## accept: "R5.1: Vello + wgpu, 60 FPS target"
-  ## status: done
+  spec {
+    "fd-render — GPU 2D renderer + hit testing"
+    accept: "R5.1: Vello + wgpu, 60 FPS target"
+    status: done
+  }
   w: 400 h: 140
   use: crate_box
   bg: #1A1A2E corner=16 shadow=(0,4,24,#00000040)
@@ -106,8 +110,10 @@ rect @render {
 # ─── Layer 3: fd-editor ──────────────────────────────────────────────────
 
 rect @editor {
-  ## "fd-editor — bidi sync, tools, undo/redo"
-  ## status: done
+  spec {
+    "fd-editor — bidi sync, tools, undo/redo"
+    status: done
+  }
   w: 400 h: 140
   use: crate_box
   bg: #1A1A2E corner=16 shadow=(0,4,24,#00000040)
@@ -134,13 +140,17 @@ rect @editor {
 # ─── Layer 4: Platform shells ────────────────────────────────────────────
 
 group @platforms {
-  ## "R6: Platform targets — VS Code now, desktop/mobile/web future"
-  ## tag: platform
+  spec {
+    "R6: Platform targets — VS Code now, desktop/mobile/web future"
+    tag: platform
+  }
   layout: row gap=16 pad=0
 
   rect @vscode {
-    ## "R6.1: VS Code / Cursor IDE custom editor (this repo)"
-    ## status: in_progress
+    spec {
+      "R6.1: VS Code / Cursor IDE custom editor (this repo)"
+      status: in_progress
+    }
     w: 160 h: 100
     fill: #007ACC
     corner: 12
@@ -153,8 +163,10 @@ group @platforms {
   }
 
   rect @desktop {
-    ## "R6.2: Desktop via Tauri (future)"
-    ## status: draft
+    spec {
+      "R6.2: Desktop via Tauri (future)"
+      status: draft
+    }
     w: 140 h: 100
     use: platform_box
     stroke: #E8E8EC 1
@@ -166,8 +178,10 @@ group @platforms {
   }
 
   rect @mobile {
-    ## "R6.3: Mobile iOS/Android (future)"
-    ## status: draft
+    spec {
+      "R6.3: Mobile iOS/Android (future)"
+      status: draft
+    }
     w: 140 h: 100
     use: platform_box
     stroke: #E8E8EC 1
@@ -179,8 +193,10 @@ group @platforms {
   }
 
   rect @webapp {
-    ## "R6.4: Web app (future)"
-    ## status: draft
+    spec {
+      "R6.4: Web app (future)"
+      status: draft
+    }
     w: 140 h: 100
     use: platform_box
     stroke: #E8E8EC 1
@@ -195,7 +211,7 @@ group @platforms {
 # ─── Dependency edges ────────────────────────────────────────────────────
 
 edge @core_to_render {
-  ## "fd-render depends on fd-core for SceneGraph + model types"
+  spec "fd-render depends on fd-core for SceneGraph + model types"
   from: @core
   to: @render
   label: "depends"
@@ -205,7 +221,7 @@ edge @core_to_render {
 }
 
 edge @core_to_editor {
-  ## "fd-editor depends on fd-core for parse/emit"
+  spec "fd-editor depends on fd-core for parse/emit"
   from: @core
   to: @editor
   stroke: #6C5CE7 2
@@ -214,7 +230,7 @@ edge @core_to_editor {
 }
 
 edge @render_to_editor {
-  ## "fd-editor depends on fd-render for canvas output"
+  spec "fd-editor depends on fd-render for canvas output"
   from: @render
   to: @editor
   label: "depends"
@@ -224,7 +240,7 @@ edge @render_to_editor {
 }
 
 edge @editor_to_vscode {
-  ## "fd-vscode wraps fd-editor via WASM bridge"
+  spec "fd-vscode wraps fd-editor via WASM bridge"
   from: @editor
   to: @vscode
   label: "WASM"

--- a/docs/design/05_edge_system.fd
+++ b/docs/design/05_edge_system.fd
@@ -31,7 +31,7 @@ text @sec1_title "Arrow Variants" {
 }
 
 rect @arrow_none_from {
-  ## "Source node for arrow: none"
+  spec "Source node for arrow: none"
   w: 120 h: 64
   use: screen
   fill: #FFFFFF
@@ -168,7 +168,7 @@ text @sec3_title "Flow Animations" {
 }
 
 rect @flow_pulse_src {
-  ## "Data source node"
+  spec "Data source node"
   w: 140 h: 80
   fill: #6C5CE7
   corner: 14
@@ -179,7 +179,7 @@ rect @flow_pulse_src {
 }
 
 rect @flow_pulse_dst {
-  ## "Data destination"
+  spec "Data destination"
   w: 140 h: 80
   fill: #00B894
   corner: 14
@@ -190,7 +190,7 @@ rect @flow_pulse_dst {
 }
 
 rect @flow_dash_src {
-  ## "Pipeline stage 1"
+  spec "Pipeline stage 1"
   w: 140 h: 80
   fill: #F59E0B
   corner: 14
@@ -201,7 +201,7 @@ rect @flow_dash_src {
 }
 
 rect @flow_dash_dst {
-  ## "Pipeline stage 2"
+  spec "Pipeline stage 2"
   w: 140 h: 80
   fill: #EF4444
   corner: 14
@@ -217,8 +217,10 @@ text @sec4_title "Annotated Edge Example" {
 }
 
 rect @login_screen {
-  ## "Login screen"
-  ## status: done
+  spec {
+    "Login screen"
+    status: done
+  }
   w: 160 h: 100
   use: screen
   fill: #FFFFFF
@@ -230,8 +232,10 @@ rect @login_screen {
 }
 
 rect @dashboard_screen {
-  ## "Main dashboard"
-  ## status: in_progress
+  spec {
+    "Main dashboard"
+    status: in_progress
+  }
   w: 160 h: 100
   use: screen
   fill: #FFFFFF
@@ -282,14 +286,14 @@ rect @dashboard_screen {
 @subtitle -> offset: @title 0, 50
 @title -> center_in: canvas
 edge @edge_no_arrow {
-  ## "arrow: none — no arrowheads"
+  spec "arrow: none — no arrowheads"
   from: @arrow_none_from
   to: @arrow_none_to
   label: "none"
   stroke: #6B7280 2
 }
 edge @edge_end_arrow {
-  ## "arrow: end — standard directional arrow"
+  spec "arrow: end — standard directional arrow"
   from: @arrow_end_from
   to: @arrow_end_to
   label: "end →"
@@ -297,7 +301,7 @@ edge @edge_end_arrow {
   arrow: end
 }
 edge @edge_both_arrow {
-  ## "arrow: both — bidirectional relationship"
+  spec "arrow: both — bidirectional relationship"
   from: @arrow_both_from
   to: @arrow_both_to
   label: "← both →"
@@ -305,7 +309,7 @@ edge @edge_both_arrow {
   arrow: both
 }
 edge @edge_straight {
-  ## "curve: straight — direct line (default)"
+  spec "curve: straight — direct line (default)"
   from: @curve_straight_a
   to: @curve_straight_b
   label: "straight"
@@ -313,7 +317,7 @@ edge @edge_straight {
   arrow: end
 }
 edge @edge_smooth {
-  ## "curve: smooth — bezier curve"
+  spec "curve: smooth — bezier curve"
   from: @curve_smooth_a
   to: @curve_smooth_b
   label: "smooth"
@@ -322,7 +326,7 @@ edge @edge_smooth {
   curve: smooth
 }
 edge @edge_step {
-  ## "curve: step — right-angle routing"
+  spec "curve: step — right-angle routing"
   from: @curve_step_a
   to: @curve_step_b
   label: "step"
@@ -331,8 +335,10 @@ edge @edge_step {
   curve: step
 }
 edge @edge_pulse_flow {
-  ## "R1.12: flow: pulse — traveling dot showing data direction"
-  ## accept: "dot moves from source to destination on loop"
+  spec {
+    "R1.12: flow: pulse — traveling dot showing data direction"
+    accept: "dot moves from source to destination on loop"
+  }
   from: @flow_pulse_src
   to: @flow_pulse_dst
   label: "data stream"
@@ -342,8 +348,10 @@ edge @edge_pulse_flow {
   flow: pulse 1200ms
 }
 edge @edge_dash_flow {
-  ## "R1.12: flow: dash — marching dashes for pipeline visualization"
-  ## accept: "dashes animate along edge path continuously"
+  spec {
+    "R1.12: flow: dash — marching dashes for pipeline visualization"
+    accept: "dashes animate along edge path continuously"
+  }
   from: @flow_dash_src
   to: @flow_dash_dst
   label: "pipeline"
@@ -353,12 +361,14 @@ edge @edge_dash_flow {
   flow: dash 800ms
 }
 edge @login_to_dash {
-  ## "Authentication flow — happy path"
-  ## accept: "complete within 3s including API call"
-  ## accept: "show loading spinner during auth"
-  ## status: in_progress
-  ## priority: high
-  ## tag: auth, flow
+  spec {
+    "Authentication flow — happy path"
+    accept: "complete within 3s including API call"
+    accept: "show loading spinner during auth"
+    status: in_progress
+    priority: high
+    tag: auth, flow
+  }
   from: @login_screen
   to: @dashboard_screen
   label: "on success"


### PR DESCRIPTION
## Summary

Remove the legacy `##` annotation syntax from all `.fd` files and documentation, unifying all structured metadata under `spec` blocks.

### Key Finding

The Rust parser already treated `##` lines as plain comments (the `collect_leading_comments` function strips the leading `#` and treats the rest as a comment string). This means **all `##` annotations in `.fd` files were silently lost during parsing** — they never appeared in the `SceneGraph` or survived round-trips.

### Changes

**7 `.fd` files migrated** (`##` → `spec` blocks):
- `crates/fd-core/tests/fixtures/login_form.fd`
- `crates/fd-editor/tests/fixtures/login_form.fd`
- `docs/design/01_format_overview.fd`
- `docs/design/02_bidi_sync.fd`
- `docs/design/03_canvas_tools.fd`
- `docs/design/04_architecture.fd`
- `docs/design/05_edge_system.fd`

**Documentation updated:**
- `REQUIREMENTS.md` — 5 `##` references → `spec` (R1.9, R1.10, R3.14, R4.5, R4.7)
- `.agents/skills/fd-format/SKILL.md` — full rewrite of Annotations section
- `docs/CHANGELOG.md` — v0.8.5 entry added

### Verification

- ✅ `cargo test --workspace` — all tests pass
- ✅ `cargo clippy --workspace -- -D warnings` — clean
- ✅ `cargo fmt --all -- --check` — formatted
- ✅ `pnpm test` — 89 TypeScript tests pass
- ✅ Zero `##` annotations remain in any `.fd` file

### BREAKING CHANGE

`##` annotation syntax is no longer used. Use `spec "description"` (inline) or `spec { ... }` (block form) instead.