### PR TITLE
feat(ui): smart defaults + Alt+click style picker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.40
+
+- **FEATURE**: Smart Defaults (Sticky Styles) — changing fill/stroke/strokeWidth/opacity/fontSize on any node stores it as the default for future shapes of that tool (Excalidraw-style)
+- **FEATURE**: Style Picker — Alt+click a node to copy its entire style (fill, stroke, opacity, font) as defaults for all tools (eyedropper for styles, not just colors)
+- **UX**: Defaults captured from both Floating Action Bar and Properties panel changes; applied automatically on new shape creation
+- **UX**: Per-tool session memory — rect remembers rect defaults, text remembers text defaults, etc. Resets on reload
+
 ### v0.8.39
 
 - **FEATURE**: Contextual Floating Toolbar — glassmorphism pill bar appears above selected nodes with: fill color swatch, stroke color swatch, stroke width input, opacity slider, font size (text nodes only), and ⋯ overflow menu (Group, Ungroup, Duplicate, Delete)

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -92,13 +92,32 @@
 
 ### When Select Tool is active (V)
 
-| Modifier       | On Object        | On Empty Space |
-| -------------- | ---------------- | -------------- |
-| None           | Move / select    | Marquee select |
-| `Alt`          | **Clone + drag** | Marquee select |
-| `Shift`        | Add to selection | Add to marquee |
-| `⌘` (hold)     | Pan              | Pan            |
-| `Space` (hold) | Pan              | Pan            |
+| Modifier           | On Object                                                 | On Empty Space |
+| ------------------ | --------------------------------------------------------- | -------------- |
+| None               | Move / select                                             | Marquee select |
+| `Alt`              | **Clone + drag**                                          | Marquee select |
+| `Alt` (click only) | **Style picker** — copies fill/stroke/opacity as defaults | —              |
+| `Shift`            | Add to selection                                          | Add to marquee |
+| `⌘` (hold)         | Pan                                                       | Pan            |
+| `Space` (hold)     | Pan                                                       | Pan            |
+
+---
+
+## Smart Defaults (Sticky Styles)
+
+Per-tool session memory for style properties. When you change a shape's style, the next shape you create uses those same styles.
+
+| Tracked Property | Applies To          |
+| ---------------- | ------------------- |
+| Fill color       | rect, ellipse, text |
+| Stroke color     | All tools           |
+| Stroke width     | All tools           |
+| Opacity          | All tools           |
+| Font size        | text only           |
+
+Defaults are **captured** from both the Floating Action Bar and the Properties panel.
+Defaults are **applied** automatically when a new shape is drawn.
+Defaults **reset** on page reload (session only, not saved to `.fd` file).
 
 ---
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.39",
+  "version": "0.8.40",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Smart Defaults + Style Picker

### Sticky Style Memory (Excalidraw-style)
- Changing fill/stroke/strokeWidth/opacity/fontSize stores it as default for future shapes
- Per-tool session memory: rect, ellipse, pen, arrow, text, frame
- Captured from both Floating Action Bar and Properties panel
- Applied automatically on new shape creation

### Style Picker (Alt+click)
- Alt+click any node → copies its entire style (fill, stroke, opacity, font) as defaults
- Works like an eyedropper for styles, not just colors
- Sets defaults globally for all tools

### Implementation
- `toolDefaults` object with per-tool session memory
- `captureDefault()` wired to 8 handlers (5 FAB + 2 Properties panel + 1 opacity)
- `applyDefaultsToNewNode()` called after shape creation in pointerup
- `pickStyleFromSelectedNode()` for Alt+click
- `lastDrawingTool` tracking for capturing from Select mode edits

### CI ✅