### PR TITLE
feat(canvas): 3×3 text alignment system — align: property + grid picker

### DIFF
--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -265,6 +265,21 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
         indent(out, depth + 1);
         writeln!(out, "label: \"{label}\"").unwrap();
     }
+    // Text alignment
+    if node.style.text_align.is_some() || node.style.text_valign.is_some() {
+        let h = match node.style.text_align {
+            Some(TextAlign::Left) => "left",
+            Some(TextAlign::Right) => "right",
+            _ => "center",
+        };
+        let v = match node.style.text_valign {
+            Some(TextVAlign::Top) => "top",
+            Some(TextVAlign::Bottom) => "bottom",
+            _ => "middle",
+        };
+        indent(out, depth + 1);
+        writeln!(out, "align: {h} {v}").unwrap();
+    }
 
     // Children
     let children = graph.children(idx);

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -193,6 +193,24 @@ pub struct Shadow {
 
 // ─── Styling ─────────────────────────────────────────────────────────────
 
+/// Horizontal text alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum TextAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+/// Vertical text alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum TextVAlign {
+    Top,
+    #[default]
+    Middle,
+    Bottom,
+}
+
 /// A reusable style set that nodes can reference via `use: style_name`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Style {
@@ -204,6 +222,10 @@ pub struct Style {
     pub shadow: Option<Shadow>,
     /// Optional label text rendered centered inside the shape (for rect/ellipse).
     pub label: Option<String>,
+    /// Horizontal text alignment (default: Center).
+    pub text_align: Option<TextAlign>,
+    /// Vertical text alignment (default: Middle).
+    pub text_valign: Option<TextVAlign>,
 }
 
 // ─── Animation ───────────────────────────────────────────────────────────
@@ -653,6 +675,12 @@ fn merge_style(dst: &mut Style, src: &Style) {
     }
     if src.label.is_some() {
         dst.label = src.label.clone();
+    }
+    if src.text_align.is_some() {
+        dst.text_align = src.text_align;
+    }
+    if src.text_valign.is_some() {
+        dst.text_valign = src.text_valign;
     }
 }
 

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -265,9 +265,38 @@ fn draw_text(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, content: &str, 
 
     let fill_color = resolve_fill_color(style);
     ctx.set_fill_style_str(&fill_color);
-    ctx.set_text_baseline("top");
 
-    let _ = ctx.fill_text(content, b.x as f64, b.y as f64 + 2.0);
+    // Apply horizontal alignment
+    let halign = style.text_align.unwrap_or(TextAlign::Center);
+    let text_align_str = match halign {
+        TextAlign::Left => "left",
+        TextAlign::Center => "center",
+        TextAlign::Right => "right",
+    };
+    ctx.set_text_align(text_align_str);
+
+    // Apply vertical alignment
+    let valign = style.text_valign.unwrap_or(TextVAlign::Middle);
+    let text_baseline_str = match valign {
+        TextVAlign::Top => "top",
+        TextVAlign::Middle => "middle",
+        TextVAlign::Bottom => "bottom",
+    };
+    ctx.set_text_baseline(text_baseline_str);
+
+    // Calculate position based on alignment
+    let x = match halign {
+        TextAlign::Left => b.x as f64,
+        TextAlign::Center => b.x as f64 + b.width as f64 / 2.0,
+        TextAlign::Right => b.x as f64 + b.width as f64,
+    };
+    let y = match valign {
+        TextVAlign::Top => b.y as f64 + 2.0,
+        TextVAlign::Middle => b.y as f64 + b.height as f64 / 2.0,
+        TextVAlign::Bottom => b.y as f64 + b.height as f64 - 2.0,
+    };
+
+    let _ = ctx.fill_text(content, x, y);
 
     ctx.restore();
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ## Completed Requirements
 
+### v0.8.9
+
+- **NEW — R3.28**: 3×3 text alignment system — `align: left|center|right top|middle|bottom` property in `.fd` format
+- **NEW**: Text nodes default to `center middle` alignment (matching Figma) instead of top-left
+- **NEW**: 3×3 alignment grid picker in the properties panel — click a cell to set text alignment, active cell highlighted with accent
+- **NEW**: Inline editor textarea respects node's horizontal text alignment via CSS `text-align`
+- **WASM**: `textAlign`/`textVAlign` exposed in node props and settable via `set_node_prop`
+- **Parser/Emitter**: Full `align:` round-trip support with test
+- **Renderer**: `draw_text` uses 9-position alignment based on `TextAlign × TextVAlign`
+
 ### v0.8.8
 
 - **UX fix**: Inline editor background now matches node context — shape nodes use their fill color, text nodes use themed background (`#1E1E2E` dark / `#FFFFFF` light), shapes without fill use themed fallback; eliminates the white-over-dark-node bug

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1270,6 +1270,47 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       grid-template-columns: 1fr 1fr;
       gap: 5px 8px;
     }
