### PR TITLE
fix: update Zed extension-name in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: huacnlee/zed-extension-action@v2
         with:
-          extension-name: fd
+          extension-name: fast-draft
           extension-path: extensions/fd
           push-to: khangnghiem/extensions
         env:


### PR DESCRIPTION
Update `extension-name` from `fd` to `fast-draft` in the automated Zed publish workflow to match the renamed extension ID.