### PR TITLE
feat(editor): add Arrow/Connector drawing tool with A shortcut

### DIFF
--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -6,9 +6,9 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 
 > Runs the full pipeline automatically. Supports three modes:
 >
-> `/yolo local` — 🧪 TDD → 🔨 Build → ✅ Verify Local **(STOP)**
+> `/yolo local` — 🧪 TDD → 🔨 Build → 🌐 E2E UX → ✅ Verify Local **(STOP)**
 > `/yolo deploy` — 📝 Commit → 📝 PR → 🔀 Merge → 📦 Publish Extension **(use after `/yolo local`)**
-> `/yolo` — 🧪 TDD → 🔨 Build → 📝 Commit → 📝 PR → 🔀 Merge → 📦 Publish Extension
+> `/yolo` — 🧪 TDD → 🔨 Build → 🌐 E2E UX → 📝 Commit → 📝 PR → 🔀 Merge → 📦 Publish Extension
 
 // turbo-all
 
@@ -65,7 +65,23 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
    cd fd-vscode && pnpm test
    ```
 
-6. **Report** results to user. **STOP HERE.**
+6. **E2E UX browser testing** (if `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `fd-vscode/webview/` changed):
+
+   Run the full `/e2e-ux` workflow using the browser subagent:
+   - Build WASM first if Rust crates changed:
+
+     ```bash
+     wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm
+     ```
+
+   - Open the Codespace in browser via `gh codespace code -c <codespace-name> --web`
+   - Execute all 8 phases from `/e2e-ux` (Canvas Load, Drawing Tools, Selection, Inline Editing, Navigation, Panels, Bidi Sync, Keyboard Shortcuts)
+   - Screenshot and report results per phase
+   - **If any phase fails**: Fix the issue before proceeding to deploy
+
+   > **Skip only if** the change is purely Rust internals with no canvas/UI impact (e.g., parser refactors covered by unit tests).
+
+7. **Report** results to user. **STOP HERE.**
 
 ---
 
@@ -73,28 +89,28 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 
 > Use this after `/yolo local` has passed.
 
-7. **Activate pre-push hook** (one-time per clone — blocks accidental pushes to `main`):
+8. **Activate pre-push hook** (one-time per clone — blocks accidental pushes to `main`):
 
    ```bash
    git config core.hooksPath .githooks
    ```
 
-8. **Check branch** (never commit to main):
+9. **Check branch** (never commit to main):
 
    ```bash
    git branch --show-current
    ```
 
-9. If on `main`, create a feature branch:
+10. If on `main`, create a feature branch:
 
-   ```bash
-   git checkout -b feat/<descriptive-name>
-   ```
+```bash
+git checkout -b feat/<descriptive-name>
+```
 
-10. **Bump Version** (if `fd-vscode/` was changed):
+11. **Bump Version** (if `fd-vscode/` was changed):
     - Bump the `version` field in `fd-vscode/package.json` appropriately (patch/minor/major).
 
-11. **Update docs** (MANDATORY — both files, every time):
+12. **Update docs** (MANDATORY — both files, every time):
     - `docs/CHANGELOG.md` — add entry under the current version section for each meaningful change
     - `REQUIREMENTS.md` — for **every** CHANGELOG entry, check if it introduces, extends, or modifies a requirement:
       - New feature → add a new `R*.N` entry and update the Requirement Index
@@ -102,40 +118,40 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
       - Bug fix on an existing requirement → no change needed (already documented)
       - Search the Requirement Index for overlap before adding new entries
 
-12. **Stage and commit**:
+13. **Stage and commit**:
 
     ```bash
     git add -A
     git commit -m "<type>(<scope>): <description>"
     ```
 
-13. **Push**:
+14. **Push**:
 
     ```bash
     git push -u origin HEAD
     ```
 
-14. **Create PR** using GitKraken MCP:
+15. **Create PR** using GitKraken MCP:
     - `provider`: github
     - `source_branch`: current branch
     - `target_branch`: main
     - Title in conventional format
     - Body summarizing changes + test results
 
