### PR TITLE
docs: update REQUIREMENTS with R3.25-R3.27, fix CHANGELOG test matrix (316 tests)

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -62,6 +62,9 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.24**: Group Visibility & Drill-down: Group nodes render a dashed blue border on hover and a solid blue border with a "Group @id" badge when selected. Clicking a child of an unselected group selects the parent group. Clicking the child again (when the group is selected) drills down to select the child (Figma/Sketch behavior).
 - **R3.28**: Inline text editing: Double-click a text node or shape to open a floating textarea overlay; background matches the node's fill (shape) or uses themed default (text node); live sync — every keystroke updates Code Mode in real-time; Enter confirms, Esc reverts to original value, click-outside commits; 3×3 alignment grid picker in properties panel for `align:` (R1.17)
 - **R3.29**: Animation drop: Drag a node onto another to assign animations — magnetic glow ring on hover, release opens a glassmorphism Animation Picker popover with preset groups (Hover/Press/Enter), live preview on hover, click to commit `anim` block to Code Mode
+- **R3.25**: Minimap navigation: Thumbnail overview in bottom-right showing full scene with draggable viewport rectangle; click-to-pan navigation (Figma/Miro-style)
+- **R3.26**: Arrow-key nudge: Arrow keys move selected node 1px (Shift+arrow = 10px); matches Figma/Sketch standard UX
+- **R3.27**: Layer rename: Double-click a layer name in the Layers panel for inline rename; renames `@id` across the entire document (word-boundary safe)
 - **R3.30**: Layer navigation: Clicking a layer item in the Layers panel selects the node and smoothly pans the camera to center it (250ms ease-out); auto-zooms in if both dimensions are < 20px on screen (truly invisible); auto-zooms out if the node overflows the viewport (15% padding); skips pan if the node center is already within 20% of the viewport center; thin shapes (lines, dividers) keep current zoom unless overflowing
 
 ### R4: AI Editing (Text)
@@ -157,3 +160,4 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 | inline editing      | R3.28                                 |
 | text alignment      | R1.17, R3.28                          |
 | layers / navigation | R3.30                                 |
+| group / drill-down  | R3.24                                 |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -324,14 +324,21 @@
 - [x] **R3.13**: Light/dark theme toggle
 - [x] **R3.14**: View mode toggle (Design | Spec)
 - [ ] **R3.15**: Live preview outlines
-- [ ] **R3.16**: Resize handles (8-point grips)
-- [ ] **R3.17**: Smart guides (alignment snapping)
-- [ ] **R3.18**: Dimension tooltip
+- [x] **R3.16**: Resize handles (8-point grips)
+- [x] **R3.17**: Smart guides (alignment snapping)
+- [x] **R3.18**: Dimension tooltip
 - [ ] **R3.19**: Alt-draw-from-center
-- [ ] **R3.20**: Zoom (⌘+/−, pinch, fit)
+- [x] **R3.20**: Zoom (⌘+/−, pinch, fit)
 - [x] **R3.21**: Grid overlay
 - [ ] **R3.22**: Pressure-sensitive stroke width
 - [ ] **R3.23**: Freehand shape recognition
+- [x] **R3.24**: Group visibility & drill-down
+- [x] **R3.25**: Minimap navigation
+- [x] **R3.26**: Arrow-key nudge
+- [x] **R3.27**: Layer rename
+- [x] **R3.28**: Inline text editing
+- [x] **R3.29**: Animation drop
+- [x] **R3.30**: Layer navigation
 
 ### R4: AI Editing (Text)
 
@@ -369,27 +376,41 @@
 
 <!-- Maps each requirement to its test functions. If a row is empty, the requirement lacks test coverage. -->
 
