### PR TITLE
refactor(core): rename Constraint::Absolute → Position + symmetric x:/y: emit

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -180,6 +180,16 @@ Easing: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `spring`
 @node_id -> fill_parent: 16
 ```
 
+Nodes can also use inline `x:` / `y:` for parent-relative positioning (e.g. after drag):
+
+```
+rect @box {
+  x: 100
+  y: 200
+  w: 50 h: 50
+}
+```
+
 ### Annotations (spec)
 
 Structured metadata attached to nodes and edges via `spec` blocks. Unlike `#` comments (which are discarded), annotations are parsed, stored on the scene graph, and survive round-trips.
@@ -187,25 +197,29 @@ Structured metadata attached to nodes and edges via `spec` blocks. Unlike `#` co
 **Inline form** (single description):
 
 ```
+
 rect @login_btn {
-  spec "Primary CTA — triggers login API call"
-  w: 280 h: 48
+spec "Primary CTA — triggers login API call"
+w: 280 h: 48
 }
+
 ```
 
 **Block form** (multiple annotations):
 
 ```
+
 rect @login_btn {
-  spec {
-    "Primary CTA — triggers login API call"
-    accept: "disabled state when fields empty"
-    status: in_progress
-    priority: high
-    tag: auth, mvp
-  }
-  w: 280 h: 48
+spec {
+"Primary CTA — triggers login API call"
+accept: "disabled state when fields empty"
+status: in_progress
+priority: high
+tag: auth, mvp
 }
+w: 280 h: 48
+}
+
 ```
 
 | Syntax            | Kind        | Purpose                        |
