### PR TITLE
test(core,render): add 3-level nested group drill-down tests

### DIFF
--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -900,6 +900,52 @@ mod tests {
     }
 
     #[test]
+    fn test_effective_target_3_level_drill_down() {
+        let mut sg = SceneGraph::new();
+
+        // Root -> group_outer -> group_inner -> rect_leaf
+        let outer_id = NodeId::intern("group_outer");
+        let inner_id = NodeId::intern("group_inner");
+        let leaf_id = NodeId::intern("rect_leaf");
+
+        let outer = SceneNode::new(
+            outer_id,
+            NodeKind::Group {
+                layout: LayoutMode::Free,
+            },
+        );
+        let inner = SceneNode::new(
+            inner_id,
+            NodeKind::Group {
+                layout: LayoutMode::Free,
+            },
+        );
+        let leaf = SceneNode::new(
+            leaf_id,
+            NodeKind::Rect {
+                width: 50.0,
+                height: 50.0,
+            },
+        );
+
+        let outer_idx = sg.add_node(sg.root, outer);
+        let inner_idx = sg.add_node(outer_idx, inner);
+        sg.add_node(inner_idx, leaf);
+
+        // Click 1: nothing selected → bubbles to highest group = group_outer
+        let t1 = sg.effective_target(leaf_id, &[]);
+        assert_eq!(t1, outer_id);
+
+        // Click 2: group_outer selected → next unselected group = group_inner
+        let t2 = sg.effective_target(leaf_id, &[outer_id]);
+        assert_eq!(t2, inner_id);
+
+        // Click 3: both groups selected → drills to leaf
+        let t3 = sg.effective_target(leaf_id, &[outer_id, inner_id]);
+        assert_eq!(t3, leaf_id);
+    }
+
+    #[test]
     fn test_is_ancestor_of() {
         let mut sg = SceneGraph::new();
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### v0.8.31
 
+- **TESTING**: Added 3-level nested group drill-down tests — `test_effective_target_3_level_drill_down` in `model.rs` (verifies click 1→outer, click 2→inner, click 3→leaf), `hit_test_nested_groups` in `hit.rs` (verifies deepest node returned through nested groups), and drill-down simulation + `findSymbolAtLine` resolution tests in `e2e-ux.test.ts`
 - **TESTING**: Expanded E2E UX test suite from 52 to 71 tests (+19) — added coverage for complex card document parsing, Drawio-style edge annotations, frame nodes, 3-level nested groups, spec fold ranges, panel column resolution, layer ordering, and rename sanitization edge cases
 - **TESTING**: Browser E2E validation of 6 real-world scenarios (Figma card build, Drawio rapid shapes, Sketch multi-select, Figma duplicate, Excalidraw rapid draw, Miro navigation) via Codespace
 


### PR DESCRIPTION
## Summary\n\nAdds comprehensive tests for 3-level nested group drill-down selection (group→group→rect) — a Figma-standard behavior that was previously only covered for 2-level nesting.\n\n## Changes\n\n### Rust Tests\n- **`model.rs`**: `test_effective_target_3_level_drill_down` — verifies Root→group_outer→group_inner→rect_leaf resolves correctly at each drill-down step (click 1→outer, click 2→inner, click 3→leaf)\n- **`hit.rs`**: `hit_test_nested_groups` — verifies deepest node is returned when hit-testing through 3 levels of nested groups\n\n### TypeScript Tests\n- **`e2e-ux.test.ts`**: drill-down selection simulation through 3 levels with `effectiveTarget` logic mirror; `findSymbolAtLine` resolution at each nesting depth\n\n## Test Results\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo test --workspace` — 14/14 passed\n- ✅ `cd fd-vscode && pnpm test` — 162/162 passed