-| Requirement | Test Functions                                                    | Coverage                    |
-| ----------- | ----------------------------------------------------------------- | --------------------------- |
-| R1.1–R1.8   | `parser::tests::parse_*`, `emitter::tests::emit_*`, `roundtrip_*` | ✅ 42 tests                 |
-| R1.9        | `emit_annotations_*`, `roundtrip_preserves_annotations`           | ✅                          |
-| R1.10       | `parse_edge_*`, `emit_edge_*`, `roundtrip_edge_*`                 | ✅                          |
-| R1.11       | `emit_edge_with_trigger_anim`, `roundtrip_edge_hover_anim`        | ✅                          |
-| R1.12       | `emit_edge_flow_*`, `roundtrip_edge_flow_*`                       | ✅                          |
-| R1.13       | `emit_generic_node`, `roundtrip_generic_*`                        | ✅                          |
-| R1.14       | `parse_import`, `emit_import`, `roundtrip_import`                 | ✅                          |
-| R1.15       | `emit_bg_shorthand`, `roundtrip_bg_shorthand`                     | ✅                          |
-| R1.16       | `roundtrip_comment_*`                                             | ✅                          |
-| R2.1–R2.4   | `sync::tests::sync_*`, `bidi_sync::*`                             | ⚠️ 5 unit + 2 integration   |
-| R3.1        | `tools::tests::select_tool_*`                                     | ⚠️ 3 tests, missing marquee |
-| R3.2        | `tools::tests::select_tool_drag`, `select_tool_shift_drag_*`      | ⚠️ Missing resize           |
-| R3.3        | `tools::tests::rect_tool_*`, `ellipse_tool_*`                     | ⚠️ Missing text tool test   |
-| R3.4        | _(none)_                                                          | ❌ No pen tool tests        |
-| R3.5        | _(future)_                                                        | —                           |
-| R3.6        | _(JS-only, no test)_                                              | ❌                          |
-| R3.7        | `commands::tests::*`, `undo_redo::*`                              | ✅ 5 unit + 4 integration   |
-| R3.8–R3.14  | _(JS-only, no test)_                                              | ❌                          |
-| R3.15–R3.23 | _(not yet implemented)_                                           | —                           |
-| R4.1–R4.6   | Covered by R1/R2 tests                                            | ✅                          |
-| R4.7–R4.11  | _(extension-side, no test)_                                       | ❌                          |
-| R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`                              | ⚠️ 6 tests                  |
+| Requirement | Test Functions                                                    | Coverage                       |
+| ----------- | ----------------------------------------------------------------- | ------------------------------ |
+| R1.1–R1.8   | `parser::tests::parse_*`, `emitter::tests::emit_*`, `roundtrip_*` | ✅ 76 fd-core + 18 integration |
+| R1.9        | `emit_annotations_*`, `roundtrip_preserves_annotations`           | ✅                             |
+| R1.10       | `parse_edge_*`, `emit_edge_*`, `roundtrip_edge_*`                 | ✅                             |
+| R1.11       | `emit_edge_with_trigger_anim`, `roundtrip_edge_hover_anim`        | ✅                             |
+| R1.12       | `emit_edge_flow_*`, `roundtrip_edge_flow_*`                       | ✅                             |
+| R1.13       | `emit_generic_node`, `roundtrip_generic_*`                        | ✅                             |
+| R1.14       | `parse_import`, `emit_import`, `roundtrip_import`                 | ✅                             |
+| R1.15       | `emit_bg_shorthand`, `roundtrip_bg_shorthand`                     | ✅                             |
+| R1.16       | `roundtrip_comment_*`                                             | ✅                             |
+| R1.17       | `parse_align_*`, `roundtrip_align*`, `style_merging_align`        | ✅                             |
+| R2.1–R2.4   | `sync::tests::sync_*`, `bidi_sync::*`                             | ✅ 12 sync + 9 integration     |
+| R3.1        | `tools::tests::select_tool_*`, `hit::tests::*`                    | ✅ 5 tests + 3 hit tests       |
+| R3.2        | `select_tool_drag`, `select_tool_shift_drag_*`, resize integ.     | ✅ 3 tests                     |
+| R3.3        | `rect_tool_*`, `ellipse_tool_*`, `text_tool_*`                    | ✅ 7 tests                     |
+| R3.4        | _(pen tool — captures pressure, no unit test)_                    | ⚠️ No pen tool tests           |
+| R3.5        | _(future)_                                                        | —                              |
+| R3.6        | E2E UX: zoom/pan/pinch tests in `e2e-ux.test.ts`                  | ✅ 4 E2E tests                 |
+| R3.7        | `commands::tests::*`, `undo_redo::*`                              | ✅ 5 unit + 7 integration      |
+| R3.8–R3.14  | E2E UX: properties, color, theme, view mode in `e2e-ux.test.ts`   | ✅ 12 E2E tests                |
+| R3.16       | `hit_test_resize_handle` (WASM), E2E UX cursor tests              | ⚠️ WASM-side only              |
+| R3.17       | E2E UX: grid/snap tests                                           | ⚠️ JS-only                     |
+| R3.18       | E2E UX: dimension tooltip tests                                   | ⚠️ JS-only                     |
+| R3.20       | E2E UX: zoom calculations, pinch clamp                            | ✅ 4 E2E tests                 |
+| R3.21       | E2E UX: grid spacing adaptation                                   | ✅ 3 E2E tests                 |
+| R3.24       | `effective_target_*`, `is_ancestor_of`, `hit_test_nested_groups`  | ✅ 4 Rust + 4 E2E tests        |
+| R3.25       | E2E UX: minimap scale, click-to-navigate                          | ✅ 2 E2E tests                 |
+| R3.26       | E2E UX: arrow nudge 1px/10px                                      | ✅ 2 E2E tests                 |
+| R3.27       | E2E UX: rename sanitization, word-boundary                        | ✅ 3 E2E tests                 |
+| R3.28       | E2E UX: inline text editing, hex luminance                        | ✅ 3 E2E tests                 |
+| R3.29       | E2E UX: animation tween engine                                    | ✅ 2 E2E tests                 |
+| R3.30       | _(JS-only, camera animation)_                                     | ⚠️ JS-only                     |
+| R4.1–R4.6   | Covered by R1/R2 tests                                            | ✅                             |
+| R4.7–R4.11  | _(extension-side, no test)_                                       | ❌                             |
+| R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`, `render2d::tests::*`        | ✅ 3 hit + 6 layout + 3 render |
+
+**Total**: 154 Rust tests + 162 TypeScript tests = **316 tests**


