### PR TITLE
feat: smarter keyboard shortcuts, z-order, Frame tool

### DIFF
--- a/crates/fd-editor/src/shortcuts.rs
+++ b/crates/fd-editor/src/shortcuts.rs
@@ -20,6 +20,7 @@ pub enum ShortcutAction {
     ToolPen,
     ToolText,
     ToolArrow,
+    ToolFrame,
     /// Toggle between current and previous tool (Screenbrush: Tab).
     ToggleLastTool,
 
@@ -131,6 +132,7 @@ impl ShortcutMap {
             "p" | "P" => Some(ShortcutAction::ToolPen),
             "t" | "T" => Some(ShortcutAction::ToolText),
             "a" | "A" => Some(ShortcutAction::ToolArrow),
+            "f" | "F" => Some(ShortcutAction::ToolFrame),
             // Screenbrush: Tab = toggle between two most-used tools
             "Tab" => Some(ShortcutAction::ToggleLastTool),
             "Delete" | "Backspace" => Some(ShortcutAction::Delete),
@@ -170,6 +172,10 @@ mod tests {
         assert_eq!(
             ShortcutMap::resolve("a", false, false, false, false),
             Some(ShortcutAction::ToolArrow)
+        );
+        assert_eq!(
+            ShortcutMap::resolve("f", false, false, false, false),
+            Some(ShortcutAction::ToolFrame)
         );
     }
 

--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -26,6 +26,7 @@ pub enum ToolKind {
     Pen,
     Text,
     Arrow,
+    Frame,
 }
 
 /// Trait for tools that handle input and produce mutations.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## Completed Requirements
 
+### v0.8.37
+
+- **FEATURE**: Z-order shortcuts — ⌘[ send backward, ⌘] bring forward, ⌘⇧[ send to back, ⌘⇧] bring to front (implemented in Rust SceneGraph)
+- **FEATURE**: Frame tool — F key, toolbar button, reuses RectTool with frame semantics
+- **FEATURE**: 0 key resets zoom to 100%
+- **SHORTCUT**: ⌘D duplicate, ⌘G group, ⌘⇧G ungroup, Del/Backspace delete — all already mapped, now documented
+- **SHORTCUT**: F key added to double-press tool lock (FF locks Frame tool)
+- **UI**: Comprehensive help dialog (?) with 6 categories: Tools, Edit, Transform, View, Modifiers, Apple Pencil Pro
+
 ### v0.8.36
 
 - **FEATURE**: Sticky Tool Mode — double-click a tool icon or press its shortcut twice (RR, OO, PP, AA, TT) to lock the tool; it stays active after placing shapes. 🔒 badge appears on locked tool button. Single-click or press V/Escape to unlock.

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -21,168 +21,28 @@ style dark_text {
   font: "Inter" 400 14
 }
 
+ellipse @_anon_1 {
+  w: 50 h: 40
+  fill: #CCCCD9
+  x: -64.9
+  y: 1207.21
+}
+
+rect @_anon_0 {
+  w: 118.35 h: 32.5
+  fill: #000000
+  corner: 0
+  x: -185
+  y: 653.31
+  text @_anon_0_label "gaga" {
+  }
+}
+
 group @settings {
   layout: column gap=20 pad=28
   opacity: 1
-  x: 483.11
-  y: -1120.04
-  group @header {
-    layout: row gap=0 pad=0
-    text @title "Settings" {
-      fill: #FFFFFF
-      font: "Inter" 700 24
-      opacity: 1
-    }
-    rect @close_btn {
-      w: 36 h: 36
-      fill: #2D2D44
-      corner: 18
-      text @_anon_25 "×" {
-        fill: #999999
-        font: "Inter" 400 20
-      }
-      anim :hover {
-        fill: #3D3D5C
-        ease: ease_out 150ms
-      }
-    }
-  }
-  rect @profile_card {
-    w: 344 h: 80
-    use: dark_card
-    x: -656.58
-    y: 860.46
-    group @_anon_26 {
-      layout: row gap=14 pad=16
-      ellipse @user_avatar {
-        spec "User profile photo"
-        w: 48 h: 48
-        fill: #6C5CE7
-        x: 178.49
-        y: -630.04
-      }
-      group @_anon_27 {
-        layout: column gap=4 pad=0
-        text @_anon_28 "Khang Nghiem" {
-          fill: #FFFFFF
-          font: "Inter" 600 16
-          x: -140.44
-          y: -8.39
-        }
-        text @_anon_29 "khang@fastdraft.io" {
-          use: dark_muted
-          x: 159.45
-          y: 287.16
-        }
-      }
-    }
-  }
-  text @_anon_30 "Preferences" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @toggle_dark {
-    w: 344 h: 56
-    use: dark_card
-    x: 238.09
-    y: 834.82
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_notif {
-    w: 344 h: 56
-    use: dark_card
-    x: 376.84
-    y: 708.79
-    group @_anon_35 {
-      layout: row gap=0 pad=16
-      group @_anon_36 {
-        layout: column gap=2 pad=0
-        text @_anon_37 "Notifications" {
-          use: dark_text
-        }
-        text @_anon_38 "Push and email alerts" {
-          use: dark_muted
-        }
-      }
-      rect @switch_off {
-        spec "Toggle — OFF state"
-        w: 44 h: 24
-        fill: #3D3D5C
-        corner: 12
-        ellipse @switch_knob_off {
-          w: 20 h: 20
-          fill: #6B7280
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  rect @toggle_sound {
-    w: 344 h: 56
-    use: dark_card
-    x: 28.51
-    y: 340.51
-    group @_anon_39 {
-      layout: row gap=0 pad=16
-      x: 72.88
-      y: 605.77
-      group @_anon_40 {
-        layout: column gap=2 pad=0
-        text @_anon_41 "Sound Effects" {
-          use: dark_text
-          fill: #E0E0E0
-          font: "Inter" 400 14
-          opacity: 1
-        }
-        text @_anon_42 "UI interaction sounds" {
-          use: dark_muted
-        }
-      }
-      rect @switch_sound {
-        w: 44 h: 24
-        fill: #6C5CE7
-        corner: 12
-        x: -19.14
-        y: 83.42
-        ellipse @switch_knob_s {
-          w: 20 h: 20
-          fill: #FFFFFF
-          x: -146.24
-          y: 32.3
-          text @switch_knob_s_label "ehe" {
-          }
-        }
-      }
-    }
-    anim :hover {
-      fill: #353550
-      ease: ease_out 150ms
-    }
-  }
-  text @_anon_43 "Display" {
-    fill: #6B7280
-    font: "Inter" 600 13
-  }
-  rect @slider_card {
-    w: 344 h: 72
-    use: dark_card
-    fill: #2D2D44
-    corner: 12
-    x: 184.69
-    y: 144.81
-    text @slider_card_label "gaga" {
-    }
-  }
-  text @_anon_48 "Danger Zone" {
-    fill: #E17055
-    font: "Inter" 600 13
-  }
+  x: 586.58
+  y: -1062.95
   rect @btn_delete {
     spec {
       "Destructive action — delete account"
@@ -208,22 +68,162 @@ group @settings {
       ease: ease_out 100ms
     }
   }
-}
-
-rect @_anon_0 {
-  w: 118.35 h: 32.5
-  fill: #000000
-  corner: 0
-  x: -185
-  y: 653.31
-  text @_anon_0_label "gaga" {
+  text @_anon_48 "Danger Zone" {
+    fill: #E17055
+    font: "Inter" 600 13
   }
-}
-
-ellipse @_anon_1 {
-  w: 50 h: 40
-  fill: #CCCCD9
-  x: -64.9
-  y: 1207.21
+  rect @slider_card {
+    w: 344 h: 72
+    use: dark_card
+    fill: #2D2D44
+    corner: 12
+    x: 184.69
+    y: 144.81
+    text @slider_card_label "gaga" {
+    }
+  }
+  text @_anon_43 "Display" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @toggle_sound {
+    w: 344 h: 56
+    use: dark_card
+    x: 28.51
+    y: 340.51
+    group @_anon_39 {
+      layout: row gap=0 pad=16
+      x: 72.88
+      y: 605.77
+      rect @switch_sound {
+        w: 44 h: 24
+        fill: #6C5CE7
+        corner: 12
+        x: -19.14
+        y: 83.42
+        ellipse @switch_knob_s {
+          w: 20 h: 20
+          fill: #FFFFFF
+          x: -146.24
+          y: 32.3
+          text @switch_knob_s_label "ehe" {
+          }
+        }
+      }
+      group @_anon_40 {
+        layout: column gap=2 pad=0
+        text @_anon_42 "UI interaction sounds" {
+          use: dark_muted
+        }
+        text @_anon_41 "Sound Effects" {
+          use: dark_text
+          fill: #E0E0E0
+          font: "Inter" 400 14
+          opacity: 1
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_notif {
+    w: 344 h: 56
+    use: dark_card
+    x: 376.84
+    y: 708.79
+    group @_anon_35 {
+      layout: row gap=0 pad=16
+      rect @switch_off {
+        spec "Toggle — OFF state"
+        w: 44 h: 24
+        fill: #3D3D5C
+        corner: 12
+        ellipse @switch_knob_off {
+          w: 20 h: 20
+          fill: #6B7280
+        }
+      }
+      group @_anon_36 {
+        layout: column gap=2 pad=0
+        text @_anon_38 "Push and email alerts" {
+          use: dark_muted
+        }
+        text @_anon_37 "Notifications" {
+          use: dark_text
+        }
+      }
+    }
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  rect @toggle_dark {
+    w: 344 h: 56
+    use: dark_card
+    x: 238.09
+    y: 834.82
+    anim :hover {
+      fill: #353550
+      ease: ease_out 150ms
+    }
+  }
+  text @_anon_30 "Preferences" {
+    fill: #6B7280
+    font: "Inter" 600 13
+  }
+  rect @profile_card {
+    w: 344 h: 80
+    use: dark_card
+    x: -656.58
+    y: 860.46
+    group @_anon_26 {
+      layout: row gap=14 pad=16
+      group @_anon_27 {
+        layout: column gap=4 pad=0
+        text @_anon_29 "khang@fastdraft.io" {
+          use: dark_muted
+          x: 159.45
+          y: 287.16
+        }
+        text @_anon_28 "Khang Nghiem" {
+          fill: #FFFFFF
+          font: "Inter" 600 16
+          x: -140.44
+          y: -8.39
+        }
+      }
+      ellipse @user_avatar {
+        spec "User profile photo"
+        w: 48 h: 48
+        fill: #6C5CE7
+        x: 178.49
+        y: -630.04
+      }
+    }
+  }
+  group @header {
+    layout: row gap=0 pad=0
+    rect @close_btn {
+      w: 36 h: 36
+      fill: #2D2D44
+      corner: 18
+      text @_anon_25 "×" {
+        fill: #999999
+        font: "Inter" 400 20
+      }
+      anim :hover {
+        fill: #3D3D5C
+        ease: ease_out 150ms
+      }
+    }
+    text @title "Settings" {
+      fill: #FFFFFF
+      font: "Inter" 700 24
+      opacity: 1
+    }
+  }
 }
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.36",
+  "version": "0.8.37",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1894,6 +1894,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     <button class="tool-btn" data-tool="pen"><span class="tool-icon">✎</span>Pen<span class="tool-key">P</span></button>
     <button class="tool-btn" data-tool="arrow"><span class="tool-icon">→</span>Arrow<span class="tool-key">A</span></button>
     <button class="tool-btn" data-tool="text"><span class="tool-icon">T</span>Text<span class="tool-key">T</span></button>
+    <button class="tool-btn" data-tool="frame"><span class="tool-icon">⊞</span>Frame<span class="tool-key">F</span></button>
     <div class="tool-sep zen-full-only"></div>
     <button class="tool-btn zen-full-only" id="ai-refine-btn" title="AI Refine selected node (rename + restyle)">&#x2728; Refine</button>
     <button class="tool-btn zen-full-only" id="ai-refine-all-btn" title="AI Refine all anonymous nodes">&#x2728; All</button>

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -820,6 +820,20 @@ document.addEventListener("keydown", (e) => {
       return;
     }
   }
+
+  // ── 0 key: reset zoom to 100% ──
+  if (e.key === "0" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    const active = document.activeElement;
+    const isTextInput = active && (active.tagName === "TEXTAREA" || active.tagName === "INPUT");
+    if (!isTextInput) {
+      e.preventDefault();
+      cameraZoom = 1.0;
+      updateZoomIndicator();
+      render();
+      return;
+    }
+  }
+
   // ── V key or Escape: unlock tool if locked ──
   if ((e.key === "v" || e.key === "V" || e.key === "Escape") && !e.metaKey && !e.ctrlKey) {
     if (lockedTool) {
@@ -830,7 +844,7 @@ document.addEventListener("keydown", (e) => {
   }
 
   // ── Double-press detection for tool locking (RR, OO, PP, AA, TT) ──
-  const toolShortcuts = { r: "rect", o: "ellipse", p: "pen", a: "arrow", t: "text" };
+  const toolShortcuts = { r: "rect", o: "ellipse", p: "pen", a: "arrow", t: "text", f: "frame" };
   const lowerKey = e.key.toLowerCase();
   if (toolShortcuts[lowerKey] && !e.metaKey && !e.ctrlKey && !e.altKey) {
     const now = Date.now();
@@ -1053,8 +1067,12 @@ function buildShortcutHelpHtml() {
         ["R", "Rectangle"],
         ["O", "Ellipse"],
         ["P", "Pen (freehand)"],
+        ["A", "Arrow"],
         ["T", "Text"],
+        ["F", "Frame"],
         ["Tab", "Toggle last two tools"],
+        ["R R", "Lock tool (stays active)"],
+        ["Escape", "Unlock tool / Deselect"],
       ],
     },
     {
@@ -1062,18 +1080,25 @@ function buildShortcutHelpHtml() {
       shortcuts: [
         [`${cmd}Z`, "Undo"],
         [`${cmd}⇧Z`, "Redo"],
-        ["Delete", "Delete selected"],
-        [`${cmd}Delete`, "Clear selected"],
-        [`${cmd}D`, "Duplicate"],
+        ["Del / ⌫", "Delete selected"],
+        [`${cmd}D`, "Duplicate (+10,+10)"],
         [`${cmd}A`, "Select all"],
-      ],
-    },
-    {
-      title: "Clipboard",
-      shortcuts: [
+        [`${cmd}G`, "Group selected"],
+        [`${cmd}⇧G`, "Ungroup"],
         [`${cmd}C`, "Copy"],
         [`${cmd}X`, "Cut"],
         [`${cmd}V`, "Paste"],
+      ],
+    },
+    {
+      title: "Transform",
+      shortcuts: [
+        [`${cmd}[`, "Send backward"],
+        [`${cmd}]`, "Bring forward"],
+        [`${cmd}⇧[`, "Send to back"],
+        [`${cmd}⇧]`, "Bring to front"],
+        ["Arrow keys", "Nudge 1px"],
+        ["Shift+Arrow", "Nudge 10px"],
       ],
     },
     {
@@ -1081,33 +1106,23 @@ function buildShortcutHelpHtml() {
       shortcuts: [
         [`${cmd}+`, "Zoom in"],
         [`${cmd}−`, "Zoom out"],
+        ["0", "Reset zoom to 100%"],
         [`${cmd}0`, "Zoom to fit"],
-        ["Pinch", "Trackpad zoom"],
+        [`${cmd}1`, "Zoom to selection"],
+        ["L", "Toggle Layers panel"],
+        ["G", "Toggle grid overlay"],
         ["Space (hold)", "Pan / hand tool"],
         [`${cmd} (hold)`, "Temp. hand tool"],
-        ["Click %", "Reset zoom to 100%"],
-        ["G", "Toggle grid overlay"],
-        [`${cmd}1`, "Zoom to selection"],
-      ],
-    },
-    {
-      title: "Z-Order",
-      shortcuts: [
-        [`${cmd}[`, "Send backward"],
-        [`${cmd}]`, "Bring forward"],
-        [`${cmd}⇧[`, "Send to back"],
-        [`${cmd}⇧]`, "Bring to front"],
+        ["Pinch", "Trackpad zoom"],
       ],
     },
     {
       title: "Modifiers (while dragging)",
       shortcuts: [
         ["Shift", "Constrain axis / square"],
-        ["Alt / ⌥", "Duplicate on click"],
-        [`⌥${cmd}`, "Copy while moving"],
-        ["Arrow keys", "Nudge 1px"],
-        ["Shift+Arrow", "Nudge 10px"],
-        ["Double-click", "Create text / edit text"],
+        ["Alt+drag", "Duplicate while moving"],
+        ["Double-click", "Edit text / create text"],
+        ["Dbl-click tool", "Lock tool (🔒)"],
       ],
     },
     {


### PR DESCRIPTION
## Smarter Keyboard Shortcuts + Z-Order + Frame Tool

### Rust Changes
- **Z-order**: `send_backward/bring_forward/send_to_back/bring_to_front` methods on SceneGraph (edge reordering). Wired in `dispatch_action`.
- **Frame tool**: `ToolKind::Frame`, F key binding, pointer dispatch (reuses RectTool)
- **ShortcutMap**: `ToolFrame` + F key + test

### JS Changes  
- **0 key**: Resets zoom to 100%
- **F in toolbar**: Frame button with ⊞ icon
- **F in tool lock**: FF locks Frame tool
- **Help dialog**: Comprehensive 6-category grid (Tools, Edit, Transform, View, Modifiers, Apple Pencil)

### Already Working (Now Documented)
⌘D duplicate, ⌘G group, ⌘⇧G ungroup, Del/Backspace delete — all were already mapped in ShortcutMap

### CI ✅
17 tests pass, clippy clean, fmt clean