+    /* 3×3 text alignment grid picker */
+    .align-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 26px);
+      grid-template-rows: repeat(3, 26px);
+      gap: 0;
+      border: 1px solid var(--fd-input-border);
+      border-radius: 8px;
+      overflow: hidden;
+      width: fit-content;
+    }
+    .align-cell {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--fd-input-bg);
+      border: none;
+      border-right: 1px solid var(--fd-input-border);
+      border-bottom: 1px solid var(--fd-input-border);
+      cursor: pointer;
+      padding: 0;
+      transition: background 0.12s ease;
+    }
+    .align-cell:nth-child(3n) { border-right: none; }
+    .align-cell:nth-child(n+7) { border-bottom: none; }
+    .align-cell:hover { background: rgba(79,195,247,0.15); }
+    .align-cell.active {
+      background: rgba(79,195,247,0.25);
+    }
+    .align-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--fd-text-secondary);
+      transition: all 0.12s ease;
+    }
+    .align-cell.active .align-dot {
+      background: #4FC3F7;
+      width: 8px;
+      height: 8px;
+    }
     .props-field {
       display: flex;
       flex-direction: column;
@@ -1837,6 +1878,20 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
           <div class="props-section-label">Content</div>
           <div class="props-field full">
             <input type="text" id="prop-text-content" placeholder="Text content">
+          </div>
+        </div>
+        <div class="props-section" id="props-align-section" style="display:none">
+          <div class="props-section-label">Alignment</div>
+          <div class="align-grid" id="align-grid">
+            <button class="align-cell" data-h="left"   data-v="top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
           </div>
         </div>
         <div class="props-section" id="props-label-section" style="display:none">

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -181,6 +181,7 @@ async function main() {
     setupContextMenu();
     setupPropertiesPanel();
     setupInlineEditor();
+    setupAlignGrid();
     setupDragAndDrop();
     setupAnimPicker();
     setupHelpButton();
@@ -1375,6 +1376,22 @@ function updatePropertiesPanel() {
     if (labelSection) labelSection.style.display = "none";
   }
 
+  // Alignment grid — show for text/rect/ellipse nodes
+  const alignSection = document.getElementById("props-align-section");
+  if (alignSection) {
+    const showAlign = props.kind === "text" || props.kind === "rect" || props.kind === "ellipse";
+    alignSection.style.display = showAlign ? "" : "none";
+    if (showAlign) {
+      const h = props.textAlign || "center";
+      const v = props.textVAlign || "middle";
+      document.querySelectorAll(".align-cell").forEach(cell => {
+        const cellH = cell.dataset.h;
+        const cellV = cell.dataset.v;
+        cell.classList.toggle("active", cellH === h && cellV === v);
+      });
+    }
+  }
+
   // Show/hide appearance section based on kind
   const appearance = document.getElementById("props-appearance");
   if (appearance) {
@@ -1382,6 +1399,24 @@ function updatePropertiesPanel() {
   }
 
   propsSuppressSync = false;
+}
+
+// ─── Alignment Grid Picker ─────────────────────────────────────────────────
+
+function setupAlignGrid() {
+  const grid = document.getElementById("align-grid");
+  if (!grid) return;
+  grid.addEventListener("click", (e) => {
+    const cell = e.target.closest(".align-cell");
+    if (!cell || !fdCanvas) return;
+    const h = cell.dataset.h;
+    const v = cell.dataset.v;
+    fdCanvas.set_node_prop("textAlign", h);
+    fdCanvas.set_node_prop("textVAlign", v);
+    render();
+    syncTextToExtension();
+    updatePropertiesPanel();
+  });
 }
 
 // ─── Inline Text Editor ────────────────────────────────────────────────────
@@ -1509,6 +1544,9 @@ function openInlineEditor(nodeId, propKey, currentValue) {
   const fontFamily = props.fontFamily || "Inter";
   const fontWeight = props.fontWeight || 400;
 
+  // Get text alignment (default: center/middle)
+  const hAlign = props.textAlign || "center";
+
   // Store original value for Esc rollback
   const originalValue = currentValue;
 
@@ -1532,6 +1570,7 @@ function openInlineEditor(nodeId, propKey, currentValue) {
     `box-shadow:0 2px 8px rgba(0,0,0,0.12)`,
     `line-height:1.4`,
     `overflow:hidden`,
+    `text-align:${hAlign}`,
   ].join(";");
 
   container.appendChild(textarea);


### PR DESCRIPTION
## 3×3 Text Alignment System

### FD Format
- New `align: left|center|right [top|middle|bottom]` property
- Default: `center middle` (matching Figma behavior)
- Short form: `align: center` (horizontal only, vertical defaults to middle)

### Data Model
- `TextAlign` enum: Left, Center (default), Right
- `TextVAlign` enum: Top, Middle (default), Bottom
- Added to `Style` struct with `merge_style` support

### Parser/Emitter
- Full round-trip support for `align:` property
- Works in both `style { }` blocks and inline node properties
- Test: `roundtrip_align` verifies parse → emit → re-parse

### Canvas Renderer
- `draw_text` now uses 9-position alignment (TextAlign × TextVAlign)
- Default center×middle matches shape label behavior

### WASM API
- `textAlign`/`textVAlign` exposed in `get_selected_node_props`
- Settable via `set_node_prop("textAlign", "left")` etc.

### Properties Panel
- 3×3 dot grid picker with active cell highlighting
- Click a cell to set alignment; syncs to Code Mode

### Inline Editor
- CSS `text-align` applied from node's alignment property

### CI
- ✅ clippy clean, fmt clean, 18 tests pass