### PR TITLE
docs(workflows): make REQUIREMENTS.md update mandatory alongside CHANGELOG

### DIFF
--- a/.agents/workflows/commit.md
+++ b/.agents/workflows/commit.md
@@ -24,9 +24,13 @@ description: Stage and commit changes to a feature branch (never main)
    git checkout -b feat/<descriptive-name>
    ```
 
-4. **Update docs** (MANDATORY):
+4. **Update docs** (MANDATORY — both files, every time):
    - `docs/CHANGELOG.md` — add entry for each meaningful change
-   - `REQUIREMENTS.md` — update if behavior changed or new feature added (check Requirement Index first)
+   - `REQUIREMENTS.md` — for **every** CHANGELOG entry, check if it introduces, extends, or modifies a requirement:
+     - New feature → add a new `R*.N` entry and update the Requirement Index
+     - Behavior change → update the existing requirement's wording
+     - Bug fix on an existing requirement → no change needed
+     - Search the Requirement Index for overlap before adding new entries
 
 5. Stage all changes:
 

--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -78,9 +78,13 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 8. **Bump Version** (if `fd-vscode/` was changed):
    - Bump the `version` field in `fd-vscode/package.json` appropriately (patch/minor/major).
 
-9. **Update docs** (MANDATORY):
+9. **Update docs** (MANDATORY — both files, every time):
    - `docs/CHANGELOG.md` — add entry under the current version section for each meaningful change
-   - `REQUIREMENTS.md` — update if behavior changed, new feature added, or requirement wording needs refinement (check the Requirement Index for overlap first)
+   - `REQUIREMENTS.md` — for **every** CHANGELOG entry, check if it introduces, extends, or modifies a requirement:
+     - New feature → add a new `R*.N` entry and update the Requirement Index
+     - Behavior change → update the existing requirement's wording
+     - Bug fix on an existing requirement → no change needed (already documented)
+     - Search the Requirement Index for overlap before adding new entries
 
 10. **Stage and commit**:
 


### PR DESCRIPTION
Make `REQUIREMENTS.md` update **mandatory** alongside `CHANGELOG.md` in both `/yolo` and `/commit` workflows.\n\nPreviously the wording was soft ("update if behavior changed"), making it easy to skip. Now each workflow has explicit sub-steps:\n- New feature → add R*.N + update Requirement Index\n- Behavior change → update existing requirement wording\n- Bug fix → no change needed\n- Always search Requirement Index for overlap first