### PR TITLE
fix(canvas): cap zoom-to-fit at 200%, bump v0.8.10

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.10
+
+- **UX**: Zoom-to-fit now caps at 200% — small designs (single icon, one button) no longer blow up to 1000% on initial load or ⌘0; large designs still zoom out to fit as before
+
 ### v0.8.9
 
 - **NEW — R3.28**: 3×3 text alignment system — `align: left|center|right top|middle|bottom` property in `.fd` format

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary\n\nCaps `zoomToFit()` at 200% max zoom so small designs (single icon, one button) don't blow up to 1000% on initial load or ⌘0. Large designs still zoom out to fit as before.\n\n## Changes\n\n- **fd-vscode/package.json**: Bump version `0.8.9` → `0.8.10`\n- **docs/CHANGELOG.md**: Add v0.8.10 entry\n\nNote: The actual `main.js` code change (`FIT_ZOOM_MAX = 2.0`) was included in PR #135.\n\n## Testing\n\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace` (14 passed, 0 failed)"