### PR TITLE
feat(canvas): smart focus on layer click — pan/zoom to node

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.19
+
+- **NEW**: Smart focus on layer click — clicking a layer item in the Layers panel now smoothly pans the camera to center the node (250ms ease-out animation); auto-zooms in if both dimensions are < 20px on screen (truly invisible), auto-zooms out if the node overflows the viewport (15% padding); skips pan if the node center is already within 20% of the viewport center; thin shapes (lines) are left at current zoom unless they overflow
+
 ### v0.8.18
 
 - **BUG FIX**: Node name no longer disappears after double-click → click outside — inline editor `commit()` now skips `set_node_prop` when value is unchanged, preventing `SetStyle` from flattening inherited styles and `SetText` from triggering unnecessary re-emission

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary\n\nClicking a layer item in the Layers panel now smoothly focuses the camera on the selected node, matching Figma/Sketch behavior.\n\n### Smart Focus Rules\n\n| Scenario | Behavior |\n|---|---|\n| Node center is far from viewport center (>20%) | Smooth pan to center (250ms ease-out) |\n| Node center is already near viewport center | Skip pan — no micro-adjustments |\n| Both dimensions < 20px on screen | Auto-zoom in to 25% of viewport width |\n| Max dimension overflows viewport | Auto-zoom out to fit with 15% padding |\n| Thin shape (e.g. line — small in one dim only) | Keep current zoom unless overflowing |\n| Node comfortably visible | Keep current zoom |\n\n### Changes\n- Added `focusOnNode(nodeId)` in `main.js` with `requestAnimationFrame`-based animation\n- Wired into layer click handler (after selection)\n- Version bumped to 0.8.19\n\n### Verification\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace`\n- ✅ `pnpm test` (89 TS tests passed)