### PR DESCRIPTION
## Summary\n\nAudited and updated REQUIREMENTS.md and CHANGELOG.md for accuracy.\n\n### REQUIREMENTS.md\n- Added R3.25 (Minimap), R3.26 (Arrow-key nudge), R3.27 (Layer rename) definitions — were referenced in the index but missing from the main list\n- Added `group / drill-down` tag to Requirement Index\n\n### CHANGELOG.md\n- Fixed R3.16-R3.30 checkboxes — 7 items were marked incomplete but are actually implemented (R3.16 Resize, R3.17 Smart guides, R3.18 Dimension tooltip, R3.20 Zoom, R3.24-R3.30)\n- Rewrote Test Matrix with accurate test counts (154 Rust + 162 TS = **316 total tests**)\n- Added rows for R1.17, R3.6, R3.8-R3.14, R3.16-R3.30 that were missing\n- Updated R2.1-R2.4 coverage from ⚠️ to ✅ (12 sync + 9 integration)\n- Updated R5 coverage to include render2d tests\n\n## Verification\n- ✅ `cargo clippy --workspace -- -D warnings` — clean\n- ✅ `cargo fmt --all -- --check` — clean\n- ✅ `cargo test --workspace` — 154 passed\n- ✅ `cd fd-vscode && pnpm test` — 162 passed