### PR TITLE
feat(ui): empty-state onboarding overlay + welcome.fd tutorial

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.42
+
+- **FEATURE**: Empty-state onboarding overlay — appears on empty canvas with "Start drawing" animated heading, 3 quick-start cards (📐 Shapes, ✏️ Sketch, 📝 Text), and `?` shortcut hint
+- **UX**: Cards activate the corresponding tool and dismiss the overlay; also dismissed on any canvas click or keypress
+- **FEATURE**: `examples/welcome.fd` — interactive tutorial with 3 step cards, hover animations, playground area; auto-opens on first-ever extension activation
+- **UX**: First-activation detection via globalState `fd.welcomed` flag — only shows once
+
 ### v0.8.41
 
 - **FIX**: Paste now recursively renames ALL `@ids` in the pasted block (not just the root) — prevents ID collisions when pasting groups with children

--- a/examples/welcome.fd
+++ b/examples/welcome.fd
@@ -1,0 +1,110 @@
+# Welcome to Fast Draft!
+# Click any shape to select it. Try moving, resizing, and editing.
+
+style accent { fill: #6C5CE7 }
+style soft { fill: #DFE6E9; corner: 12 }
+style label_style { font: "Inter" 500 14; fill: #2D3436 }
+
+# ── Title ──
+text @welcome_title "Welcome to Fast Draft ✨" {
+  x: 180  y: 40
+  font: "Inter" 700 28
+  fill: #2D3436
+}
+
+text @welcome_sub "Click, move, and edit these shapes to learn the basics" {
+  x: 180  y: 80
+  font: "Inter" 400 14
+  fill: #636E72
+}
+
+# ── Step 1: Shapes ──
+rect @step1_bg {
+  x: 60  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step1_title "1. Draw Shapes" {
+  x: 80  y: 160
+  use: label_style
+}
+
+text @step1_desc "Press R for rectangles\nPress O for ellipses\nPress F for frames" {
+  x: 80  y: 190
+  font: "Inter" 400 12
+  fill: #636E72
+}
+
+rect @step1_demo {
+  x: 220  y: 200
+  w: 30  h: 30
+  use: accent
+  corner: 6
+  anim :hover { scale: 1.1; ease: spring 200ms }
+}
+
+# ── Step 2: Text ──
+rect @step2_bg {
+  x: 300  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step2_title "2. Add Text" {
+  x: 320  y: 160
+  use: label_style
+}
+
+text @step2_desc "Press T for text tool\nDouble-click to edit\nTry changing this!" {
+  x: 320  y: 190
+  font: "Inter" 400 12
+  fill: #636E72
+}
+
+# ── Step 3: Styles ──
+rect @step3_bg {
+  x: 540  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step3_title "3. Style It" {
+  x: 560  y: 160
+  use: label_style
+}
+
+text @step3_desc "Select a shape\nUse the floating bar\nto change fill & stroke" {
+  x: 560  y: 190
+  font: "Inter" 400 12
+  fill: #636E72
+}
+
+ellipse @step3_demo {
+  x: 700  y: 200
+  w: 20  h: 20
+  fill: #E17055
+  anim :hover { fill: #00B894; ease: ease_out 300ms }
+}
+
+# ── Interactive Demo Area ──
+text @playground_label "Playground — try drawing below!" {
+  x: 180  y: 330
+  font: "Inter" 600 16
+  fill: #2D3436
+}
+
+rect @playground {
+  x: 60  y: 360
+  w: 680  h: 240
+  fill: #FAFAFA
+  stroke: #DFE6E9 2
+  corner: 16
+}
+
+# ── Shortcut Hint ──
+text @shortcut_hint "Press ? for all keyboard shortcuts" {
+  x: 260  y: 640
+  font: "Inter" 400 12
+  fill: #B2BEC3
+}

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.41",
+  "version": "0.8.42",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -579,6 +579,85 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       border-radius: 4px;
     }
     .fab-menu-item:hover { background: rgba(255,255,255,0.1); color: #fff; }
+
+    /* ── Onboarding Overlay ── */
+    #onboarding-overlay {
+      position: absolute;
+      inset: 0;
+      z-index: 950;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(ellipse at center, rgba(20,20,30,0.92) 0%, rgba(10,10,18,0.97) 100%);
+      backdrop-filter: blur(8px);
+      pointer-events: auto;
+      opacity: 1;
+      transition: opacity 0.4s ease;
+    }
+    #onboarding-overlay.hidden { opacity: 0; pointer-events: none; }
+    .onboard-heading {
+      font-size: 28px;
+      font-weight: 300;
+      color: #eee;
+      letter-spacing: 1px;
+      margin-bottom: 8px;
+      animation: onboardFloat 3s ease-in-out infinite;
+    }
+    .onboard-sub {
+      font-size: 13px;
+      color: rgba(255,255,255,0.4);
+      margin-bottom: 32px;
+    }
+    @keyframes onboardFloat {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
+    .onboard-cards {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 40px;
+    }
+    .onboard-card {
+      width: 140px;
+      padding: 20px 16px;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 14px;
+      text-align: center;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    .onboard-card:hover {
+      background: rgba(255,255,255,0.12);
+      border-color: var(--fd-accent);
+      transform: translateY(-4px);
+      box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    }
+    .onboard-card-icon { font-size: 28px; display: block; margin-bottom: 10px; }
+    .onboard-card-title {
+      font-size: 13px;
+      font-weight: 500;
+      color: #ddd;
+    }
+    .onboard-card-desc {
+      font-size: 10px;
+      color: rgba(255,255,255,0.35);
+      margin-top: 4px;
+    }
+    .onboard-hint {
+      font-size: 11px;
+      color: rgba(255,255,255,0.25);
+      letter-spacing: 0.5px;
+    }
+    .onboard-hint kbd {
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.15);
+      border-radius: 3px;
+      padding: 1px 5px;
+      font-family: inherit;
+      font-size: 11px;
+    }
     .tool-icon { font-size: 13px; }
     .tool-key {
       font-size: 9px;
@@ -2039,6 +2118,28 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       <div class="palette-item" draggable="true" data-shape="line">━<span class="palette-label">Line</span></div>
       <div class="palette-item" draggable="true" data-shape="arrow">→<span class="palette-label">Arrow</span></div>
     </div>
+    <div id="onboarding-overlay">
+      <div class="onboard-heading">Start drawing</div>
+      <div class="onboard-sub">Create something beautiful</div>
+      <div class="onboard-cards">
+        <div class="onboard-card" data-tool="rect">
+          <span class="onboard-card-icon">📐</span>
+          <div class="onboard-card-title">Draw shapes</div>
+          <div class="onboard-card-desc">Rectangles, ellipses, frames</div>
+        </div>
+        <div class="onboard-card" data-tool="pen">
+          <span class="onboard-card-icon">✏️</span>
+          <div class="onboard-card-title">Sketch freely</div>
+          <div class="onboard-card-desc">Freehand pen drawings</div>
+        </div>
+        <div class="onboard-card" data-tool="text">
+          <span class="onboard-card-icon">📝</span>
+          <div class="onboard-card-title">Type text</div>
+          <div class="onboard-card-desc">Labels, headings, notes</div>
+        </div>
+      </div>
+      <div class="onboard-hint">Press <kbd>?</kbd> for all shortcuts</div>
+    </div>
     <div id="floating-action-bar">
       <span class="fab-label">Fill</span>
       <input type="color" id="fab-fill" class="fab-color" value="#4A90D9" title="Fill color">
@@ -3294,6 +3395,22 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
+
+  // ─── Auto-open welcome.fd on first activation ───────────────────────
+  const welcomed = context.globalState.get<boolean>("fd.welcomed", false);
+  if (!welcomed) {
+    context.globalState.update("fd.welcomed", true);
+    // Find welcome.fd in workspace examples folder
+    vscode.workspace.findFiles("**/examples/welcome.fd", null, 1).then(files => {
+      if (files.length > 0) {
+        vscode.commands.executeCommand(
+          "vscode.openWith",
+          files[0],
+          FdEditorProvider.viewType
+        );
+      }
+    });
+  }
 
   // ─── Track opened .fd documents ──────────────────────────────────────
   const openedUris = new Set<string>();


### PR DESCRIPTION
## Empty-State Onboarding + Welcome Tutorial

### Onboarding Overlay
- Centered overlay with animated "Start drawing" heading
- 3 quick-start cards: 📐 Shapes, ✏️ Sketch, 📝 Text
- Cards activate the tool and dismiss the overlay
- "Press ? for shortcuts" hint
- Auto-dismissed on any click or keypress

### Welcome Example
- `examples/welcome.fd`: 3-step interactive tutorial
- Hover animations on demo shapes
- Playground area for experimentation

### Auto-open
- First-ever activation opens `welcome.fd` via globalState flag

### CI ✅