### PR TITLE
feat(editor): center single-click shapes at click point (Excalidraw UX)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.32
+
+- **UX**: Single-click shape creation now centers the shape at the click point (Excalidraw behavior) — previously the top-left corner was placed at click; rect default size changed from 100×100 to 120×80; ellipse default remains 100×100 centered
+- **TESTING**: 3 new unit tests — `rect_tool_click_creates_centered`, `ellipse_tool_click_creates_centered`, `rect_tool_drag_still_works`
+
 ### v0.8.31
 
 - **TESTING**: Added 3-level nested group drill-down tests — `test_effective_target_3_level_drill_down` in `model.rs` (verifies click 1→outer, click 2→inner, click 3→leaf), `hit_test_nested_groups` in `hit.rs` (verifies deepest node returned through nested groups), and drill-down simulation + `findSymbolAtLine` resolution tests in `e2e-ux.test.ts`


### PR DESCRIPTION
## Summary\n\nSingle-click shape creation now centers the shape at the click point, matching Excalidraw's behavior. Previously, the shape's top-left corner was positioned at the click point.\n\n## Changes\n\n- **RectTool** click-to-create: 120×80 centered at click (was 100×100 top-left)\n- **EllipseTool** click-to-create: 100×100 centered at click (was top-left)\n- Drag-to-create behavior is **unchanged**\n\n## Tests\n\n3 new unit tests:\n- `rect_tool_click_creates_centered` — verifies 120×80 + MoveNode centering\n- `ellipse_tool_click_creates_centered` — verifies 100×100 + MoveNode centering\n- `rect_tool_drag_still_works` — regression test for drag-to-create\n\n## CI\n\n- ✅ `cargo test --workspace`\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all -- --check`