@@ -222,7 +236,7 @@ rect @login_btn {
 > Research shows semantic naming has 2× more impact on AI accuracy than any other factor.
 
 1. **Semantic IDs** — `@login_form` not `@rect_17`; the #1 factor for AI comprehension
-2. **Constraints over coords** — `center_in: canvas` tells agents _why_, not just _where_; LLMs reason better with relationships than absolute positions
+2. **Constraints over coords** — `center_in: canvas` tells agents _why_, not just _where_; LLMs reason better with relationships than absolute positions. Inline `x:` / `y:` is the acceptable escape hatch for pinned/drag-placed nodes.
 3. **Accurate comments** — `#` lines help, but wrong comments actively hurt AI; keep them correct or remove them
 4. **Spec blocks** — `spec { status: in_progress }` gives AI structured metadata it can reliably parse, unlike freeform comments
 5. **Style reuse** — `use:` references enforce consistency; consistent codebases produce better AI-generated code
@@ -231,26 +245,28 @@ rect @login_btn {
 ## Example: Complete Card
 
 ```
+
 style body { font: "Inter" 14; fill: #333 }
 style accent { fill: #6C5CE7 }
 
 group @card {
-  layout: column gap=12 pad=20
-  bg: #FFF corner=8 shadow=(0,2,8,#0001)
+layout: column gap=12 pad=20
+bg: #FFF corner=8 shadow=(0,2,8,#0001)
 
-  text @heading "Dashboard" { font: "Inter" 600 20; fill: #111 }
-  text @desc "Overview of metrics" { use: body }
+text @heading "Dashboard" { font: "Inter" 600 20; fill: #111 }
+text @desc "Overview of metrics" { use: body }
 
-  rect @cta {
-    w: 180 h: 40
-    corner: 8
-    use: accent
-    text "View Details" { font: "Inter" 500 14; fill: #FFF }
-    anim :hover { scale: 1.03; ease: spring 200ms }
-  }
+rect @cta {
+w: 180 h: 40
+corner: 8
+use: accent
+text "View Details" { font: "Inter" 500 14; fill: #FFF }
+anim :hover { scale: 1.03; ease: spring 200ms }
+}
 }
 
 @card -> center_in: canvas
+
 ```
 
 ## Crate Locations
@@ -259,3 +275,7 @@ group @card {
 - Emitter: `crates/fd-core/src/emitter.rs`
 - Data model: `crates/fd-core/src/model.rs`
 - Layout solver: `crates/fd-core/src/layout.rs`
+
+```
+
+```

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -189,7 +189,7 @@ fn resolve_children(
             let mut rel_x = 0.0;
             let mut rel_y = 0.0;
             for c in &child_node.constraints {
-                if let Constraint::Absolute { x, y } = c {
+                if let Constraint::Position { x, y } = c {
                     rel_x = *x;
                     rel_y = *y;
                 }
@@ -310,7 +310,7 @@ fn apply_constraint(
                 );
             }
         }
-        Constraint::Absolute { x, y } => {
+        Constraint::Position { x, y } => {
             let (px, py) = match graph.parent(node_idx).and_then(|p| bounds.get(&p)) {
                 Some(p_bounds) => (p_bounds.x, p_bounds.y),
                 None => (0.0, 0.0),

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -3,7 +3,8 @@
 //! The document is a DAG (Directed Acyclic Graph) where nodes represent
 //! visual elements (shapes, text, groups) and edges represent parent→child
 //! containment. Styles and animations are attached to nodes. Layout is
-//! constraint-based — no absolute coordinates are stored in the format.
+//! constraint-based — relationships are preferred over raw positions.
+//! `Position { x, y }` is the escape hatch for drag-placed or pinned nodes.
 
 use crate::id::NodeId;
 use petgraph::graph::{DiGraph, NodeIndex};
@@ -309,8 +310,9 @@ pub enum Constraint {
     Offset { from: NodeId, dx: f32, dy: f32 },
     /// Fill the parent with optional padding.
     FillParent { pad: f32 },
-    /// Explicit position (only used after layout resolution or for pinning).
-    Absolute { x: f32, y: f32 },
+    /// Parent-relative position (used for drag-placed or pinned nodes).
+    /// Resolved as `parent.x + x`, `parent.y + y` by the layout solver.
+    Position { x: f32, y: f32 },
 }
 
 // ─── Edges (connections between nodes) ───────────────────────────────────

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -621,25 +621,25 @@ fn parse_node_property(
     match prop_name {
         "x" => {
             let x_val = parse_number.parse_next(input)?;
-            // Replace existing Absolute constraint if present, else push new
-            if let Some(Constraint::Absolute { x, .. }) = constraints
+            // Replace existing Position constraint if present, else push new
+            if let Some(Constraint::Position { x, .. }) = constraints
                 .iter_mut()
-                .find(|c| matches!(c, Constraint::Absolute { .. }))
+                .find(|c| matches!(c, Constraint::Position { .. }))
             {
                 *x = x_val;
             } else {
-                constraints.push(Constraint::Absolute { x: x_val, y: 0.0 });
+                constraints.push(Constraint::Position { x: x_val, y: 0.0 });
             }
         }
         "y" => {
             let y_val = parse_number.parse_next(input)?;
-            if let Some(Constraint::Absolute { y, .. }) = constraints
+            if let Some(Constraint::Position { y, .. }) = constraints
                 .iter_mut()
-                .find(|c| matches!(c, Constraint::Absolute { .. }))
+                .find(|c| matches!(c, Constraint::Position { .. }))
             {
                 *y = y_val;
             } else {
-                constraints.push(Constraint::Absolute { x: 0.0, y: y_val });
+                constraints.push(Constraint::Position { x: 0.0, y: y_val });
             }
         }
         "w" | "width" => {
@@ -1074,17 +1074,17 @@ fn parse_constraint_line(input: &mut &str) -> ModalResult<(NodeId, Constraint)> 
             let pad = opt(parse_number).parse_next(input)?.unwrap_or(0.0);
             Constraint::FillParent { pad }
         }
-        "absolute" => {
+        "absolute" | "position" => {
             let x = parse_number.parse_next(input)?;
             skip_space(input);
             let _ = ','.parse_next(input)?;
             skip_space(input);
             let y = parse_number.parse_next(input)?;
-            Constraint::Absolute { x, y }
+            Constraint::Position { x, y }
         }
         _ => {
             let _ = take_till::<_, _, ContextError>(0.., '\n').parse_next(input);
-            Constraint::Absolute { x: 0.0, y: 0.0 }
+            Constraint::Position { x: 0.0, y: 0.0 }
         }
     };
 

--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -321,7 +321,8 @@ rect @b2 {
         let text = engine.current_text();
         assert!(!text.contains("group @my_group"));
         assert!(text.contains("rect @b1"));
-        assert!(text.contains("-> absolute: 10, 10"));
+        assert!(text.contains("x: 10"), "should contain inline x position");
+        assert!(text.contains("y: 10"), "should contain inline y position");
     }
 
     #[test]

--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -362,7 +362,7 @@ impl Tool for RectTool {
                         height: 0.0,
                     },
                 );
-                node.constraints.push(Constraint::Absolute { x: *x, y: *y });
+                node.constraints.push(Constraint::Position { x: *x, y: *y });
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),
@@ -635,7 +635,7 @@ impl Tool for EllipseTool {
                 self.current_id = Some(id);
 
                 let mut node = SceneNode::new(id, NodeKind::Ellipse { rx: 0.0, ry: 0.0 });
-                node.constraints.push(Constraint::Absolute { x: *x, y: *y });
+                node.constraints.push(Constraint::Position { x: *x, y: *y });
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),
@@ -746,7 +746,7 @@ impl Tool for TextTool {
                         content: "Text".to_string(),
                     },
                 );
-                node.constraints.push(Constraint::Absolute { x: *x, y: *y });
+                node.constraints.push(Constraint::Position { x: *x, y: *y });
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),
@@ -1107,11 +1107,11 @@ mod tests {
                     }
                     _ => panic!("expected Text node"),
                 }
-                // Should have an Absolute constraint for positioning
+                // Should have a Position constraint for positioning
                 assert!(
                     node.constraints
                         .iter()
-                        .any(|c| matches!(c, Constraint::Absolute { .. }))
+                        .any(|c| matches!(c, Constraint::Position { .. }))
                 );
             }
             _ => panic!("expected AddNode"),

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -1112,7 +1112,7 @@ impl FdCanvas {
             _ => return false,
         };
         let mut node = SceneNode::new(id, node_kind);
-        node.constraints.push(Constraint::Absolute { x, y });
+        node.constraints.push(Constraint::Position { x, y });
 
         // Set a default fill for shapes
         if kind != "text" {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.11
+
+- **REFACTOR**: Renamed `Constraint::Absolute` → `Constraint::Position` — clarifies parent-relative semantics (was misleadingly named "absolute")
+- **UX**: Emitter now outputs `x:` / `y:` inline instead of top-level `@id -> absolute:` arrows — saves ~4 tokens per positioned node, symmetric round-trip with parser
+- **COMPAT**: Parser accepts both `absolute` and `position` keywords in constraint arrows for backwards compatibility
+- **Tests**: New `roundtrip_inline_position` test verifying symmetric `x:/y:` parse↔emit
+
 ### v0.8.10
 
 - **UX**: Zoom-to-fit now caps at 200% — small designs (single icon, one button) no longer blow up to 1000% on initial load or ⌘0; large designs still zoom out to fit as before
@@ -125,7 +132,7 @@
 
 ### v0.7.3
 
-- **R1.1 fix**: Fixed node/edge drag jitter and reverse-direction movement — `MoveNode` now correctly converts absolute screen coords to parent-relative before storing in `Constraint::Absolute`, and strips conflicting positioning constraints (`CenterIn`, `Offset`, `FillParent`). Skips full layout re-resolve for move-only batches to prevent constraint values from overwriting in-place bounds updates.
+- **R1.1 fix**: Fixed node/edge drag jitter and reverse-direction movement — `MoveNode` now correctly converts absolute screen coords to parent-relative before storing in `Constraint::Position`, and strips conflicting positioning constraints (`CenterIn`, `Offset`, `FillParent`). Skips full layout re-resolve for move-only batches to prevent constraint values from overwriting in-place bounds updates.
 
 ### v0.7.0 (**BREAKING**)
 


### PR DESCRIPTION
## Summary

Rename the misleading `Constraint::Absolute` to `Constraint::Position` (it's actually parent-relative), and make the emitter output `x: / y:` inline inside node blocks instead of top-level `@id -> absolute: x, y` arrows.

### Changes

- **Rename `Constraint::Absolute` → `Constraint::Position`** across all 7 files (model, parser, emitter, layout, sync, tools, wasm)
- **Symmetric emit**: `x:/y:` now emitted inline in node blocks instead of as top-level arrows (~4 tokens saved per positioned node)
- **Backwards compat**: Parser accepts both `absolute` and `position` keywords in constraint arrows
- **New test**: `roundtrip_inline_position` verifies symmetric parse↔emit for inline coordinates
- **Updated docs**: CHANGELOG v0.8.11, SKILL.md inline position syntax, all code comments

### Verification

- ✅ `cargo check --workspace`
- ✅ `cargo test --workspace` (37 tests pass)
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`