### PR TITLE
fix(canvas): inline editor themed bg + live text sync + Esc cancel

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -58,6 +58,8 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.21**: Grid overlay: Toggleable dot/line grid with configurable spacing; shapes snap to grid when enabled
 - **R3.22**: Pressure-sensitive stroke width: Pen tool maps pointer pressure to stroke thickness in real-time (Apple Pencil + Wacom); width range configurable
 - **R3.23**: Freehand shape recognition: After pen stroke completes, detect near-rectangular/elliptical/linear shapes and offer a one-click "Snap to Shape" action — converting freehand to a clean geometric node
+- **R3.28**: Inline text editing: Double-click a text node or shape to open a floating textarea overlay; background matches the node's fill (shape) or uses themed default (text node); live sync — every keystroke updates Code Mode in real-time; Enter confirms, Esc reverts to original value, click-outside commits
+- **R3.29**: Animation drop: Drag a node onto another to assign animations — magnetic glow ring on hover, release opens a glassmorphism Animation Picker popover with preset groups (Hover/Press/Enter), live preview on hover, click to commit `anim` block to Code Mode
 
 ### R4: AI Editing (Text)
 
@@ -146,6 +148,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 | edge               | R1.10, R1.11, R1.12, R4.6, R5.7, R5.8 |
 | import             | R1.14                                 |
 | style              | R1.4, R4.3                            |
-| animation          | R1.5, R1.11, R1.12, R5.6, R5.8        |
+| animation          | R1.5, R1.11, R1.12, R3.29, R5.6, R5.8 |
 | rendering          | R5.1, R5.2, R5.4, R5.5                |
 | platform           | R6.1, R6.2, R6.3, R6.4                |
+| inline editing     | R3.28                                 |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.8
+
+- **UX fix**: Inline editor background now matches node context — shape nodes use their fill color, text nodes use themed background (`#1E1E2E` dark / `#FFFFFF` light), shapes without fill use themed fallback; eliminates the white-over-dark-node bug
+- **NEW**: Live text sync — typing in the inline editor updates Code Mode in real time (every keystroke syncs via `set_node_prop`)
+- **NEW**: Esc to cancel — pressing Escape reverts the text to the original value before editing started and syncs
+- **UX**: Enter confirms and closes the editor (unchanged), click-outside also commits (unchanged)
+
 ### v0.8.7
 
 - **NEW**: Drag-and-drop animation picker — drag a node onto another node to assign animations via a glassmorphism popover with 11 presets across 3 trigger groups (Hover, Press, Enter)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Fix Inline Editor Background + Live Text Sync

### Bug Fix: White Background on Double-Click
- **Text nodes**: Background now uses themed default (`#1E1E2E` dark / `#FFFFFF` light); text color uses the node's fill color
- **Shape nodes**: Background correctly uses the node's fill color with auto-contrast text
- **No-fill shapes**: Falls back to themed default instead of `transparent`

### New: Live Text Sync
- Every keystroke in the inline editor updates Code Mode in real-time
- No more waiting for Enter or blur to see changes in the text editor

### New: Esc Cancel
- Pressing Escape now reverts the text to the original value before editing started
- The reversion is synced to Code Mode immediately

### Docs
- Added **R3.28** (inline text editing) and **R3.29** (animation drop) to `REQUIREMENTS.md`
- Updated `CHANGELOG.md` with v0.8.8 entry
- Updated requirement index with `inline editing` and `animation` tags

### CI
- ✅ clippy clean, fmt clean, all tests pass