### PR TITLE
fix(canvas): layer rename now syncs to Code Mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.17
+
+- **BUG FIX**: Layer rename now syncs to Code Mode — added a `committed` guard flag to prevent double invocation of the `commit()` closure (Enter removes the input from DOM, triggering blur's `setTimeout(commit, 100)` which could race and skip `syncTextToExtension()`); also checks `set_text()` return value so parse errors don't silently swallow the rename
+
 ### v0.8.16
 
 - **UX**: Resize handle cursor feedback — hovering over the 8 resize handles now shows the appropriate directional cursor (`nwse-resize`, `nesw-resize`, `ns-resize`, `ew-resize`) instead of the default pointer, matching Figma/Sketch behavior

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -2675,7 +2675,10 @@ function refreshLayersPanel() {
       input.focus();
       input.select();
 
+      let committed = false;
       const commit = () => {
+        if (committed) return;
+        committed = true;
         const newId = input.value.trim().replace(/[^a-zA-Z0-9_]/g, "_");
         if (input.parentNode) input.parentNode.removeChild(input);
         if (!newId || newId === oldId || !fdCanvas) {
@@ -2689,9 +2692,11 @@ function refreshLayersPanel() {
           `@${newId}`
         );
         if (renamed !== text) {
-          fdCanvas.set_text(renamed);
-          render();
-          syncTextToExtension();
+          const ok = fdCanvas.set_text(renamed);
+          if (ok) {
+            render();
+            syncTextToExtension();
+          }
         }
         refreshLayersPanel();
       };


### PR DESCRIPTION
## Summary\n\nFixes bug where double-clicking a layer name to rename it didn't propagate the new name to Code Mode.\n\n## Root Cause\n\nThe `commit()` closure in the layer rename handler had two issues:\n1. **Double invocation** — Pressing Enter calls `commit()`, which removes the input from DOM, triggering `blur`'s `setTimeout(commit, 100)`. Without a guard, the second call could race and skip `syncTextToExtension()`.\n2. **No error check on `set_text()`** — If the WASM parser rejected the renamed text, the old text silently stayed.\n\n## Fix\n\n- Added `committed` guard flag to prevent double invocation\n- Check `fdCanvas.set_text()` return value before syncing\n\n## Verification\n\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace` (14 passed)\n- ✅ `pnpm test` (89 passed)