### PR TITLE
feat(ui): add Sticky Tool Mode (tool locking)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.36
+
+- **FEATURE**: Sticky Tool Mode — double-click a tool icon or press its shortcut twice (RR, OO, PP, AA, TT) to lock the tool; it stays active after placing shapes. 🔒 badge appears on locked tool button. Single-click or press V/Escape to unlock.
+- **UX**: Excalidraw-style rapid shape placement without re-selecting the tool each time
+
 ### v0.8.35
 
 - **FEATURE**: Zen Mode — minimal Excalidraw-like toolbar layout; floating pill bar at bottom center with 6 drawing tools (Select, Rect, Ellipse, Pen, Arrow, Text); hides Layers, Properties, Minimap, Shape Palette panels

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -449,6 +449,20 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       box-shadow: var(--fd-segment-shadow);
       font-weight: 600;
     }
+    .tool-btn.locked {
+      background: var(--fd-segment-active);
+      color: var(--fd-text);
+      box-shadow: var(--fd-segment-shadow), 0 0 0 1.5px var(--fd-accent);
+      font-weight: 600;
+    }
+    .tool-btn.locked::after {
+      content: '🔒';
+      font-size: 8px;
+      position: absolute;
+      top: -3px;
+      right: -3px;
+      line-height: 1;
+    }
     .tool-icon { font-size: 13px; }
     .tool-key {
       font-size: 9px;


### PR DESCRIPTION
## Sticky Tool Mode (Tool Locking)

### What
Double-click a tool icon or press its shortcut twice (RR, OO, PP, AA, TT) to **lock** the tool. Locked tool stays active after placing shapes — Excalidraw-style rapid shape placement.

### How to Unlock
- Single-click the locked tool button
- Press **V** (Select) or **Escape**
- Switch to a different tool (clears lock)

### Visual Indicator  
🔒 badge on locked button + accent ring

### Files Changed
- `extension.ts`: `.locked` CSS with 🔒 `::after` badge
- `main.js`: `lockTool()/unlockTool()`, double-click, double-press (400ms), pointer_up override