-15. **Merge PR** and clean up:
+16. **Merge PR** and clean up:
 
     ```bash
     gh pr merge <PR_NUMBER> --merge --delete-branch
     ```
 
-16. **Sync main**:
+17. **Sync main**:
 
     ```bash
     git checkout main
     git pull origin main
     ```
 
-17. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
+18. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
 
     > ⚠️ **MANDATORY**: Read `.env` for `VSCE_PAT`, `VSX_PAT`, and `GEMINI_API_KEY` BEFORE publishing.
     > Never rely on interactive prompts — always pass tokens via flags.
@@ -145,8 +161,6 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
     ```bash
     wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm
     ```
-
-    > 🛑 **If WASM was rebuilt**: Run `/e2e` in a Codespace to verify canvas renders before publishing.
 
     Then compile TypeScript:
 
@@ -167,10 +181,10 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
     > Skip publish if the change is local-only or version wasn't bumped.
     > **NEVER** publish to only one registry — both Marketplace AND Open VSX are required.
 
-18. Report PR URL, merge status, and publish results to user.
+19. Report PR URL, merge status, and publish results to user.
 
 ---
 
 ## `/yolo` — Full Pipeline
 
-Runs **all steps 1–18** in sequence (local + deploy).
+Runs **all steps 1–19** in sequence (local + deploy).

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -25,6 +25,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.15**: Background shorthand — `bg: #FFF corner=12 shadow=(0,4,20,#0002)` for combined fill, corner, and shadow in one line
 - **R1.16**: Comment preservation — `# text` lines attached to the following node survive all parse/emit round-trips and format passes
 - **R1.17**: Text alignment — `align: left|center|right [top|middle|bottom]` property on text and shape nodes; defaults to `center middle`; reusable via `style` blocks and `use:` inheritance
+- **R1.18**: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges; enables importing existing diagrams from Markdown docs
 
 ### R2: Bidirectional Sync
 
@@ -66,6 +67,9 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.26**: Arrow-key nudge: Arrow keys move selected node 1px (Shift+arrow = 10px); matches Figma/Sketch standard UX
 - **R3.27**: Layer rename: Double-click a layer name in the Layers panel for inline rename; renames `@id` across the entire document (word-boundary safe)
 - **R3.30**: Layer navigation: Clicking a layer item in the Layers panel selects the node and smoothly pans the camera to center it (250ms ease-out); auto-zooms in if both dimensions are < 20px on screen (truly invisible); auto-zooms out if the node overflows the viewport (15% padding); skips pan if the node center is already within 20% of the viewport center; thin shapes (lines, dividers) keep current zoom unless overflowing
+- **R3.31**: Export — PNG (2× resolution), SVG, and clipboard export of the full canvas or selected elements; configurable background (transparent or themed); accessible via toolbar button + keyboard shortcut (⌘⇧E)
+- **R3.32**: Image embedding — drag-and-drop or paste raster images (PNG, JPG, WebP) onto the canvas as `image` nodes; images stored inline (base64) or as external file references; resizable with aspect-ratio lock by default
+- **R3.33**: Component libraries — reusable collections of nodes/groups that can be dragged onto the canvas from a library panel; user-created and community-shared libraries; stored as `.fd` files with `export` markers
 
 ### R4: AI Editing (Text)
 
@@ -98,6 +102,11 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.2** (future): Desktop app via Tauri (macOS, Windows, Linux)
 - **R6.3** (future): Mobile app (iOS, Android) via native wgpu
 - **R6.4** (future): Web app (standalone browser app)
+
+### R7: Collaboration
+
+- **R7.1** (future): Real-time multiplayer — concurrent editing with cursor presence, CRDT-based conflict resolution, and live sync across connected clients
+- **R7.2** (future): Shareable links — generate a URL to share a read-only or editable view of an `.fd` document without requiring IDE installation
 
 ## Non-Functional Requirements
 
@@ -139,7 +148,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 | cursor              | R3.11, R3.16                          |
 | resize              | R3.2, R3.16                           |
 | feedback / tooltip  | R3.15, R3.18                          |
