### PR TITLE
feat(render): add Sketchy hand-drawn rendering mode toggle

### DIFF
--- a/.agents/workflows/nonstop.md
+++ b/.agents/workflows/nonstop.md
@@ -64,7 +64,23 @@ description: Continuous autonomous agent — work until all tasks are done, then
 
 9. **Fix any failures** before proceeding. If a check fails, fix and re-run.
 
-10. **Commit and push**:
+10. **E2E UX browser testing** (if `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `fd-vscode/webview/` changed):
+
+    Run the full `/e2e-ux` workflow using the browser subagent:
+    - Build WASM first if Rust crates changed:
+
+      ```bash
+      wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm
+      ```
+
+    - Open the Codespace in browser via `gh codespace code -c <codespace-name> --web`
+    - Execute all 8 phases from `/e2e-ux` (Canvas Load, Drawing Tools, Selection, Inline Editing, Navigation, Panels, Bidi Sync, Keyboard Shortcuts)
+    - Screenshot and report results per phase
+    - **If any phase fails**: Fix the issue before proceeding
+
+    > **Skip only if** the change is purely Rust internals with no canvas/UI impact (e.g., parser refactors covered by unit tests).
+
+11. **Commit and push**:
 
     ```bash
     git add -A
@@ -72,34 +88,34 @@ description: Continuous autonomous agent — work until all tasks are done, then
     git push -u origin HEAD
     ```
 
-11. **Create a PR** using GitKraken MCP:
+12. **Create a PR** using GitKraken MCP:
     - `provider`: github
     - `source_branch`: current branch
     - `target_branch`: main
     - Title in conventional commit format
     - Body with summary + verification results
 
-12. **Mark task `[x]`** in `task.md` and return to step 5.
+13. **Mark task `[x]`** in `task.md` and return to step 5.
 
 ## Phase 3: Proactive Discovery
 
 > When all known tasks are done, look for more work.
 
-13. **Re-scan** for new TODOs, untested code, or missing docs:
+14. **Re-scan** for new TODOs, untested code, or missing docs:
 
     ```bash
     rg -n "TODO|FIXME|HACK|XXX" --type rust --type ts || true
     ```
 
-14. **Check test coverage gaps** — look for public functions without tests:
+15. **Check test coverage gaps** — look for public functions without tests:
 
     ```bash
     cargo test --workspace -- --list 2>&1 | head -50
     ```
 
-15. If new work is found, add to `task.md` and return to **Phase 2**.
+16. If new work is found, add to `task.md` and return to **Phase 2**.
 
-16. If no more work is found, **report summary** to user:
+17. If no more work is found, **report summary** to user:
     - Total tasks completed
     - PRs created (with URLs)
     - Remaining known issues (if any)

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -44,6 +44,8 @@ pub struct FdCanvas {
     suppress_sync: bool,
     /// Dark mode flag — `false` = light (default), `true` = dark.
     dark_mode: bool,
+    /// Sketchy hand-drawn rendering mode.
+    sketchy_mode: bool,
     hovered_id: Option<fd_core::id::NodeId>,
     pressed_id: Option<fd_core::id::NodeId>,
     /// Deferred drill-down target: when pointer-down on a child of a selected
@@ -83,6 +85,7 @@ impl FdCanvas {
             height,
             suppress_sync: false,
             dark_mode: false,
+            sketchy_mode: false,
             hovered_id: None,
             pressed_id: None,
             pending_drill_target: None,
@@ -135,12 +138,23 @@ impl FdCanvas {
             self.hovered_id.as_ref().map(|id| id.as_str()),
             self.pressed_id.as_ref().map(|id| id.as_str()),
             &guides,
+            self.sketchy_mode,
         );
     }
 
     /// Set the canvas theme.
     pub fn set_theme(&mut self, is_dark: bool) {
         self.dark_mode = is_dark;
+    }
+
+    /// Enable or disable sketchy (hand-drawn) rendering mode.
+    pub fn set_sketchy_mode(&mut self, enabled: bool) {
+        self.sketchy_mode = enabled;
+    }
+
+    /// Check if sketchy rendering mode is enabled.
+    pub fn get_sketchy_mode(&self) -> bool {
+        self.sketchy_mode
     }
 
     /// Resize the canvas.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.8.34
+
+- **FEATURE**: Sketchy / hand-drawn rendering mode — toggle via ✏️ toolbar button; rects get wobbly corners with double-stroke, ellipses use overlapping jittery arcs, straight edges get midpoint displacement; deterministic jitter seeded by position (shapes don't dance on re-render); cosmetic only — underlying geometry stays precise
+- **UX**: State persists across sessions via webview state
+- **TESTING**: 3 new tests — `sketchy_jitter_deterministic`, `sketchy_jitter_bounded`, `sketchy_jitter_varies_with_index`
+
 ### v0.8.33
 
 - **FEATURE**: Arrow/Connector drawing tool — press `A` to activate, click-drag from one node to another to draw an edge (smooth curve with arrowhead); live dashed preview line during drag; auto-switch back to Select after drawing

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.33",
+  "version": "0.8.34",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1824,6 +1824,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     <button class="tool-btn" id="grid-toggle-btn" title="Toggle grid overlay (G)">⊞</button>
     <button class="tool-btn" id="export-btn" title="Export canvas as PNG">📥</button>
     <div class="tool-sep"></div>
+    <button class="tool-btn" id="sketchy-toggle-btn" title="Toggle sketchy hand-drawn mode">✏️</button>
     <button class="tool-btn" id="theme-toggle-btn" title="Toggle light/dark canvas theme">🌙</button>
     <button id="zoom-level" title="Zoom level (click to reset to 100%)">100%</button>
     <button class="tool-btn" id="tool-help-btn" title="Keyboard shortcuts">?</button>

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -190,6 +190,7 @@ async function main() {
     setupHelpButton();
     setupApplePencilPro();
     setupThemeToggle();
+    setupSketchyToggle();
     setupZoomIndicator();
     setupGridToggle();
     setupExportButton();
@@ -2843,6 +2844,32 @@ function applyTheme(isDark) {
     fdCanvas.set_theme(isDark);
     render();
   }
+}
+
+// ─── Sketchy Mode Toggle ──────────────────────────────────────────────────────
+
+function setupSketchyToggle() {
+  const btn = document.getElementById("sketchy-toggle-btn");
+  if (!btn) return;
+
+  // Restore persisted state
+  const savedState = vscode.getState();
+  if (savedState && savedState.sketchyMode) {
+    btn.classList.add("active");
+    if (fdCanvas) {
+      fdCanvas.set_sketchy_mode(true);
+      render();
+    }
+  }
+
+  btn.addEventListener("click", () => {
+    if (!fdCanvas) return;
+    const enabled = !fdCanvas.get_sketchy_mode();
+    fdCanvas.set_sketchy_mode(enabled);
+    btn.classList.toggle("active", enabled);
+    vscode.setState({ ...(vscode.getState() || {}), sketchyMode: enabled });
+    render();
+  });
 }
 
 // ─── Dimension Tooltip (R3.18) ────────────────────────────────────────────────


### PR DESCRIPTION
## Sketchy / Hand-Drawn Rendering Mode

### Changes
- **Sketchy drawing functions** (`render2d.rs`): `draw_rect_sketchy()` with wobbly corners + double-stroke, `draw_ellipse_sketchy()` with overlapping jittery arcs, `sketchy_line()` with midpoint displacement for edges
- **Deterministic jitter**: `sketchy_jitter()` seeded by node position — shapes don't dance on re-render
- **WASM API** (`lib.rs`): `set_sketchy_mode()` / `get_sketchy_mode()` + `sketchy: bool` threaded through entire render pipeline
- **Toolbar toggle** (`extension.ts`): ✏️ button with persistent state
- **JS handler** (`main.js`): `setupSketchyToggle()` with webview state persistence
- Cosmetic only — underlying geometry stays precise for AI consumption

### Tests (3 new)
- `sketchy_jitter_deterministic` — same seed+index always returns same value
- `sketchy_jitter_bounded` — output stays within [-amplitude, +amplitude]
- `sketchy_jitter_varies_with_index` — different indices produce different values

### CI
- `cargo test --workspace` ✅ (17 passed)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