### PR TITLE
test(e2e): expand UX test suite to 71 tests + browser E2E validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.31
+
+- **TESTING**: Expanded E2E UX test suite from 52 to 71 tests (+19) — added coverage for complex card document parsing, Drawio-style edge annotations, frame nodes, 3-level nested groups, spec fold ranges, panel column resolution, layer ordering, and rename sanitization edge cases
+- **TESTING**: Browser E2E validation of 6 real-world scenarios (Figma card build, Drawio rapid shapes, Sketch multi-select, Figma duplicate, Excalidraw rapid draw, Miro navigation) via Codespace
+
 ### v0.8.30
 
 - **BUG FIX**: Fixed `parseSpecNodes` annotation bleed — `lines.indexOf()` found the first occurrence of identical spec block lines, causing annotations from earlier nodes to leak into later nodes; switched to indexed `for` loop (fixes Spec View filtering accuracy)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Changes

Expand E2E UX test suite from 52 to 71 tests (+19 new tests) and validate 6 real-world design tool scenarios via browser E2E in Codespace.

### New Vitest Tests (19)
- **Complex card documents**: styles + text + nested groups with `use:` references
- **Edge annotations**: `edge @id { from: @X to: @Y spec "..." }`
- **Frame nodes**: auto-layout container parsing with children
- **3-level nesting**: deeply nested `group > group > rect` hierarchy
- **Fold ranges**: consecutive hidden lines grouping for Spec View
- **Panel column resolution**: `resolveTargetColumn` all branches
- **Layer ordering**: symbols preserve source-order for panel display
- **Rename sanitization**: word-boundary safety and special character stripping

### Browser E2E Scenarios (6)
1. Figma card build → draw rect, add text, multi-select, group, rename
2. Drawio rapid shapes → R, E, R rapid tool switching
3. Sketch multi-select → shift-click, properties panel
4. Figma duplicate → context menu, copy-paste
5. Excalidraw rapid draw → R→E→T→V rapid flow
6. Miro navigation → zoom out, zoom-to-fit, layer click-to-focus

### Test Results
- ✅ 160 tests pass (71 e2e-ux + 89 fd-parse)
- ✅ All Rust tests pass
- ✅ clippy/fmt clean