-| export              | R3.24                                 |
+| export              | R3.31, R4.7                           |
 | minimap             | R3.25                                 |
 | nudge               | R3.26                                 |
 | rename              | R3.27                                 |
@@ -152,7 +161,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 | pressure / pencil   | R3.4, R3.10, R3.22                    |
 | ai / refinement     | R4.7, R4.8, R4.9, R4.10               |
 | edge                | R1.10, R1.11, R1.12, R4.6, R5.7, R5.8 |
-| import              | R1.14                                 |
+| import              | R1.14, R1.18                          |
 | style               | R1.4, R4.3                            |
 | animation           | R1.5, R1.11, R1.12, R3.29, R5.6, R5.8 |
 | rendering           | R5.1, R5.2, R5.4, R5.5                |
@@ -161,3 +170,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 | text alignment      | R1.17, R3.28                          |
 | layers / navigation | R3.30                                 |
 | group / drill-down  | R3.24                                 |
+| image               | R3.32                                 |
+| library             | R3.33                                 |
+| collaboration       | R7.1, R7.2                            |
+| mermaid             | R1.18                                 |

--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -207,6 +207,16 @@ fn compute_inverse(engine: &SyncEngine, mutation: &GraphMutation) -> GraphMutati
                 animations: old_animations,
             }
         }
+        GraphMutation::AddEdge { edge } => GraphMutation::RemoveEdge { id: edge.id },
+        GraphMutation::RemoveEdge { id } => {
+            if let Some(edge) = engine.graph.edges.iter().find(|e| e.id == *id) {
+                GraphMutation::AddEdge {
+                    edge: Box::new(edge.clone()),
+                }
+            } else {
+                GraphMutation::RemoveEdge { id: *id }
+            }
+        }
     }
 }
 

--- a/crates/fd-editor/src/shortcuts.rs
+++ b/crates/fd-editor/src/shortcuts.rs
@@ -19,6 +19,7 @@ pub enum ShortcutAction {
     ToolEllipse,
     ToolPen,
     ToolText,
+    ToolArrow,
     /// Toggle between current and previous tool (Screenbrush: Tab).
     ToggleLastTool,
 
@@ -129,6 +130,7 @@ impl ShortcutMap {
             "o" | "O" => Some(ShortcutAction::ToolEllipse),
             "p" | "P" => Some(ShortcutAction::ToolPen),
             "t" | "T" => Some(ShortcutAction::ToolText),
+            "a" | "A" => Some(ShortcutAction::ToolArrow),
             // Screenbrush: Tab = toggle between two most-used tools
             "Tab" => Some(ShortcutAction::ToggleLastTool),
             "Delete" | "Backspace" => Some(ShortcutAction::Delete),
@@ -164,6 +166,10 @@ mod tests {
         assert_eq!(
             ShortcutMap::resolve("t", false, false, false, false),
             Some(ShortcutAction::ToolText)
+        );
+        assert_eq!(
+            ShortcutMap::resolve("a", false, false, false, false),
+            Some(ShortcutAction::ToolArrow)
         );
     }
 

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -354,6 +354,12 @@ impl SyncEngine {
                     self.bounds.remove(&group_idx);
                 }
             }
+            GraphMutation::AddEdge { edge } => {
+                self.graph.edges.push(*edge);
+            }
+            GraphMutation::RemoveEdge { id } => {
+                self.graph.edges.retain(|e| e.id != id);
+            }
         }
 
         self.text_dirty = true;
