### PR TITLE
feat(ai): add Open Settings button to AI Refine error messages

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.15
+
+- **UX**: AI Refine error messages now include an **"Open Settings"** action button — clicking it opens VS Code settings filtered to `fd.ai` for quick API key configuration or provider switching
+- **UX**: Error messages are now provider-agnostic — each warns which key is missing and reminds users they can switch to any of the 5 supported providers (Gemini, OpenAI, Anthropic, Ollama, OpenRouter)
+
 ### v0.8.14
 
 - **BUG FIX**: Layer selection now works — click handler pre-sets `lastLayerHash` before calling `render()`, so `refreshLayersPanel()` skips DOM rebuild and preserves the click handler's DOM references for visual highlight update

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -21,191 +21,24 @@ style dark_text {
   font: "Inter" 400 14
 }
 
+ellipse @_anon_1 {
+  w: 50 h: 40
+  fill: #CCCCD9
+  x: -64.9
+  y: 1207.21
+}
+
+rect @_anon_0 {
+  w: 118.35 h: 32.5
+  fill: #000000
+  corner: 0
+  label: "gaga"
+  x: -75.41
+  y: 934.47
+}
+
 group @settings {
   layout: column gap=20 pad=28
-  group @header {
-    layout: row gap=0 pad=0
-    text @title "Settings" {
-      fill: #FFFFFF
-      font: "Inter" 700 24
-    }
-    rect @close_btn {
-      w: 36 h: 36
-      fill: #2D2D44
-      corner: 18
-      text @_anon_25 "×" {
-        fill: #999999
-        font: "Inter" 400 20
-      }
-      anim :hover {
-        fill: #3D3D5C
-        ease: ease_out 150ms
-      }
-    }
-  }
-  rect @profile_card {
-    w: 344 h: 80
-    use: dark_card
-    group @_anon_26 {
-      layout: row gap=14 pad=16
-      ellipse @user_avatar {
-        spec "User profile photo"
-        w: 48 h: 48
-        fill: #6C5CE7
-      }
-      group @_anon_27 {
-        layout: column gap=4 pad=0
-        text @_anon_28 "Khang Nghiem" {
-          fill: #FFFFFF
-          font: "Inter" 600 16
-        }
-        text @_anon_29 "khang@fastdraft.io" {
-          use: dark_muted
-        }
-      }
-    }
-  }
-  text @_anon_30 "Preferences" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @toggle_dark {
-    w: 344 h: 56
-    use: dark_card
-    group @_anon_31 {
-      layout: row gap=0 pad=16
-      group @_anon_32 {
-        layout: column gap=2 pad=0
-        text @_anon_33 "Dark Mode" {
-          use: dark_text
-        }
-        text @_anon_34 "Use dark theme across the app" {
-          use: dark_muted
-        }
-      }
-      rect @switch_on {
-        spec "Toggle — ON state"
-        w: 44 h: 24
-        fill: #6C5CE7
-        corner: 12
-        ellipse @switch_knob {
-          w: 20 h: 20
-          fill: #FFFFFF
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_notif {
-    w: 344 h: 56
-    use: dark_card
-    group @_anon_35 {
-      layout: row gap=0 pad=16
-      group @_anon_36 {
-        layout: column gap=2 pad=0
-        text @_anon_37 "Notifications" {
-          use: dark_text
-        }
-        text @_anon_38 "Push and email alerts" {
-          use: dark_muted
-        }
-      }
-      rect @switch_off {
-        spec "Toggle — OFF state"
-        w: 44 h: 24
-        fill: #3D3D5C
-        corner: 12
-        ellipse @switch_knob_off {
-          w: 20 h: 20
-          fill: #6B7280
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_sound {
-    w: 344 h: 56
-    use: dark_card
-    group @_anon_39 {
-      layout: row gap=0 pad=16
-      group @_anon_40 {
-        layout: column gap=2 pad=0
-        text @_anon_41 "Sound Effects" {
-          use: dark_text
-        }
-        text @_anon_42 "UI interaction sounds" {
-          use: dark_muted
-        }
-      }
-      rect @switch_sound {
-        w: 44 h: 24
-        fill: #6C5CE7
-        corner: 12
-        ellipse @switch_knob_s {
-          w: 20 h: 20
-          fill: #FFFFFF
-          label: "ehe"
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  text @_anon_43 "Display" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @slider_card {
-    w: 344 h: 72
-    use: dark_card
-    fill: #2D2D44
-    corner: 12
-    label: "gaga"
-    group @_anon_44 {
-      layout: column gap=8 pad=16
-      text @_anon_45 "Canvas Zoom" {
-        use: dark_text
-      }
-      group @_anon_46 {
-        layout: row gap=0 pad=0
-        rect @slider_track {
-          w: 260 h: 4
-          fill: #3D3D5C
-          corner: 2
-          rect @slider_fill {
-            w: 160 h: 4
-            fill: #6C5CE7
-            corner: 2
-          }
-          ellipse @slider_thumb {
-            spec "Draggable thumb"
-            w: 16 h: 16
-            fill: #FFFFFF
-            anim :press {
-              scale: 1.3
-              ease: spring 200ms
-            }
-          }
-        }
-        text @_anon_47 "75%" {
-          fill: #A29BFE
-          font: "Inter" 600 13
-        }
-      }
-    }
-  }
-  text @_anon_48 "Danger Zone" {
-    fill: #E17055
-    font: "Inter" 600 13
-  }
   rect @btn_delete {
     spec {
       "Destructive action — delete account"
@@ -216,6 +49,8 @@ group @settings {
     fill: #E1705520
     stroke: #E17055 1
     corner: 10
+    x: 635.39
+    y: 633.41
     text @_anon_49 "Delete Account" {
       fill: #E17055
       font: "Inter" 600 14
@@ -229,23 +64,219 @@ group @settings {
       ease: ease_out 100ms
     }
   }
+  text @_anon_48 "Danger Zone" {
+    fill: #E17055
+    font: "Inter" 600 13
+  }
+  rect @slider_card {
+    w: 344 h: 72
+    use: dark_card
+    fill: #2D2D44
+    corner: 12
+    label: "gaga"
+    x: 353.91
+    y: 189.09
+    group @_anon_44 {
+      layout: column gap=8 pad=16
+      x: -3117.15
+      y: -10280.47
+      group @_anon_46 {
+        layout: row gap=0 pad=0
+        text @_anon_47 "75%" {
+          fill: #A29BFE
+          font: "Inter" 600 13
+        }
+        rect @slider_track {
+          w: 260 h: 4
+          fill: #3D3D5C
+          corner: 2
+          x: 3401.04
+          y: 11038.97
+          ellipse @slider_thumb {
+            spec "Draggable thumb"
+            w: 16 h: 16
+            fill: #FFFFFF
+            x: -771.99
+            y: -377.34
+            anim :press {
+              scale: 1.3
+              ease: spring 200ms
+            }
+          }
+          rect @slider_fill {
+            w: 160 h: 4
+            fill: #6C5CE7
+            corner: 2
+          }
+        }
+      }
+      text @_anon_45 "Canvas Zoom" {
+        use: dark_text
+      }
+    }
+  }
+  text @_anon_43 "Display" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @toggle_sound {
+    w: 344 h: 56
+    use: dark_card
+    x: 28.51
+    y: 340.51
+    group @_anon_39 {
+      layout: row gap=0 pad=16
+      rect @switch_sound {
+        w: 44 h: 24
+        fill: #6C5CE7
+        corner: 12
+        x: -19.14
+        y: 83.42
+        ellipse @switch_knob_s {
+          w: 20 h: 20
+          fill: #FFFFFF
+          label: "ehe"
+          x: -146.24
+          y: 32.3
+        }
+      }
+      group @_anon_40 {
+        layout: column gap=2 pad=0
+        text @_anon_42 "UI interaction sounds" {
+          use: dark_muted
+        }
+        text @_anon_41 "Sound Effects" {
+          use: dark_text
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_notif {
+    w: 344 h: 56
+    use: dark_card
+    x: 376.84
+    y: 708.79
+    group @_anon_35 {
+      layout: row gap=0 pad=16
+      rect @switch_off {
+        spec "Toggle — OFF state"
+        w: 44 h: 24
+        fill: #3D3D5C
+        corner: 12
+        ellipse @switch_knob_off {
+          w: 20 h: 20
+          fill: #6B7280
+        }
+      }
+      group @_anon_36 {
+        layout: column gap=2 pad=0
+        text @_anon_38 "Push and email alerts" {
+          use: dark_muted
+        }
+        text @_anon_37 "Notifications" {
+          use: dark_text
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_dark {
+    w: 344 h: 56
+    use: dark_card
+    x: 238.09
+    y: 834.82
+    group @_anon_31 {
+      layout: row gap=0 pad=16
+      x: -280.7
+      y: -1556.15
+      rect @switch_on {
+        spec "Toggle — ON state"
+        w: 44 h: 24
+        fill: #6C5CE7
+        corner: 12
+        ellipse @switch_knob {
+          w: 20 h: 20
+          fill: #FFFFFF
+        }
+      }
+      group @_anon_32 {
+        layout: column gap=2 pad=0
+        x: 44
+        y: 22
+        text @_anon_34 "Use dark theme across the app" {
+          use: dark_muted
+          x: 3129.49
+          y: 15512.29
+        }
+        text @_anon_33 "Dark Mode" {
+          use: dark_text
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  text @_anon_30 "Preferences" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @profile_card {
+    w: 344 h: 80
+    use: dark_card
+    x: 30.12
+    y: 527.12
+    group @_anon_26 {
+      layout: row gap=14 pad=16
+      group @_anon_27 {
+        layout: column gap=4 pad=0
+        text @_anon_29 "khang@fastdraft.io" {
+          use: dark_muted
+          x: 159.45
+          y: 287.16
+        }
+        text @_anon_28 "Khang Nghiem" {
+          fill: #FFFFFF
+          font: "Inter" 600 16
+        }
+      }
+      ellipse @user_avatar {
+        spec "User profile photo"
+        w: 48 h: 48
+        fill: #6C5CE7
+        x: 178.49
+        y: -630.04
+      }
+    }
+  }
+  group @header {
+    layout: row gap=0 pad=0
+    rect @close_btn {
+      w: 36 h: 36
+      fill: #2D2D44
+      corner: 18
+      text @_anon_25 "×" {
+        fill: #999999
+        font: "Inter" 400 20
+      }
+      anim :hover {
+        fill: #3D3D5C
+        ease: ease_out 150ms
+      }
+    }
+    text @title "Settings" {
+      fill: #FFFFFF
+      font: "Inter" 700 24
+    }
+  }
 }
 
 @settings -> center_in: canvas
-@btn_delete -> absolute: 635.39, 633.41
-@slider_card -> absolute: 353.91, 189.09
-@_anon_44 -> absolute: -3117.15, -10280.47
-@_anon_46 -> absolute: 0, 0
-@slider_track -> absolute: 3401.04, 11038.97
-@slider_thumb -> absolute: -771.99, -377.34
-@toggle_sound -> absolute: 28.51, 340.51
-@switch_sound -> absolute: -19.14, 83.42
-@switch_knob_s -> absolute: -146.24, 32.3
-@toggle_notif -> absolute: 376.84, 708.79
-@toggle_dark -> absolute: 238.09, 834.82
-@_anon_31 -> absolute: -414.78, -1405.56
-@_anon_32 -> absolute: 44, 22
-@_anon_34 -> absolute: 3129.49, 15512.29
-@profile_card -> absolute: 30.12, 527.12
-@_anon_29 -> absolute: 159.45, 287.16
-@user_avatar -> absolute: 178.49, -630.04

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/ai-refine.ts
+++ b/fd-vscode/src/ai-refine.ts
@@ -26,6 +26,8 @@ interface AiConfig {
 interface RefineResult {
   refinedText: string;
   error?: string;
+  /** When true, the caller should offer an "Open Settings" action. */
+  needsSettings?: boolean;
 }
 
 // ─── Configuration ───────────────────────────────────────────────────────
@@ -316,7 +318,8 @@ export async function refineSelectedNodes(
           return {
             refinedText: fdText,
             error:
-              "Gemini API key not configured. Get a FREE key at https://aistudio.google.com/ and set 'fd.ai.geminiApiKey' in settings.",
+              "Gemini API key not configured. Get a FREE key at aistudio.google.com and set 'fd.ai.geminiApiKey' in Settings. (You can also switch to OpenAI, Anthropic, Ollama, or OpenRouter.)",
+            needsSettings: true,
           };
         }
         refined = await callGemini(prompt, config.apiKey, config.model);
@@ -326,7 +329,9 @@ export async function refineSelectedNodes(
         if (!config.apiKey) {
           return {
             refinedText: fdText,
-            error: "OpenAI API key not configured. Set 'fd.ai.openaiApiKey' in settings.",
+            error:
+              "OpenAI API key not configured. Set 'fd.ai.openaiApiKey' in Settings. (You can also switch to Gemini, Anthropic, Ollama, or OpenRouter.)",
+            needsSettings: true,
           };
         }
         refined = await callOpenAi(prompt, config.apiKey, config.model);
@@ -336,7 +341,9 @@ export async function refineSelectedNodes(
         if (!config.apiKey) {
           return {
             refinedText: fdText,
-            error: "Anthropic API key not configured. Set 'fd.ai.anthropicApiKey' in settings.",
+            error:
+              "Anthropic API key not configured. Set 'fd.ai.anthropicApiKey' in Settings. (You can also switch to Gemini, OpenAI, Ollama, or OpenRouter.)",
+            needsSettings: true,
           };
         }
         refined = await callAnthropic(prompt, config.apiKey, config.model);
@@ -351,7 +358,8 @@ export async function refineSelectedNodes(
           return {
             refinedText: fdText,
             error:
-              "OpenRouter API key not configured. Get one at https://openrouter.ai/ and set 'fd.ai.openrouterApiKey' in settings.",
+              "OpenRouter API key not configured. Get one at openrouter.ai and set 'fd.ai.openrouterApiKey' in Settings. (You can also switch to Gemini, OpenAI, Anthropic, or Ollama.)",
+            needsSettings: true,
           };
         }
         refined = await callOpenRouter(prompt, config.apiKey, config.model);

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -241,7 +241,14 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     const result = await refineSelectedNodes(document.getText(), nodeIds);
 
     if (result.error) {
-      vscode.window.showWarningMessage(`AI Refine: ${result.error}`);
+      const action = result.needsSettings ? "Open Settings" : undefined;
+      const chosen = await vscode.window.showWarningMessage(
+        `AI Refine: ${result.error}`,
+        ...(action ? [action] : [])
+      );
+      if (chosen === "Open Settings") {
+        vscode.commands.executeCommand("workbench.action.openSettings", "fd.ai");
+      }
       webviewPanel.webview.postMessage({
         type: "aiRefineComplete",
         error: result.error,
@@ -3374,7 +3381,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
       const result = await refineSelectedNodes(editor.document.getText(), nodeIds);
       if (result.error) {
-        vscode.window.showWarningMessage(`AI Refine: ${result.error}`);
+        const action = result.needsSettings ? "Open Settings" : undefined;
+        const chosen = await vscode.window.showWarningMessage(
+          `AI Refine: ${result.error}`,
+          ...(action ? [action] : [])
+        );
+        if (chosen === "Open Settings") {
+          vscode.commands.executeCommand("workbench.action.openSettings", "fd.ai");
+        }
         return;
       }
       const edit = new vscode.WorkspaceEdit();
@@ -3407,7 +3421,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
       const result = await refineSelectedNodes(editor.document.getText(), nodeIds);
       if (result.error) {
-        vscode.window.showWarningMessage(`AI Refine: ${result.error}`);
+        const action = result.needsSettings ? "Open Settings" : undefined;
+        const chosen = await vscode.window.showWarningMessage(
+          `AI Refine: ${result.error}`,
+          ...(action ? [action] : [])
+        );
+        if (chosen === "Open Settings") {
+          vscode.commands.executeCommand("workbench.action.openSettings", "fd.ai");
+        }
         return;
       }
       const edit = new vscode.WorkspaceEdit();


### PR DESCRIPTION
## Summary\n\nImproves AI Refine error UX with two changes:\n\n1. **Open Settings button** — error messages now include an \"Open Settings\" action button that opens VS Code settings filtered to `fd.ai` for quick API key configuration\n2. **Provider-agnostic messages** — each error mentions the specific missing key and reminds users they can switch to any of the 5 supported providers (Gemini, OpenAI, Anthropic, Ollama, OpenRouter)\n\n## Changes\n\n- `ai-refine.ts`: Added `needsSettings` flag to `RefineResult` interface; updated all 4 provider error messages to be provider-agnostic\n- `extension.ts`: Updated all 3 error handlers (`handleAiRefine`, `fd.aiRefine`, `fd.aiRefineAll`) to show \"Open Settings\" action button when `needsSettings` is true\n- Synced to `zed-extensions/` copy\n- Bumped version to 0.8.15\n\n## Verification\n\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace`\n- ✅ `pnpm test` (89/89 tests pass)"