### PR TITLE
refactor(core): deprecate label style property in favor of text child nodes

### DIFF
--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -279,10 +279,7 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
         )
         .unwrap();
     }
-    if let Some(ref label) = node.style.label {
-        indent(out, depth + 1);
-        writeln!(out, "label: \"{label}\"").unwrap();
-    }
+
     // Text alignment
     if node.style.text_align.is_some() || node.style.text_valign.is_some() {
         let h = match node.style.text_align {

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -222,8 +222,7 @@ pub struct Style {
     pub corner_radius: Option<f32>,
     pub opacity: Option<f32>,
     pub shadow: Option<Shadow>,
-    /// Optional label text rendered centered inside the shape (for rect/ellipse).
-    pub label: Option<String>,
+
     /// Horizontal text alignment (default: Center).
     pub text_align: Option<TextAlign>,
     /// Vertical text alignment (default: Middle).
@@ -722,9 +721,7 @@ fn merge_style(dst: &mut Style, src: &Style) {
     if src.shadow.is_some() {
         dst.shadow = src.shadow.clone();
     }
-    if src.label.is_some() {
-        dst.label = src.label.clone();
-    }
+
     if src.text_align.is_some() {
         dst.text_align = src.text_align;
     }

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -125,15 +125,9 @@ fn render_node(
         }
         NodeKind::Rect { .. } => {
             draw_rect(ctx, node_bounds, &style, is_selected);
-            if let Some(ref label) = style.label {
-                draw_shape_label(ctx, node_bounds, label, &style);
-            }
         }
         NodeKind::Ellipse { .. } => {
             draw_ellipse(ctx, node_bounds, &style, is_selected);
-            if let Some(ref label) = style.label {
-                draw_shape_label(ctx, node_bounds, label, &style);
-            }
         }
         NodeKind::Text { content } => {
             draw_text(ctx, node_bounds, content, &style);
@@ -195,9 +189,6 @@ fn render_node(
         }
         NodeKind::Frame { .. } => {
             draw_rect(ctx, node_bounds, &style, is_selected);
-            if let Some(ref label) = style.label {
-                draw_shape_label(ctx, node_bounds, label, &style);
-            }
         }
         NodeKind::Path { commands } => {
             draw_path(ctx, node_bounds, commands, &style, is_selected);
@@ -354,6 +345,7 @@ fn draw_text(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, content: &str, 
 }
 
 /// Draw a label centered inside a shape (rect or ellipse).
+#[allow(dead_code)]
 fn draw_shape_label(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
@@ -384,6 +376,7 @@ fn draw_shape_label(
 }
 
 /// Pick a readable label color based on the shape's fill luminance.
+#[allow(dead_code)]
 fn pick_label_color(style: &Style) -> String {
     match &style.fill {
         Some(Paint::Solid(c)) => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## Completed Requirements
 
+### v0.8.29
+
+- **BREAKING**: Deprecated `label` style property on shapes — inline text on rect/ellipse/frame is now represented as a `text` child node instead of a `label:` property; parser silently ignores `label:` in old files for backwards compatibility
+- **WASM**: `get_selected_node_props` now returns text child content as `label` prop; `set_node_prop("label")` creates/updates/removes a `text` child node
+- **Renderer**: Removed `draw_shape_label` calls from shape rendering — text children render themselves as normal `Text` nodes
+- **UI**: Removed Label section from properties panel — shapes' text is edited via double-click inline editor (creates text child automatically)
+- **Examples**: Converted all `label: "..."` usage in `dark_theme.fd` to `text` child nodes
+
 ### v0.8.28
 
 - **BUG FIX**: Dragging a selected child node within a group now moves only the child, not the whole group — if the raw hit node is already selected (user drilled in), `effective_target` is skipped to preserve the child selection for drag

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -21,166 +21,28 @@ style dark_text {
   font: "Inter" 400 14
 }
 
+ellipse @_anon_1 {
+  w: 50 h: 40
+  fill: #CCCCD9
+  x: -64.9
+  y: 1207.21
+}
+
+rect @_anon_0 {
+  w: 118.35 h: 32.5
+  fill: #000000
+  corner: 0
+  x: -100.08
+  y: 877.4
+  text @_anon_0_label "gaga" {
+  }
+}
+
 group @settings {
   layout: column gap=20 pad=28
   opacity: 1
-  x: -77.84
-  y: -901.6
-  group @header {
-    layout: row gap=0 pad=0
-    text @title "Settings" {
-      fill: #FFFFFF
-      font: "Inter" 700 24
-      opacity: 1
-    }
-    rect @close_btn {
-      w: 36 h: 36
-      fill: #2D2D44
-      corner: 18
-      text @_anon_25 "×" {
-        fill: #999999
-        font: "Inter" 400 20
-      }
-      anim :hover {
-        fill: #3D3D5C
-        ease: ease_out 150ms
-      }
-    }
-  }
-  rect @profile_card {
-    w: 344 h: 80
-    use: dark_card
-    x: -396.39
-    y: 1018.76
-    group @_anon_26 {
-      layout: row gap=14 pad=16
-      ellipse @user_avatar {
-        spec "User profile photo"
-        w: 48 h: 48
-        fill: #6C5CE7
-        x: 178.49
-        y: -630.04
-      }
-      group @_anon_27 {
-        layout: column gap=4 pad=0
-        text @_anon_28 "Khang Nghiem" {
-          fill: #FFFFFF
-          font: "Inter" 600 16
-          x: -140.44
-          y: -8.39
-        }
-        text @_anon_29 "khang@fastdraft.io" {
-          use: dark_muted
-          x: 159.45
-          y: 287.16
-        }
-      }
-    }
-  }
-  text @_anon_30 "Preferences" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @toggle_dark {
-    w: 344 h: 56
-    use: dark_card
-    x: 238.09
-    y: 834.82
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_notif {
-    w: 344 h: 56
-    use: dark_card
-    x: 376.84
-    y: 708.79
-    group @_anon_35 {
-      layout: row gap=0 pad=16
-      group @_anon_36 {
-        layout: column gap=2 pad=0
-        text @_anon_37 "Notifications" {
-          use: dark_text
-        }
-        text @_anon_38 "Push and email alerts" {
-          use: dark_muted
-        }
-      }
-      rect @switch_off {
-        spec "Toggle — OFF state"
-        w: 44 h: 24
-        fill: #3D3D5C
-        corner: 12
-        ellipse @switch_knob_off {
-          w: 20 h: 20
-          fill: #6B7280
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_sound {
-    w: 344 h: 56
-    use: dark_card
-    x: 28.51
-    y: 340.51
-    group @_anon_39 {
-      layout: row gap=0 pad=16
-      x: 72.88
-      y: 605.77
-      group @_anon_40 {
-        layout: column gap=2 pad=0
-        text @_anon_41 "Sound Effects" {
-          use: dark_text
-          fill: #E0E0E0
-          font: "Inter" 400 14
-          opacity: 1
-        }
-        text @_anon_42 "UI interaction sounds" {
-          use: dark_muted
-        }
-      }
-      rect @switch_sound {
-        w: 44 h: 24
-        fill: #6C5CE7
-        corner: 12
-        x: -19.14
-        y: 83.42
-        ellipse @switch_knob_s {
-          w: 20 h: 20
-          fill: #FFFFFF
-          label: "ehe"
-          x: -146.24
-          y: 32.3
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  text @_anon_43 "Display" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @slider_card {
-    w: 344 h: 72
-    use: dark_card
-    fill: #2D2D44
-    corner: 12
-    label: "gaga"
-    x: 184.69
-    y: 144.81
-  }
-  text @_anon_48 "Danger Zone" {
-    fill: #E17055
-    font: "Inter" 600 13
-  }
+  x: 285.2
+  y: -983.93
   rect @btn_delete {
     spec {
       "Destructive action — delete account"
@@ -191,8 +53,8 @@ group @settings {
     fill: #E1705520
     stroke: #E17055 1
     corner: 10
-    x: 635.39
-    y: 633.41
+    x: 686.46
+    y: -362.54
     text @_anon_49 "Delete Account" {
       fill: #E17055
       font: "Inter" 600 14
@@ -206,21 +68,162 @@ group @settings {
       ease: ease_out 100ms
     }
   }
-}
-
-rect @_anon_0 {
-  w: 118.35 h: 32.5
-  fill: #000000
-  corner: 0
-  label: "gaga"
-  x: -100.08
-  y: 877.4
-}
-
-ellipse @_anon_1 {
-  w: 50 h: 40
-  fill: #CCCCD9
-  x: -64.9
-  y: 1207.21
+  text @_anon_48 "Danger Zone" {
+    fill: #E17055
+    font: "Inter" 600 13
+  }
+  rect @slider_card {
+    w: 344 h: 72
+    use: dark_card
+    fill: #2D2D44
+    corner: 12
+    x: 184.69
+    y: 144.81
+    text @slider_card_label "gaga" {
+    }
+  }
+  text @_anon_43 "Display" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @toggle_sound {
+    w: 344 h: 56
+    use: dark_card
+    x: 28.51
+    y: 340.51
+    group @_anon_39 {
+      layout: row gap=0 pad=16
+      x: 72.88
+      y: 605.77
+      rect @switch_sound {
+        w: 44 h: 24
+        fill: #6C5CE7
+        corner: 12
+        x: -19.14
+        y: 83.42
+        ellipse @switch_knob_s {
+          w: 20 h: 20
+          fill: #FFFFFF
+          x: -146.24
+          y: 32.3
+          text @switch_knob_s_label "ehe" {
+          }
+        }
+      }
+      group @_anon_40 {
+        layout: column gap=2 pad=0
+        text @_anon_42 "UI interaction sounds" {
+          use: dark_muted
+        }
+        text @_anon_41 "Sound Effects" {
+          use: dark_text
+          fill: #E0E0E0
+          font: "Inter" 400 14
+          opacity: 1
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_notif {
+    w: 344 h: 56
+    use: dark_card
+    x: 376.84
+    y: 708.79
+    group @_anon_35 {
+      layout: row gap=0 pad=16
+      rect @switch_off {
+        spec "Toggle — OFF state"
+        w: 44 h: 24
+        fill: #3D3D5C
+        corner: 12
+        ellipse @switch_knob_off {
+          w: 20 h: 20
+          fill: #6B7280
+        }
+      }
+      group @_anon_36 {
+        layout: column gap=2 pad=0
+        text @_anon_38 "Push and email alerts" {
+          use: dark_muted
+        }
+        text @_anon_37 "Notifications" {
+          use: dark_text
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_dark {
+    w: 344 h: 56
+    use: dark_card
+    x: 238.09
+    y: 834.82
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  text @_anon_30 "Preferences" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @profile_card {
+    w: 344 h: 80
+    use: dark_card
+    x: -656.58
+    y: 860.46
+    group @_anon_26 {
+      layout: row gap=14 pad=16
+      group @_anon_27 {
+        layout: column gap=4 pad=0
+        text @_anon_29 "khang@fastdraft.io" {
+          use: dark_muted
+          x: 159.45
+          y: 287.16
+        }
+        text @_anon_28 "Khang Nghiem" {
+          fill: #FFFFFF
+          font: "Inter" 600 16
+          x: -140.44
+          y: -8.39
+        }
+      }
+      ellipse @user_avatar {
+        spec "User profile photo"
+        w: 48 h: 48
+        fill: #6C5CE7
+        x: 178.49
+        y: -630.04
+      }
+    }
+  }
+  group @header {
+    layout: row gap=0 pad=0
+    rect @close_btn {
+      w: 36 h: 36
+      fill: #2D2D44
+      corner: 18
+      text @_anon_25 "×" {
+        fill: #999999
+        font: "Inter" 400 20
+      }
+      anim :hover {
+        fill: #3D3D5C
+        ease: ease_out 150ms
+      }
+    }
+    text @title "Settings" {
+      fill: #FFFFFF
+      font: "Inter" 700 24
+      opacity: 1
+    }
+  }
 }
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.28",
+  "version": "0.8.29",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1922,13 +1922,6 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
             <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
           </div>
         </div>
-        <div class="props-section" id="props-label-section" style="display:none">
-          <div class="props-section-label">Label</div>
-          <div class="props-field full">
-            <input type="text" id="prop-label" placeholder="Shape label (optional)">
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div id="annotation-card">

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -956,7 +956,7 @@ function buildShortcutHelpHtml() {
         [`⌥${cmd}`, "Copy while moving"],
         ["Arrow keys", "Nudge 1px"],
         ["Shift+Arrow", "Nudge 10px"],
-        ["Double-click", "Create text / edit label"],
+        ["Double-click", "Create text / edit text"],
       ],
     },
     {
@@ -1309,7 +1309,7 @@ function setupPropertiesPanel() {
     { id: "prop-w", key: "width" },
     { id: "prop-h", key: "height" },
     { id: "prop-text-content", key: "content" },
-    { id: "prop-label", key: "label" },
+
   ];
 
   let debounceTimer = null;
@@ -1406,23 +1406,15 @@ function updatePropertiesPanel() {
   if (opacitySlider) opacitySlider.value = opacity;
   if (opacityVal) opacityVal.textContent = Math.round(opacity * 100) + "%";
 
-  // Text content (for text nodes) and label (for rect/ellipse)
+  // Text content (for text nodes)
   const textSection = document.getElementById("props-text-section");
   const textInput = document.getElementById("prop-text-content");
-  const labelSection = document.getElementById("props-label-section");
-  const labelInput = document.getElementById("prop-label");
 
   if (props.kind === "text") {
     if (textSection) textSection.style.display = "";
-    if (labelSection) labelSection.style.display = "none";
     if (textInput) textInput.value = props.content || "";
-  } else if (props.kind === "rect" || props.kind === "ellipse") {
-    if (textSection) textSection.style.display = "none";
-    if (labelSection) labelSection.style.display = "";
-    if (labelInput) labelInput.value = props.label || "";
   } else {
     if (textSection) textSection.style.display = "none";
-    if (labelSection) labelSection.style.display = "none";
   }
 
   // Alignment grid — show for text/rect/ellipse nodes


### PR DESCRIPTION
## Summary

Deprecates the `label` style property on shapes (rect/ellipse/frame) in favor of `text` child nodes.

### Changes
- **fd-core**: Removed `Style.label` field, parser silently skips `label:` for backwards compat, removed label emission
- **fd-wasm**: `get_selected_node_props` finds first Text child content; `set_node_prop("label")` creates/updates/removes text children
- **render2d**: Removed `draw_shape_label` calls from shape rendering
- **fd-vscode**: Removed Label section from properties panel HTML and JS
- **examples**: Converted `dark_theme.fd` labels to text child nodes

### CI Results
- ✅ `cargo check --workspace`
- ✅ `cargo test --workspace` (14 passed, 0 failed)
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`