### PR TITLE
fix(canvas): reduce auto-zoom-in aggressiveness for layer focus

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.20
+
+- **UX**: Reduced auto-zoom-in aggressiveness for layer focus (R3.30) — target node now fills ~10% of viewport width instead of 25%, preserving more surrounding context
+
 ### v0.8.19
 
 - **NEW**: Smart focus on layer click — clicking a layer item in the Layers panel now smoothly pans the camera to center the node (250ms ease-out animation); auto-zooms in if both dimensions are < 20px on screen (truly invisible), auto-zooms out if the node overflows the viewport (15% padding); skips pan if the node center is already within 20% of the viewport center; thin shapes (lines) are left at current zoom unless they overflow

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -3344,7 +3344,7 @@ function focusOnNode(nodeId) {
 
   const MIN_VISIBLE_PX = 20;
   const FIT_PADDING_RATIO = 0.15;
-  const FIT_TARGET_RATIO = 0.25;
+  const FIT_TARGET_RATIO = 0.10;
 
   // Auto-zoom in: both dimensions < 20px (truly invisible, not just thin)
   if (screenW < MIN_VISIBLE_PX && screenH < MIN_VISIBLE_PX) {


### PR DESCRIPTION
Reduce auto-zoom-in target from 25% to 10% of viewport width for layer click focus (R3.30). Preserves more surrounding context when focusing on small nodes.\n\n### Verification\n- ✅ clippy, fmt, test, 89 TS tests