### PR TITLE
fix: update extension-path to extensions/fast-draft

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: huacnlee/zed-extension-action@v2
         with:
           extension-name: fast-draft
-          extension-path: extensions/fd
+          extension-path: extensions/fast-draft
           push-to: khangnghiem/extensions
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Update `extension-path` from `extensions/fd` to `extensions/fast-draft` to match the renamed submodule directory.