@@ -499,6 +505,14 @@ pub enum GraphMutation {
     SetAnimations {
         id: NodeId,
         animations: smallvec::SmallVec<[AnimKeyframe; 2]>,
+    },
+    /// Add an edge (arrow/connector) between two nodes.
+    AddEdge {
+        edge: Box<Edge>,
+    },
+    /// Remove an edge by its ID.
+    RemoveEdge {
+        id: NodeId,
     },
 }
 

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -118,6 +118,18 @@ fn render_node(
     let style = graph.resolve_style(node, &triggers);
     let is_selected = selected_ids.iter().any(|sel| sel == node.id.as_str());
 
+    // Apply scale transform from node center if animation set it
+    let has_scale = style.scale.is_some_and(|s| (s - 1.0).abs() > f32::EPSILON);
+    if has_scale {
+        let cx = node_bounds.x as f64 + node_bounds.width as f64 / 2.0;
+        let cy = node_bounds.y as f64 + node_bounds.height as f64 / 2.0;
+        let s = style.scale.unwrap_or(1.0) as f64;
+        ctx.save();
+        ctx.translate(cx, cy).unwrap_or(());
+        ctx.scale(s, s).unwrap_or(());
+        ctx.translate(-cx, -cy).unwrap_or(());
+    }
+
     match &node.kind {
         NodeKind::Root => {}
         NodeKind::Generic => {
@@ -217,6 +229,11 @@ fn render_node(
     // Selection overlay (drawn after children so it's on top)
     if is_selected {
         draw_selection_handles(ctx, node_bounds);
+    }
+
+    // Restore scale transform
+    if has_scale {
+        ctx.restore();
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.8.33
+
+- **FEATURE**: Arrow/Connector drawing tool — press `A` to activate, click-drag from one node to another to draw an edge (smooth curve with arrowhead); live dashed preview line during drag; auto-switch back to Select after drawing
+- **CORE**: `AddEdge`/`RemoveEdge` mutations with full undo/redo support
+- **TESTING**: 5 new tests — `arrow_tool_creates_edge_between_nodes`, `arrow_tool_same_node_no_edge`, `arrow_tool_no_source_no_edge`, `arrow_tool_preview_line_during_drag`, `resolve_arrow_shortcut`
+
 ### v0.8.32
 
 - **UX**: Single-click shape creation now centers the shape at the click point (Excalidraw behavior) — previously the top-left corner was placed at click; rect default size changed from 100×100 to 120×80; ellipse default remains 100×100 centered

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -21,28 +21,168 @@ style dark_text {
   font: "Inter" 400 14
 }
 
-ellipse @_anon_1 {
-  w: 50 h: 40
-  fill: #CCCCD9
-  x: -64.9
-  y: 1207.21
-}
-
-rect @_anon_0 {
-  w: 118.35 h: 32.5
-  fill: #000000
-  corner: 0
-  x: -100.08
-  y: 877.4
-  text @_anon_0_label "gaga" {
-  }
-}
-
 group @settings {
   layout: column gap=20 pad=28
   opacity: 1
-  x: 285.2
-  y: -983.93
+  x: 483.11
+  y: -1120.04
+  group @header {
+    layout: row gap=0 pad=0
+    text @title "Settings" {
+      fill: #FFFFFF
+      font: "Inter" 700 24
+      opacity: 1
+    }
+    rect @close_btn {
+      w: 36 h: 36
+      fill: #2D2D44
+      corner: 18
+      text @_anon_25 "×" {
+        fill: #999999
+        font: "Inter" 400 20
+      }
+      anim :hover {
+        fill: #3D3D5C
+        ease: ease_out 150ms
+      }
+    }
+  }
+  rect @profile_card {
+    w: 344 h: 80
+    use: dark_card
+    x: -656.58
+    y: 860.46
+    group @_anon_26 {
+      layout: row gap=14 pad=16
+      ellipse @user_avatar {
+        spec "User profile photo"
+        w: 48 h: 48
+        fill: #6C5CE7
+        x: 178.49
+        y: -630.04
+      }
+      group @_anon_27 {
+        layout: column gap=4 pad=0
+        text @_anon_28 "Khang Nghiem" {
+          fill: #FFFFFF
+          font: "Inter" 600 16
+          x: -140.44
+          y: -8.39
+        }
+        text @_anon_29 "khang@fastdraft.io" {
+          use: dark_muted
+          x: 159.45
+          y: 287.16
+        }
+      }
+    }
+  }
+  text @_anon_30 "Preferences" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @toggle_dark {
+    w: 344 h: 56
+    use: dark_card
+    x: 238.09
+    y: 834.82
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_notif {
+    w: 344 h: 56
+    use: dark_card
+    x: 376.84
+    y: 708.79
+    group @_anon_35 {
+      layout: row gap=0 pad=16
+      group @_anon_36 {
+        layout: column gap=2 pad=0
+        text @_anon_37 "Notifications" {
+          use: dark_text
+        }
+        text @_anon_38 "Push and email alerts" {
+          use: dark_muted
+        }
+      }
+      rect @switch_off {
+        spec "Toggle — OFF state"
+        w: 44 h: 24
+        fill: #3D3D5C
+        corner: 12
+        ellipse @switch_knob_off {
+          w: 20 h: 20
+          fill: #6B7280
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_sound {
+    w: 344 h: 56
+    use: dark_card
+    x: 28.51
+    y: 340.51
+    group @_anon_39 {
+      layout: row gap=0 pad=16
+      x: 72.88
+      y: 605.77
+      group @_anon_40 {
+        layout: column gap=2 pad=0
+        text @_anon_41 "Sound Effects" {
+          use: dark_text
+          fill: #E0E0E0
+          font: "Inter" 400 14
+          opacity: 1
+        }
+        text @_anon_42 "UI interaction sounds" {
+          use: dark_muted
+        }
+      }
+      rect @switch_sound {
+        w: 44 h: 24
+        fill: #6C5CE7
+        corner: 12
+        x: -19.14
+        y: 83.42
+        ellipse @switch_knob_s {
+          w: 20 h: 20
+          fill: #FFFFFF
+          x: -146.24
+          y: 32.3
+          text @switch_knob_s_label "ehe" {
+          }
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  text @_anon_43 "Display" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @slider_card {
+    w: 344 h: 72
+    use: dark_card
+    fill: #2D2D44
+    corner: 12
+    x: 184.69
+    y: 144.81
+    text @slider_card_label "gaga" {
+    }
+  }
+  text @_anon_48 "Danger Zone" {
+    fill: #E17055
+    font: "Inter" 600 13
+  }
   rect @btn_delete {
     spec {
       "Destructive action — delete account"
@@ -68,162 +208,22 @@ group @settings {
       ease: ease_out 100ms
     }
   }
-  text @_anon_48 "Danger Zone" {
-    fill: #E17055
-    font: "Inter" 600 13
+}
+
+rect @_anon_0 {
+  w: 118.35 h: 32.5
+  fill: #000000
+  corner: 0
+  x: -185
+  y: 653.31
+  text @_anon_0_label "gaga" {
   }
-  rect @slider_card {
-    w: 344 h: 72
-    use: dark_card
-    fill: #2D2D44
-    corner: 12
-    x: 184.69
-    y: 144.81
-    text @slider_card_label "gaga" {
-    }
-  }
-  text @_anon_43 "Display" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @toggle_sound {
-    w: 344 h: 56
-    use: dark_card
-    x: 28.51
-    y: 340.51
-    group @_anon_39 {
-      layout: row gap=0 pad=16
-      x: 72.88
-      y: 605.77
-      rect @switch_sound {
-        w: 44 h: 24
-        fill: #6C5CE7
-        corner: 12
-        x: -19.14
-        y: 83.42
-        ellipse @switch_knob_s {
-          w: 20 h: 20
-          fill: #FFFFFF
-          x: -146.24
-          y: 32.3
-          text @switch_knob_s_label "ehe" {
-          }
-        }
-      }
-      group @_anon_40 {
-        layout: column gap=2 pad=0
-        text @_anon_42 "UI interaction sounds" {
-          use: dark_muted
-        }
-        text @_anon_41 "Sound Effects" {
-          use: dark_text
-          fill: #E0E0E0
-          font: "Inter" 400 14
-          opacity: 1
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_notif {
-    w: 344 h: 56
-    use: dark_card
-    x: 376.84
-    y: 708.79
-    group @_anon_35 {
-      layout: row gap=0 pad=16
-      rect @switch_off {
-        spec "Toggle — OFF state"
-        w: 44 h: 24
-        fill: #3D3D5C
-        corner: 12
-        ellipse @switch_knob_off {
-          w: 20 h: 20
-          fill: #6B7280
-        }
-      }
-      group @_anon_36 {
-        layout: column gap=2 pad=0
-        text @_anon_38 "Push and email alerts" {
-          use: dark_muted
-        }
-        text @_anon_37 "Notifications" {
-          use: dark_text
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_dark {
-    w: 344 h: 56
-    use: dark_card
-    x: 238.09
-    y: 834.82
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  text @_anon_30 "Preferences" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @profile_card {
-    w: 344 h: 80
-    use: dark_card
-    x: -656.58
-    y: 860.46
-    group @_anon_26 {
-      layout: row gap=14 pad=16
-      group @_anon_27 {
-        layout: column gap=4 pad=0
-        text @_anon_29 "khang@fastdraft.io" {
-          use: dark_muted
-          x: 159.45
-          y: 287.16
-        }
-        text @_anon_28 "Khang Nghiem" {
-          fill: #FFFFFF
-          font: "Inter" 600 16
-          x: -140.44
-          y: -8.39
-        }
-      }
-      ellipse @user_avatar {
-        spec "User profile photo"
-        w: 48 h: 48
-        fill: #6C5CE7
-        x: 178.49
-        y: -630.04
-      }
-    }
-  }
-  group @header {
-    layout: row gap=0 pad=0
-    rect @close_btn {
-      w: 36 h: 36
-      fill: #2D2D44
-      corner: 18
-      text @_anon_25 "×" {
-        fill: #999999
-        font: "Inter" 400 20
-      }
-      anim :hover {
-        fill: #3D3D5C
-        ease: ease_out 150ms
-      }
-    }
-    text @title "Settings" {
-      fill: #FFFFFF
-      font: "Inter" 700 24
-      opacity: 1
-    }
-  }
+}
+
+ellipse @_anon_1 {
+  w: 50 h: 40
+  fill: #CCCCD9
+  x: -64.9
+  y: 1207.21
 }
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1810,6 +1810,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     <button class="tool-btn" data-tool="rect"><span class="tool-icon">▢</span>Rect<span class="tool-key">R</span></button>
     <button class="tool-btn" data-tool="ellipse"><span class="tool-icon">◯</span>Ellipse<span class="tool-key">O</span></button>
     <button class="tool-btn" data-tool="pen"><span class="tool-icon">✎</span>Pen<span class="tool-key">P</span></button>
+    <button class="tool-btn" data-tool="arrow"><span class="tool-icon">→</span>Arrow<span class="tool-key">A</span></button>
     <button class="tool-btn" data-tool="text"><span class="tool-icon">T</span>Text<span class="tool-key">T</span></button>
     <div class="tool-sep"></div>
     <button class="tool-btn" id="ai-refine-btn" title="AI Refine selected node (rename + restyle)">&#x2728; Refine</button>


### PR DESCRIPTION
## Arrow/Connector Drawing Tool

### Changes
- **ArrowTool** (`tools.rs`): Click-drag from node-to-node to create edges with smooth curves and arrowheads
- **AddEdge/RemoveEdge mutations** (`sync.rs`): Full undo/redo support via commands.rs
- **Keyboard shortcut** `A` to activate arrow tool (`shortcuts.rs`)
- **Toolbar button** with `→` icon between Pen and Text (`extension.ts`)
- **Live preview** dashed line with arrowhead during drag (`main.js`)
- Auto-switch back to Select tool after edge creation

### Testing
- `arrow_tool_creates_edge_between_nodes` — verifies AddEdge mutation with correct from/to
- `arrow_tool_same_node_no_edge` — guard: no self-referencing edges
- `arrow_tool_no_source_no_edge` — guard: no edge without source node
- `arrow_tool_preview_line_during_drag` — lifecycle: appears on down, updates on move, clears on up
- `resolve_arrow_shortcut` — key A maps to ToolArrow

### CI
- `cargo test --workspace` ✅ (all pass)
- `cargo clippy --workspace -- -D warnings` ✅ (clean)
- `cargo fmt --all -- --check` ✅ (clean)