### PR TITLE
docs(requirements): restructure REQUIREMENTS.md + create docs/specs/

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,7 +30,7 @@ Before modifying ANY file:
 
 ### 📋 Requirement Deduplication
 
-Before proposing any new requirement, search the **Requirement Index** at the bottom of `REQUIREMENTS.md` and check `docs/CHANGELOG.md` for overlapping keywords. If a similar requirement exists, **extend it** instead of creating a duplicate. Always update the index when adding new requirements.
+Before proposing any new requirement, search the **Requirement Index** at the bottom of `docs/REQUIREMENTS.md` and check `docs/CHANGELOG.md` for overlapping keywords. If a similar requirement exists, **extend it** instead of creating a duplicate. Always update the index when adding new requirements. For complex features, check `docs/specs/` for detailed behavior specifications.
 
 ### 🔀 Git Workflow (MANDATORY)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### Requirements Overhaul
+
+- **DOCS**: Restructured `REQUIREMENTS.md` — inline status tags on all 60+ requirements, R3 reorganized into 5 sub-categories (R3a–R3e: Selection, Drawing, Navigation, Panels, Export)
+- **DOCS**: Created `docs/specs/` with 5 detailed spec docs: `selection.md`, `drawing-tools.md`, `inline-editing.md`, `edge-system.md`, `animation-system.md`
+- **DOCS**: Removed 134 duplicate lines (completion checklist + test matrix) from CHANGELOG — now tracked inline in REQUIREMENTS.md
+- **DOCS**: Updated GEMINI.md Requirement Deduplication rule to reference `docs/specs/`
+
 ### Docs Restructure
 
 - **DOCS**: Moved `REQUIREMENTS.md` and `EDITORS.md` from project root into `docs/` directory
@@ -396,136 +403,4 @@
 - **R3.14**: Layers panel restyled with Figma/Apple design language (sticky header, indent guides, chevron toggles, hover/selection states)
 - **Workflow**: `/yolo` and `/commit` workflows now include a mandatory docs update step before committing
 
-### R1: File Format (`.fd`)
-
-- [x] **R1.1**: Token-efficient text DSL
-- [x] **R1.2**: Graph-based document model (DAG)
-- [x] **R1.3**: Constraint-based layout
-- [x] **R1.4**: Reusable styles via `style` blocks
-- [x] **R1.5**: Animation declarations with triggers
-- [x] **R1.6**: Git-friendly plain text
-- [x] **R1.7**: Comments via `#` prefix
-- [x] **R1.8**: Human-readable and AI-writable
-- [x] **R1.9**: Structured annotations (`spec` blocks)
-- [x] **R1.10**: First-class edges
-- [x] **R1.11**: Edge trigger animations
-- [x] **R1.12**: Edge flow animations
-- [x] **R1.13**: Generic nodes
-- [x] **R1.14**: Namespaced imports
-- [x] **R1.15**: Background shorthand
-- [x] **R1.16**: Comment preservation
-
-### R2: Bidirectional Sync
-
-- [x] **R2.1**: Canvas → Text sync (<16ms)
-- [x] **R2.2**: Text → Canvas sync (<16ms)
-- [ ] **R2.3**: Incremental parse/emit (currently full re-parse — fast enough for typical docs)
-- [x] **R2.4**: Conflict-free via single authoritative SceneGraph
-
-### R3: Human Editing (Canvas)
-
-- [x] **R3.1**: Selection (click, shift, marquee)
-- [x] **R3.2**: Manipulation (drag, resize, shift-constrain)
-- [x] **R3.3**: Creation (rect, ellipse, text, pen + shortcuts)
-- [x] **R3.4**: Freehand pen tool (Catmull-Rom smoothing) — _pressure captured but not yet mapped to stroke width_
-- [ ] **R3.5**: Path editing (future — boolean operations)
-- [x] **R3.6**: Canvas controls — pan (Space+drag, middle-click, ⌘-hold)
-- [x] **R3.7**: Undo/redo command stack
-- [x] **R3.8**: Properties panel (frosted glass inspector)
-- [x] **R3.9**: Drag-and-drop shape palette
-- [x] **R3.10**: Apple Pencil Pro squeeze toggle
-- [x] **R3.11**: Per-tool cursor feedback
-- [x] **R3.12**: Annotation pins (badge dots + inline card)
-- [x] **R3.13**: Light/dark theme toggle
-- [x] **R3.14**: View mode toggle (Design | Spec)
-- [ ] **R3.15**: Live preview outlines
-- [x] **R3.16**: Resize handles (8-point grips)
-- [x] **R3.17**: Smart guides (alignment snapping)
-- [x] **R3.18**: Dimension tooltip
-- [ ] **R3.19**: Alt-draw-from-center
-- [x] **R3.20**: Zoom (⌘+/−, pinch, fit)
-- [x] **R3.21**: Grid overlay
-- [ ] **R3.22**: Pressure-sensitive stroke width
-- [ ] **R3.23**: Freehand shape recognition
-- [x] **R3.24**: Group visibility & drill-down
-- [x] **R3.25**: Minimap navigation
-- [x] **R3.26**: Arrow-key nudge
-- [x] **R3.27**: Layer rename
-- [x] **R3.28**: Inline text editing
-- [x] **R3.29**: Animation drop
-- [x] **R3.30**: Layer navigation
-
-### R4: AI Editing (Text)
-
-- [x] **R4.1**: AI reads/writes `.fd` directly
-- [x] **R4.2**: Semantic node names
-- [x] **R4.3**: Style inheritance
-- [x] **R4.4**: Constraint relationships
-- [x] **R4.5**: Annotations as structured metadata
-- [x] **R4.6**: Edges for AI flow reasoning
-- [x] **R4.7**: Spec-view export (markdown report)
-- [x] **R4.8**: AI node refinement (Gemini)
-- [x] **R4.9**: Multi-provider AI (Gemini configured, OpenAI/Anthropic settings present)
-- [x] **R4.10**: Auto-format pipeline (`format_document` via LSP)
-- [x] **R4.11**: Inline Spec View
-
-### R5: Rendering
-
-- [x] **R5.1**: GPU-accelerated 2D — Vello + wgpu crate exists; webview currently uses Canvas2D fallback
-- [x] **R5.2**: WASM-compatible (wasm-pack build)
-- [ ] **R5.3**: Native desktop/mobile (future)
-- [x] **R5.4**: Shapes (rect, ellipse, path, text)
-- [x] **R5.5**: Styling (fill, stroke, gradients, shadows, corner radius, opacity)
-- [x] **R5.6**: Animation (keyframe transitions)
-- [x] **R5.7**: Edge rendering (lines, curves, arrows, labels)
-- [x] **R5.8**: Edge animation rendering (pulse dots, marching dashes)
-
-### R6: Platform Targets
-
-- [x] **R6.1**: VS Code / Cursor IDE extension (published)
-- [ ] **R6.2**: Desktop app via Tauri (future)
-- [ ] **R6.3**: Mobile app (future)
-- [ ] **R6.4**: Web app (future)
-
-## Test Matrix
-
-<!-- Maps each requirement to its test functions. If a row is empty, the requirement lacks test coverage. -->
-
-| Requirement | Test Functions                                                    | Coverage                       |
-| ----------- | ----------------------------------------------------------------- | ------------------------------ |
-| R1.1–R1.8   | `parser::tests::parse_*`, `emitter::tests::emit_*`, `roundtrip_*` | ✅ 76 fd-core + 18 integration |
-| R1.9        | `emit_annotations_*`, `roundtrip_preserves_annotations`           | ✅                             |
-| R1.10       | `parse_edge_*`, `emit_edge_*`, `roundtrip_edge_*`                 | ✅                             |
-| R1.11       | `emit_edge_with_trigger_anim`, `roundtrip_edge_hover_anim`        | ✅                             |
-| R1.12       | `emit_edge_flow_*`, `roundtrip_edge_flow_*`                       | ✅                             |
-| R1.13       | `emit_generic_node`, `roundtrip_generic_*`                        | ✅                             |
-| R1.14       | `parse_import`, `emit_import`, `roundtrip_import`                 | ✅                             |
-| R1.15       | `emit_bg_shorthand`, `roundtrip_bg_shorthand`                     | ✅                             |
-| R1.16       | `roundtrip_comment_*`                                             | ✅                             |
-| R1.17       | `parse_align_*`, `roundtrip_align*`, `style_merging_align`        | ✅                             |
-| R2.1–R2.4   | `sync::tests::sync_*`, `bidi_sync::*`                             | ✅ 12 sync + 9 integration     |
-| R3.1        | `tools::tests::select_tool_*`, `hit::tests::*`                    | ✅ 5 tests + 3 hit tests       |
-| R3.2        | `select_tool_drag`, `select_tool_shift_drag_*`, resize integ.     | ✅ 3 tests                     |
-| R3.3        | `rect_tool_*`, `ellipse_tool_*`, `text_tool_*`                    | ✅ 7 tests                     |
-| R3.4        | _(pen tool — captures pressure, no unit test)_                    | ⚠️ No pen tool tests           |
-| R3.5        | _(future)_                                                        | —                              |
-| R3.6        | E2E UX: zoom/pan/pinch tests in `e2e-ux.test.ts`                  | ✅ 4 E2E tests                 |
-| R3.7        | `commands::tests::*`, `undo_redo::*`                              | ✅ 5 unit + 7 integration      |
-| R3.8–R3.14  | E2E UX: properties, color, theme, view mode in `e2e-ux.test.ts`   | ✅ 12 E2E tests                |
-| R3.16       | `hit_test_resize_handle` (WASM), E2E UX cursor tests              | ⚠️ WASM-side only              |
-| R3.17       | E2E UX: grid/snap tests                                           | ⚠️ JS-only                     |
-| R3.18       | E2E UX: dimension tooltip tests                                   | ⚠️ JS-only                     |
-| R3.20       | E2E UX: zoom calculations, pinch clamp                            | ✅ 4 E2E tests                 |
-| R3.21       | E2E UX: grid spacing adaptation                                   | ✅ 3 E2E tests                 |
-| R3.24       | `effective_target_*`, `is_ancestor_of`, `hit_test_nested_groups`  | ✅ 5 Rust + 4 E2E tests        |
-| R3.25       | E2E UX: minimap scale, click-to-navigate                          | ✅ 2 E2E tests                 |
-| R3.26       | E2E UX: arrow nudge 1px/10px                                      | ✅ 2 E2E tests                 |
-| R3.27       | E2E UX: rename sanitization, word-boundary                        | ✅ 3 E2E tests                 |
-| R3.28       | E2E UX: inline text editing, hex luminance                        | ✅ 3 E2E tests                 |
-| R3.29       | E2E UX: animation tween engine                                    | ✅ 2 E2E tests                 |
-| R3.30       | _(JS-only, camera animation)_                                     | ⚠️ JS-only                     |
-| R4.1–R4.6   | Covered by R1/R2 tests                                            | ✅                             |
-| R4.7–R4.11  | _(extension-side, no test)_                                       | ❌                             |
-| R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`, `render2d::tests::*`        | ✅ 3 hit + 6 layout + 3 render |
-
-**Total**: 154 Rust tests + 162 TypeScript tests = **316 tests**
+> Requirement status and test coverage are now tracked inline in [REQUIREMENTS.md](REQUIREMENTS.md).

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -8,105 +8,119 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 ### R1: File Format (`.fd`)
 
-- **R1.1**: Token-efficient text DSL — ~5× fewer tokens than SVG for equivalent content
-- **R1.2**: Graph-based document model (DAG) — nodes reference by `@id`, not coordinates
-- **R1.3**: Constraint-based layout (`center_in`, `offset`, `fill_parent`) — no absolute coordinates until render time
-- **R1.4**: Reusable styles via `style` blocks and `use:` references
-- **R1.5**: Animation declarations with triggers (`:hover`, `:press`, `:enter`) and easing
-- **R1.6**: Git-friendly plain text — line-oriented diffs work well
-- **R1.7**: Comments via `#` prefix
-- **R1.8**: Human-readable and AI-writable without special tooling
-- **R1.9**: Structured annotations (`spec` blocks) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
-- **R1.10**: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `spec` annotations for user flows, wireframes, and state machines
-- **R1.11**: Edge trigger animations — edges support `anim :hover { ... }` blocks identical to nodes
-- **R1.12**: Edge flow animations — `flow: pulse Nms` (traveling dot) and `flow: dash Nms` (marching dashes) for visualizing data flow direction
-- **R1.13**: Generic nodes — `@id { ... }` without explicit kind keyword for abstract/placeholder elements
-- **R1.14**: Namespaced imports — `import "path.fd" as ns` for cross-file style/node reuse with `ns.style_name` references
-- **R1.15**: Background shorthand — `bg: #FFF corner=12 shadow=(0,4,20,#0002)` for combined fill, corner, and shadow in one line
-- **R1.16**: Comment preservation — `# text` lines attached to the following node survive all parse/emit round-trips and format passes
-- **R1.17**: Text alignment — `align: left|center|right [top|middle|bottom]` property on text and shape nodes; defaults to `center middle`; reusable via `style` blocks and `use:` inheritance
-- **R1.18**: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges; enables importing existing diagrams from Markdown docs
+- **R1.1** _(done)_: Token-efficient text DSL — ~5× fewer tokens than SVG for equivalent content
+- **R1.2** _(done)_: Graph-based document model (DAG) — nodes reference by `@id`, not coordinates
+- **R1.3** _(done)_: Constraint-based layout (`center_in`, `offset`, `fill_parent`) — no absolute coordinates until render time
+- **R1.4** _(done)_: Reusable styles via `style` blocks and `use:` references
+- **R1.5** _(done)_: Animation declarations with triggers (`:hover`, `:press`, `:enter`) and easing → [spec](specs/animation-system.md)
+- **R1.6** _(done)_: Git-friendly plain text — line-oriented diffs work well
+- **R1.7** _(done)_: Comments via `#` prefix
+- **R1.8** _(done)_: Human-readable and AI-writable without special tooling
+- **R1.9** _(done)_: Structured annotations (`spec` blocks) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
+- **R1.10** _(done)_: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `spec` annotations → [spec](specs/edge-system.md)
+- **R1.11** _(done)_: Edge trigger animations — edges support `anim :hover { ... }` blocks identical to nodes → [spec](specs/edge-system.md)
+- **R1.12** _(done)_: Edge flow animations — `flow: pulse Nms` (traveling dot) and `flow: dash Nms` (marching dashes) → [spec](specs/edge-system.md)
+- **R1.13** _(done)_: Generic nodes — `@id { ... }` without explicit kind keyword for abstract/placeholder elements
+- **R1.14** _(done)_: Namespaced imports — `import "path.fd" as ns` for cross-file style/node reuse with `ns.style_name` references
+- **R1.15** _(done)_: Background shorthand — `bg: #FFF corner=12 shadow=(0,4,20,#0002)` for combined fill, corner, and shadow in one line
+- **R1.16** _(done)_: Comment preservation — `# text` lines attached to the following node survive all parse/emit round-trips and format passes
+- **R1.17** _(done)_: Text alignment — `align: left|center|right [top|middle|bottom]` property; defaults to `center middle`; reusable via `style` blocks and `use:` inheritance
+- **R1.18** _(planned)_: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges
 
 ### R2: Bidirectional Sync
 
-- **R2.1**: Canvas → Text: Visual edits (drag, resize, draw) update the `.fd` source in <16ms
-- **R2.2**: Text → Canvas: Source edits re-render the canvas in <16ms
-- **R2.3**: Incremental: Only re-parse/re-emit changed regions, not the entire document
-- **R2.4**: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
-- **R2.5**: Selection sync — clicking anywhere inside a node block in the text editor (not just the `@id` declaration line) selects it on canvas; clicking a node on canvas reveals and highlights its `@id` line in the text editor
+- **R2.1** _(done)_: Canvas → Text: Visual edits (drag, resize, draw) update the `.fd` source in <16ms
+- **R2.2** _(done)_: Text → Canvas: Source edits re-render the canvas in <16ms
+- **R2.3** _(planned)_: Incremental: Only re-parse/re-emit changed regions, not the entire document
+- **R2.4** _(done)_: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
+- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node block in the text editor selects it on canvas; clicking a node on canvas reveals its `@id` line in the text editor
 
 ### R3: Human Editing (Canvas)
 
-- **R3.1**: Selection: Click to select, Shift+click to toggle multi-select, marquee drag-to-select (rubber-band box selection on empty canvas) with Shift+marquee additive mode
-- **R3.2**: Manipulation: Drag, resize, rotate; shift-constrain to axis
-- **R3.3**: Creation: Rectangle, ellipse, text, group tools with keyboard shortcuts (V/R/O/P/T)
-- **R3.4**: Freehand: Pen/pencil tool with pressure sensitivity (Apple Pencil Pro)
-- **R3.5**: Path editing: Node manipulation, curve handles, boolean operations (future)
-- **R3.6**: Canvas controls: Pan (Space+drag, middle-click drag, ⌘-hold hand tool), zoom (see R3.20), grid (see R3.21)
-- **R3.7**: Undo/redo: Full command stack, works across both text and canvas edits
-- **R3.8**: Properties panel: Apple-style frosted glass inspector for position, size, fill, stroke, corner radius, opacity, and text content — edits propagate bidirectionally
-- **R3.9**: Drag-and-drop: Shape palette for dropping Rect, Ellipse, or Text onto canvas
-- **R3.10**: Apple Pencil Pro squeeze: Toggle between last two tools
-- **R3.11**: Per-tool cursor feedback (crosshair for drawing, text cursor for text, default for select)
-- **R3.12**: Annotation pins: Visual badge dots on annotated nodes with inline edit card
-- **R3.13**: Light/dark theme toggle — canvas defaults to light mode with a toolbar toggle button (🌙 in light → switch to dark, ☀️ in dark → switch to light); preference persists across sessions via VS Code state
-- **R3.14**: View mode toggle — **Design | Spec** segmented control in the canvas toolbar (Design default); Spec View hides the canvas and shows a scrollable overlay of node IDs, `spec` annotations, acceptance criteria, status/priority/tag badges, unannotated node chips, and edges; overlay updates live as the `.fd` source changes; also accessible via `FD: Toggle Design/Spec View` command in the editor title bar and Command Palette
-- **R3.15**: Live preview: Dashed outline ghost of shape during drag-to-create (rect, ellipse); live smooth curve during pen draw (no jagged LineTo visible to user)
-- **R3.16**: Resize handles: 8-point resize grips (4 corners + 4 edge midpoints) on selected shapes; directional cursors (`nwse-resize`, `nesw-resize`, `ew-resize`, `ns-resize`) on hover
-- **R3.17**: Smart guides: Alignment snapping with visual guide lines — snap to center, edges, and equal spacing of nearby nodes; hold Ctrl/⌘ to temporarily disable snapping
-- **R3.18**: Dimension tooltip: Floating `W × H` badge near cursor during draw and resize; absolute position `(X, Y)` badge during move
-- **R3.19**: Alt-draw-from-center: Hold Alt/⌥ while creating rect/ellipse to anchor the starting point as center (not top-left corner)
-- **R3.20**: Zoom: ⌘+/⌘− to step-zoom, ⌘0 to zoom-to-fit, pinch-to-zoom on trackpad; zoom level indicator in toolbar (e.g. "100%")
-- **R3.21**: Grid overlay: Toggleable dot/line grid with configurable spacing; shapes snap to grid when enabled
-- **R3.22**: Pressure-sensitive stroke width: Pen tool maps pointer pressure to stroke thickness in real-time (Apple Pencil + Wacom); width range configurable
-- **R3.23**: Freehand shape recognition: After pen stroke completes, detect near-rectangular/elliptical/linear shapes and offer a one-click "Snap to Shape" action — converting freehand to a clean geometric node
-- **R3.24**: Group Visibility & Drill-down: Group nodes render a dashed blue border on hover and a solid blue border with a "Group @id" badge when selected. Clicking a child of an unselected group selects the parent group. Clicking the child again (when the group is selected) drills down to select the child (Figma/Sketch behavior).
-- **R3.28**: Inline text editing: Double-click a text node or shape to open a floating textarea overlay; background matches the node's fill (shape) or uses themed default (text node); live sync — every keystroke updates Code Mode in real-time; Enter confirms, Esc reverts to original value, click-outside commits; 3×3 alignment grid picker in properties panel for `align:` (R1.17)
-- **R3.29**: Animation drop: Drag a node onto another to assign animations — magnetic glow ring on hover, release opens a glassmorphism Animation Picker popover with preset groups (Hover/Press/Enter), live preview on hover, click to commit `anim` block to Code Mode
-- **R3.25**: Minimap navigation: Thumbnail overview in bottom-right showing full scene with draggable viewport rectangle; click-to-pan navigation (Figma/Miro-style)
-- **R3.26**: Arrow-key nudge: Arrow keys move selected node 1px (Shift+arrow = 10px); matches Figma/Sketch standard UX
-- **R3.27**: Layer rename: Double-click a layer name in the Layers panel for inline rename; renames `@id` across the entire document (word-boundary safe)
-- **R3.30**: Layer navigation: Clicking a layer item in the Layers panel selects the node and smoothly pans the camera to center it (250ms ease-out); auto-zooms in if both dimensions are < 20px on screen (truly invisible); auto-zooms out if the node overflows the viewport (15% padding); skips pan if the node center is already within 20% of the viewport center; thin shapes (lines, dividers) keep current zoom unless overflowing
-- **R3.31**: Export — PNG (2× resolution), SVG, and clipboard export of the full canvas or selected elements; configurable background (transparent or themed); accessible via toolbar button + keyboard shortcut (⌘⇧E)
-- **R3.32**: Image embedding — drag-and-drop or paste raster images (PNG, JPG, WebP) onto the canvas as `image` nodes; images stored inline (base64) or as external file references; resizable with aspect-ratio lock by default
-- **R3.33**: Component libraries — reusable collections of nodes/groups that can be dragged onto the canvas from a library panel; user-created and community-shared libraries; stored as `.fd` files with `export` markers
+#### R3a: Selection & Manipulation
+
+- **R3.1** _(done)_: Click to select, Shift+click multi-select, marquee drag-to-select with Shift+marquee additive mode → [spec](specs/selection.md)
+- **R3.2** _(done)_: Drag, resize, rotate; Shift-constrain to axis → [spec](specs/selection.md)
+- **R3.16** _(done)_: 8-point resize grips (4 corners + 4 midpoints); directional cursors on hover → [spec](specs/selection.md)
+- **R3.24** _(done)_: Group drill-down — click child of unselected group → selects parent; click again → drills to child (Figma/Sketch) → [spec](specs/selection.md)
+- **R3.26** _(done)_: Arrow-key nudge — 1px (Shift = 10px); matches Figma/Sketch standard
+
+#### R3b: Drawing Tools
+
+- **R3.3** _(done)_: Rectangle, ellipse, text, group tools with keyboard shortcuts (V/R/O/P/T) → [spec](specs/drawing-tools.md)
+- **R3.4** _(partial)_: Freehand pen/pencil tool — Catmull-Rom smoothing done, pressure captured but not yet mapped to stroke width → [spec](specs/drawing-tools.md)
+- **R3.5** _(planned)_: Path editing — node manipulation, curve handles, boolean operations
+- **R3.15** _(planned)_: Live preview — dashed outline ghost during drag-to-create; smooth curve during pen draw → [spec](specs/drawing-tools.md)
+- **R3.19** _(planned)_: Alt-draw-from-center — Alt/⌥ anchors start point as center (not top-left)
+- **R3.22** _(planned)_: Pressure-sensitive stroke width — pen maps pressure to thickness in real-time → [spec](specs/drawing-tools.md)
+- **R3.23** _(planned)_: Freehand shape recognition — detect near-geometric shapes, offer "Snap to Shape" action → [spec](specs/drawing-tools.md)
+
+#### R3c: Navigation & View
+
+- **R3.6** _(done)_: Pan (Space+drag, middle-click, ⌘-hold), zoom (see R3.20), grid (see R3.21)
+- **R3.13** _(done)_: Light/dark theme toggle — toolbar button, preference persists via VS Code state
+- **R3.14** _(done)_: Design | Spec view toggle — segmented control; Spec View shows annotations overlay
+- **R3.20** _(done)_: Zoom — ⌘+/⌘−, ⌘0 zoom-to-fit, pinch-to-zoom; zoom indicator in toolbar
+- **R3.21** _(done)_: Grid overlay — toggleable dot/line grid with adaptive spacing; keyboard shortcut `G`
+- **R3.25** _(done)_: Minimap — thumbnail in bottom-right with draggable viewport rectangle (Figma/Miro-style)
+- **R3.30** _(done)_: Layer navigation — click layer item → smooth pan to center node (250ms ease-out); auto-zoom for tiny/overflow nodes
+
+#### R3d: Panels & UI
+
+- **R3.7** _(done)_: Undo/redo — full command stack, works across text and canvas edits
+- **R3.8** _(done)_: Properties panel — frosted glass inspector for position, size, fill, stroke, corner, opacity
+- **R3.9** _(done)_: Shape palette — drag-and-drop for Rect, Ellipse, Text, Frame, Line, Arrow
+- **R3.10** _(done)_: Apple Pencil Pro squeeze — toggle between last two tools
+- **R3.11** _(done)_: Per-tool cursor feedback (crosshair, text cursor, default)
+- **R3.12** _(done)_: Annotation pins — badge dots on annotated nodes with inline edit card
+- **R3.17** _(done)_: Smart guides — alignment snapping with visual guide lines; Ctrl/⌘ to disable
+- **R3.18** _(done)_: Dimension tooltip — floating `W × H` badge during draw/resize; `(X, Y)` during move
+- **R3.27** _(done)_: Layer rename — double-click layer name for inline rename; renames `@id` document-wide → [spec](specs/inline-editing.md)
+- **R3.28** _(done)_: Inline text editing — double-click to edit; Enter confirms, Esc reverts; live sync → [spec](specs/inline-editing.md)
+- **R3.29** _(done)_: Animation drop — drag node onto another to assign animations via picker → [spec](specs/animation-system.md)
+
+#### R3e: Export & Media
+
+- **R3.31** _(done)_: Export — PNG (2×), SVG, clipboard; configurable background; ⌘⇧E shortcut
+- **R3.32** _(planned)_: Image embedding — drag-and-drop raster images as `image` nodes; base64 or file reference
+- **R3.33** _(planned)_: Component libraries — reusable node collections from a library panel; stored as `.fd` files
 
 ### R4: AI Editing (Text)
 
-- **R4.1**: AI reads/writes `.fd` text directly — no binary format needed
-- **R4.2**: Semantic node names (`@login_form`, `@submit_btn`) help AI understand intent
-- **R4.3**: Style inheritance reduces repetition — AI only specifies overrides
-- **R4.4**: Constraints describe relationships ("center in canvas") not pixel positions
-- **R4.5**: Annotations (`spec` blocks) give AI structured metadata — acceptance criteria, status, priority, tags — on the visual element itself
-- **R4.6**: Edges let AI reason about flows and transitions between screens
-- **R4.7**: Spec-view export — generate markdown report of `spec` annotations (requirements, status, acceptance criteria) from any `.fd` file
-- **R4.8**: AI node refinement — restyle selected nodes and replace anonymous IDs (`_anon_N`) with semantic names via configurable AI provider
-- **R4.9**: Multi-provider AI — per-provider API keys (`fd.ai.geminiApiKey`, `fd.ai.openaiApiKey`, `fd.ai.anthropicApiKey`), custom model selection per provider, and support for Gemini, OpenAI, Anthropic, Ollama (local), and OpenRouter (multi-model gateway)
-- **R4.10**: Auto-format pipeline — `format_document` via LSP; lint diagnostics (anonymous IDs, duplicate `use:`, unused styles) + configurable dedup/hoist transforms via `fd.format.*` settings
-- **R4.11**: Inline Spec View — canvas-embedded spec overlay (client-side parser, no roundtrip) showing node structure + annotations; complements the separate `FD: Show Spec View` sidebar panel and `FD: Export Spec to Markdown` export command
+- **R4.1** _(done)_: AI reads/writes `.fd` text directly — no binary format needed
+- **R4.2** _(done)_: Semantic node names (`@login_form`, `@submit_btn`) help AI understand intent
+- **R4.3** _(done)_: Style inheritance reduces repetition — AI only specifies overrides
+- **R4.4** _(done)_: Constraints describe relationships ("center in canvas") not pixel positions
+- **R4.5** _(done)_: Annotations (`spec` blocks) give AI structured metadata on visual elements
+- **R4.6** _(done)_: Edges let AI reason about flows and transitions between screens
+- **R4.7** _(done)_: Spec-view export — generate markdown report of `spec` annotations from any `.fd` file
+- **R4.8** _(done)_: AI node refinement — restyle selected nodes, replace anonymous IDs via configurable provider
+- **R4.9** _(done)_: Multi-provider AI — Gemini, OpenAI, Anthropic, Ollama, OpenRouter with per-provider API keys
+- **R4.10** _(done)_: Auto-format pipeline — `format_document` via LSP; lint diagnostics + configurable transforms
+- **R4.11** _(done)_: Inline Spec View — canvas-embedded spec overlay with node structure + annotations
 
 ### R5: Rendering
 
-- **R5.1**: GPU-accelerated 2D rendering via Vello + wgpu
-- **R5.2**: WASM-compatible for web/IDE deployment
-- **R5.3**: Native-compatible for desktop/mobile (same Rust code)
-- **R5.4**: Shapes: rect, ellipse, path, text
-- **R5.5**: Styling: fill, stroke, gradients, shadows, corner radius, opacity
-- **R5.6**: Animation: keyframe transitions with easing functions
-- **R5.7**: Edge rendering: lines, smooth curves, step routing with arrowheads and midpoint labels
-- **R5.8**: Edge animation rendering: trigger-based hover/press effects and continuous flow animations (pulse dots, marching dashes)
+- **R5.1** _(done)_: GPU-accelerated 2D rendering via Vello + wgpu (webview currently uses Canvas2D fallback)
+- **R5.2** _(done)_: WASM-compatible for web/IDE deployment
+- **R5.3** _(future)_: Native-compatible for desktop/mobile (same Rust code)
+- **R5.4** _(done)_: Shapes: rect, ellipse, path, text, frame, generic
+- **R5.5** _(done)_: Styling: fill, stroke, gradients, shadows, corner radius, opacity
+- **R5.6** _(done)_: Animation: keyframe transitions with easing functions → [spec](specs/animation-system.md)
+- **R5.7** _(done)_: Edge rendering: lines, smooth curves, step routing with arrowheads and labels → [spec](specs/edge-system.md)
+- **R5.8** _(done)_: Edge animation rendering: trigger effects + flow animations → [spec](specs/edge-system.md)
 
 ### R6: Platform Targets
 
-- **R6.1** (this repo): VS Code / Cursor IDE custom editor extension
-- **R6.2** (future): Desktop app via Tauri (macOS, Windows, Linux)
-- **R6.3** (future): Mobile app (iOS, Android) via native wgpu
-- **R6.4** (future): Web app (standalone browser app)
+- **R6.1** _(done)_: VS Code / Cursor IDE custom editor extension (published)
+- **R6.2** _(future)_: Desktop app via Tauri (macOS, Windows, Linux)
+- **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
+- **R6.4** _(future)_: Web app (standalone browser app)
 
 ### R7: Collaboration
 
-- **R7.1** (future): Real-time multiplayer — concurrent editing with cursor presence, CRDT-based conflict resolution, and live sync across connected clients
-- **R7.2** (future): Shareable links — generate a URL to share a read-only or editable view of an `.fd` document without requiring IDE installation
+- **R7.1** _(future)_: Real-time multiplayer — CRDT-based conflict resolution, cursor presence, live sync
+- **R7.2** _(future)_: Shareable links — URL to share read-only or editable view without IDE
 
 ## Non-Functional Requirements
 
@@ -122,20 +136,65 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 ## Tech Stack
 
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, data flow, and rendering pipeline.
+
 | Layer            | Technology                            |
 | ---------------- | ------------------------------------- |
 | Language         | Rust (edition 2024)                   |
-| Rendering        | Vello + wgpu                          |
+| Rendering        | Vello + wgpu (Canvas2D fallback)      |
 | Parsing          | winnow                                |
-| Graph            | petgraph (DAG)                        |
+| Graph            | petgraph `StableDiGraph`              |
 | String interning | lasso                                 |
 | WASM             | wasm-pack + wasm-bindgen              |
 | IDE glue         | TypeScript (minimal VS Code API shim) |
 | Desktop (future) | Tauri                                 |
 
+## Test Matrix
+
+<!-- Maps each requirement to its test functions. If a row is empty, the requirement lacks test coverage. -->
+
+| Requirement | Test Functions                                                    | Coverage                       |
+| ----------- | ----------------------------------------------------------------- | ------------------------------ |
+| R1.1–R1.8   | `parser::tests::parse_*`, `emitter::tests::emit_*`, `roundtrip_*` | ✅ 76 fd-core + 18 integration |
+| R1.9        | `emit_annotations_*`, `roundtrip_preserves_annotations`           | ✅                             |
+| R1.10       | `parse_edge_*`, `emit_edge_*`, `roundtrip_edge_*`                 | ✅                             |
+| R1.11       | `emit_edge_with_trigger_anim`, `roundtrip_edge_hover_anim`        | ✅                             |
+| R1.12       | `emit_edge_flow_*`, `roundtrip_edge_flow_*`                       | ✅                             |
+| R1.13       | `emit_generic_node`, `roundtrip_generic_*`                        | ✅                             |
+| R1.14       | `parse_import`, `emit_import`, `roundtrip_import`                 | ✅                             |
+| R1.15       | `emit_bg_shorthand`, `roundtrip_bg_shorthand`                     | ✅                             |
+| R1.16       | `roundtrip_comment_*`                                             | ✅                             |
+| R1.17       | `parse_align_*`, `roundtrip_align*`, `style_merging_align`        | ✅                             |
+| R2.1–R2.4   | `sync::tests::sync_*`, `bidi_sync::*`                             | ✅ 12 sync + 9 integration     |
+| R3.1        | `tools::tests::select_tool_*`, `hit::tests::*`                    | ✅ 5 tests + 3 hit tests       |
+| R3.2        | `select_tool_drag`, `select_tool_shift_drag_*`, resize integ.     | ✅ 3 tests                     |
+| R3.3        | `rect_tool_*`, `ellipse_tool_*`, `text_tool_*`                    | ✅ 7 tests                     |
+| R3.4        | _(pen tool — captures pressure, no unit test)_                    | ⚠️ No pen tool tests           |
+| R3.5        | _(planned)_                                                       | —                              |
+| R3.6        | E2E UX: zoom/pan/pinch tests in `e2e-ux.test.ts`                  | ✅ 4 E2E tests                 |
+| R3.7        | `commands::tests::*`, `undo_redo::*`                              | ✅ 5 unit + 7 integration      |
+| R3.8–R3.14  | E2E UX: properties, color, theme, view mode in `e2e-ux.test.ts`   | ✅ 12 E2E tests                |
+| R3.16       | `hit_test_resize_handle` (WASM), E2E UX cursor tests              | ⚠️ WASM-side only              |
+| R3.17       | E2E UX: grid/snap tests                                           | ⚠️ JS-only                     |
+| R3.18       | E2E UX: dimension tooltip tests                                   | ⚠️ JS-only                     |
+| R3.20       | E2E UX: zoom calculations, pinch clamp                            | ✅ 4 E2E tests                 |
+| R3.21       | E2E UX: grid spacing adaptation                                   | ✅ 3 E2E tests                 |
+| R3.24       | `effective_target_*`, `is_ancestor_of`, `hit_test_nested_groups`  | ✅ 5 Rust + 4 E2E tests        |
+| R3.25       | E2E UX: minimap scale, click-to-navigate                          | ✅ 2 E2E tests                 |
+| R3.26       | E2E UX: arrow nudge 1px/10px                                      | ✅ 2 E2E tests                 |
+| R3.27       | E2E UX: rename sanitization, word-boundary                        | ✅ 3 E2E tests                 |
+| R3.28       | E2E UX: inline text editing, hex luminance                        | ✅ 3 E2E tests                 |
+| R3.29       | E2E UX: animation tween engine                                    | ✅ 2 E2E tests                 |
+| R3.30       | _(JS-only, camera animation)_                                     | ⚠️ JS-only                     |
+| R4.1–R4.6   | Covered by R1/R2 tests                                            | ✅                             |
+| R4.7–R4.11  | _(extension-side, no test)_                                       | ❌                             |
+| R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`, `render2d::tests::*`        | ✅ 3 hit + 6 layout + 3 render |
+
+**Total**: 154 Rust tests + 162 TypeScript tests = **316 tests**
+
 ## Requirement Index
 
-<!-- AI: Search this index BEFORE proposing new requirements. If a similar tag already exists, extend the existing requirement instead of creating a duplicate. -->
+<!-- AI: Search this index BEFORE proposing new requirements. If a similar tag already exists, extend the existing requirement instead of creating a duplicate. Also check docs/specs/ for detailed spec docs. -->
 
 | Tag                 | Requirements                          |
 | ------------------- | ------------------------------------- |

--- a/docs/specs/animation-system.md
+++ b/docs/specs/animation-system.md
@@ -1,0 +1,182 @@
+# Animation System
+
+> R1.5, R3.29, R5.6 | Status: done
+
+## Format (R1.5)
+
+### Trigger Animations
+
+```fd
+rect @button {
+  w: 200 h: 48
+  fill: #6C5CE7
+
+  anim :hover {
+    fill: #5A4BD1
+    scale: 1.02
+    ease: ease_out 300ms
+  }
+
+  anim :press {
+    scale: 0.95
+    ease: spring 150ms
+  }
+
+  anim :enter {
+    opacity: 0 -> 1
+    ease: ease_in 500ms
+  }
+}
+```
+
+### Triggers
+
+| Trigger  | Fires when                     | Reverts when              |
+| -------- | ------------------------------ | ------------------------- |
+| `:hover` | Pointer enters node bounds     | Pointer exits node bounds |
+| `:press` | Pointer-down on node           | Pointer-up anywhere       |
+| `:enter` | Node first appears in viewport | _(never — plays once)_    |
+
+### Animatable Properties
+
+| Property  | Type          | Range             |
+| --------- | ------------- | ----------------- |
+| `fill`    | Color         | Any hex color     |
+| `stroke`  | Color + width | `#color width`    |
+| `opacity` | Float         | 0.0–1.0           |
+| `scale`   | Float         | 0.0+ (1.0 = 100%) |
+| `corner`  | Float         | 0+                |
+| `x`, `y`  | Float         | Offset in px      |
+
+### Easing Functions
+
+| Keyword       | Curve                            |
+| ------------- | -------------------------------- |
+| `linear`      | Constant speed                   |
+| `ease_in`     | Slow start, fast end             |
+| `ease_out`    | Fast start, slow end             |
+| `ease_in_out` | Slow start and end               |
+| `spring`      | Overshoot bounce (damped spring) |
+
+Duration format: `Nms` (e.g. `300ms`, `1500ms`)
+
+## Tween Engine (R5.6)
+
+Animation state machine per node:
+
+```
+IDLE → trigger fires → ANIMATING → duration elapsed → HOLD
+                                                        ↓
+                                         trigger reverts → REVERTING → IDLE
+```
+
+### Interpolation
+
+For each frame during animation:
+
+1. Calculate `t = elapsed / duration` (clamped to [0, 1])
+2. Apply easing function to get `eased_t`
+3. Interpolate each property: `value = from + (to - from) * eased_t`
+4. Color interpolation in RGB space (per-channel lerp)
+
+### Property Resolution with Animations
+
+Style resolution order:
+
+1. Base style (`use:` referenced styles)
+2. Inline style (node's own `fill:`, `stroke:`, etc.)
+3. Animation override (if animating — blended value at current `t`)
+
+The animation value **temporarily overrides** the resolved style during rendering. It never mutates the SceneGraph — it's a rendering-only effect.
+
+## Animation Drop (R3.29)
+
+### Gesture Flow
+
+```
+1. Select a node (the "preset source")
+2. Drag it onto another node (the "target")
+3. Target shows magnetic glow ring (purple pulse border)
+4. Release → Animation Picker popover opens
+5. Hover presets → live preview plays on target
+6. Click preset → commit anim block to FD source
+```
+
+### Magnetic Glow Ring
+
+When dragging over a valid target node:
+
+- Purple pulsing border (CSS `box-shadow` with keyframe animation)
+- Appears when pointer enters target bounds
+- Disappears when pointer exits
+
+### Animation Picker Popover
+
+Glassmorphism UI with 3 groups:
+
+| Group     | Presets                              |
+| --------- | ------------------------------------ |
+| **Hover** | Glow, Lift, Color Shift, Scale Up    |
+| **Press** | Bounce, Shrink, Flash                |
+| **Enter** | Fade In, Slide Up, Scale In, Blur In |
+
+Each preset maps to a specific `anim` block:
+
+```fd
+# "Lift" preset generates:
+anim :hover {
+  y: -4
+  shadow: 0,8,24,#0003
+  ease: ease_out 200ms
+}
+```
+
+### Live Preview
+
+Hovering a preset in the picker:
+
+1. Temporarily applies the animation values to the target node
+2. Plays the tween at normal speed
+3. Reverts on mouse-leave
+4. No SceneGraph mutation — rendering-only preview
+
+### Commit
+
+Clicking a preset:
+
+1. Generate the `anim :trigger { ... }` FD text block
+2. Call `add_animation_to_node(target_id, anim_text)` via WASM
+3. WASM applies `SetAnimations` mutation (with undo/redo support)
+4. `emit_document()` → FD source updated in Code Mode
+
+## Edge Cases
+
+- **Multiple animations on same trigger** → last one wins (replacement, not merge)
+- **Animation on deleted node** → animation block removed with the node
+- **`:enter` fires repeatedly on re-parse** → debounced by `entered` flag per node
+- **Scale animation causes hit-test mismatch** → hit testing uses base bounds, not animated bounds
+- **`:press` during inline edit** → `clear_pressed()` suppresses press animation state
+- **Animation during drag** → `:hover` suppressed during active drag to prevent flicker
+
+## Implementation Notes
+
+| Module          | File                               | Key Functions                                           |
+| --------------- | ---------------------------------- | ------------------------------------------------------- |
+| Animation model | `crates/fd-core/src/model.rs`      | `AnimKeyframe`, `AnimTrigger`, `Easing`                 |
+| Parser          | `crates/fd-core/src/parser.rs`     | `parse_animation()`, `parse_easing()`                   |
+| Emitter         | `crates/fd-core/src/emitter.rs`    | `emit_animations()`                                     |
+| Tween engine    | `crates/fd-wasm/src/render2d.rs`   | `apply_anim_state()`, `interpolate_color()`             |
+| WASM API        | `crates/fd-wasm/src/lib.rs`        | `add_animation_to_node()`, `get_node_animations_json()` |
+| Mutations       | `crates/fd-editor/src/commands.rs` | `SetAnimations`                                         |
+| Picker UI (JS)  | `fd-vscode/webview/main.js`        | Animation Picker popover DOM                            |
+
+## Test Coverage
+
+| Test                      | Location         | What it covers                           |
+| ------------------------- | ---------------- | ---------------------------------------- |
+| `parse_animation`         | `parser.rs`      | Trigger parsing, easing, properties      |
+| `emit_animations`         | `emitter.rs`     | Animation block serialization            |
+| `roundtrip_animation_*`   | `emitter.rs`     | Parse→emit fidelity                      |
+| `sketchy_jitter_*`        | `render2d.rs`    | Deterministic rendering jitter (3 tests) |
+| E2E: tween engine         | `e2e-ux.test.ts` | Interpolation accuracy (2 tests)         |
+| `arrow_tool_preview_line` | `tools.rs`       | Preview line during arrow drag           |

--- a/docs/specs/drawing-tools.md
+++ b/docs/specs/drawing-tools.md
@@ -1,0 +1,133 @@
+# Drawing Tools
+
+> R3.3, R3.4, R3.5, R3.15, R3.19, R3.22, R3.23 | Status: partial
+
+## Tool Lifecycle
+
+All drawing tools follow the same state machine:
+
+```
+IDLE → pointer-down → DRAWING → pointer-up → commit node → switch to Select
+```
+
+**Exceptions:**
+
+- **Double-press** shortcut (RR, OO, PP, TT) → locks tool in **Sticky Mode** (🔒 badge); stays active after placing shapes
+- **⌘+drag** while in a drawing tool → **temporary Select** (move/marquee); auto-restores tool on pointer-up
+
+## Shape Tools (R3.3)
+
+### Rectangle (`R` key)
+
+| Action                          | Result                                          |
+| ------------------------------- | ----------------------------------------------- |
+| Click on canvas                 | Create 120×80 rect **centered** at click point  |
+| Click + drag                    | Create rect from drag origin to current pointer |
+| Shift + drag                    | Constrain to square                             |
+| Alt/⌥ + drag _(R3.19, planned)_ | Anchor center at drag origin                    |
+
+Default style: `fill: #D5D5E0`, `corner: 0`, `stroke: none`
+
+### Ellipse (`O` key)
+
+| Action          | Result                                        |
+| --------------- | --------------------------------------------- |
+| Click on canvas | Create 100×100 circle centered at click point |
+| Click + drag    | Create ellipse from bounding box              |
+| Shift + drag    | Constrain to circle                           |
+
+### Text (`T` key)
+
+| Action                    | Result                                           |
+| ------------------------- | ------------------------------------------------ |
+| Click on canvas           | Create text node, immediately open inline editor |
+| Double-click empty canvas | Same as pressing T + click                       |
+
+Default: `font: "Inter" 400 16`, `fill: #333333`, initial bounds 80×24
+
+### Frame (`F` key)
+
+| Action       | Result                                            |
+| ------------ | ------------------------------------------------- |
+| Click + drag | Create frame container (visible, clippable group) |
+
+Default: 200×150, `fill: #FAFAFA`, `stroke: #E0E0E0 1`, `corner: 0`
+
+### Arrow/Connector (`A` key)
+
+| Action                                  | Result                                    |
+| --------------------------------------- | ----------------------------------------- |
+| Click source node → drag to target node | Create edge with smooth curve + arrowhead |
+| Drag over node                          | Dashed preview line follows cursor        |
+| Release on same node                    | No edge created                           |
+| Release on empty canvas                 | No edge created                           |
+
+## Pen Tool (R3.4)
+
+### Current (done)
+
+- Freehand drawing with Catmull-Rom smoothing
+- Pressure captured from pointer events (`pointerEvent.pressure`)
+- Creates `path` node with smoothed control points
+
+### Planned (R3.22)
+
+- Map `pressure` → stroke `width` in real-time
+- Width range configurable (e.g. 1px–8px)
+- Apple Pencil Pro + Wacom support
+
+### Planned (R3.23) — Shape Recognition
+
+After pen stroke completes:
+
+1. Analyze path geometry (bounding box aspect ratio, point distribution)
+2. If near-rectangular → offer "Snap to Rect" action
+3. If near-circular → offer "Snap to Ellipse"
+4. If near-linear → offer "Snap to Line"
+5. One-click converts freehand path to clean geometric node
+
+## Live Preview (R3.15, planned)
+
+During drag-to-create:
+
+- **Rect/Ellipse** → dashed outline ghost at current dimensions
+- **Pen** → smooth curve preview (no jagged `LineTo` visible to user)
+- Ghost disappears on pointer-up and is replaced by the committed shape
+
+## Visual Feedback
+
+| Tool          | Cursor      | Toolbar state |
+| ------------- | ----------- | ------------- |
+| Select (`V`)  | `default`   | Highlighted   |
+| Rect (`R`)    | `crosshair` | Highlighted   |
+| Ellipse (`O`) | `crosshair` | Highlighted   |
+| Pen (`P`)     | `crosshair` | Highlighted   |
+| Text (`T`)    | `text`      | Highlighted   |
+| Frame (`F`)   | `crosshair` | Highlighted   |
+| Arrow (`A`)   | `crosshair` | Highlighted   |
+
+## Smart Defaults (Sticky Styles)
+
+Changing fill/stroke/opacity/fontSize on any node stores it as the default for future shapes of that tool type. Alt+click a node to copy its entire style as defaults for all tools.
+
+Per-tool session memory — rect remembers rect defaults, text remembers text defaults. Resets on reload.
+
+## Implementation Notes
+
+| Module        | File                                | Key Functions                                                 |
+| ------------- | ----------------------------------- | ------------------------------------------------------------- |
+| Tool dispatch | `crates/fd-editor/src/tools.rs`     | `RectTool`, `EllipseTool`, `PenTool`, `TextTool`, `ArrowTool` |
+| Node creation | `crates/fd-wasm/src/lib.rs`         | `create_node_at(kind, x, y)`                                  |
+| Mutations     | `crates/fd-editor/src/commands.rs`  | `AddNode`, `AddEdge`                                          |
+| Shortcuts     | `crates/fd-editor/src/shortcuts.rs` | `resolve_shortcut()`                                          |
+
+## Test Coverage
+
+| Test                     | Location       | What it covers                                                                 |
+| ------------------------ | -------------- | ------------------------------------------------------------------------------ |
+| `rect_tool_*`            | `tools.rs`     | Click-create centered, drag-create (3 tests)                                   |
+| `ellipse_tool_*`         | `tools.rs`     | Click-create, drag-create (2 tests)                                            |
+| `text_tool_*`            | `tools.rs`     | Click-create (1 test)                                                          |
+| `arrow_tool_*`           | `tools.rs`     | Edge between nodes, same-node reject, no-source reject, preview line (5 tests) |
+| `resolve_arrow_shortcut` | `shortcuts.rs` | Arrow key → tool switch                                                        |
+| R3.4 pen tool            | —              | ⚠️ No unit tests (E2E only)                                                    |

--- a/docs/specs/edge-system.md
+++ b/docs/specs/edge-system.md
@@ -1,0 +1,162 @@
+# Edge System
+
+> R1.10, R1.11, R1.12, R5.7, R5.8 | Status: done
+
+## Format (R1.10)
+
+### Basic Edge
+
+```fd
+edge @flow_login_to_dashboard {
+  from: @login_screen
+  to: @dashboard
+  arrow: end
+  stroke: #6C5CE7 2
+}
+```
+
+### Edge Properties
+
+| Property  | Values                         | Default      |
+| --------- | ------------------------------ | ------------ |
+| `from:`   | `@node_id`                     | _(required)_ |
+| `to:`     | `@node_id`                     | _(required)_ |
+| `arrow:`  | `none`, `start`, `end`, `both` | `end`        |
+| `curve:`  | `straight`, `smooth`, `step`   | `smooth`     |
+| `stroke:` | `#color width`                 | `#999 1`     |
+| `label:`  | `"text"`                       | _(none)_     |
+| `flow:`   | `pulse Nms`, `dash Nms`        | _(none)_     |
+
+### With Annotations
+
+```fd
+edge @user_login_flow {
+  from: @login_form
+  to: @dashboard
+  arrow: end
+  curve: smooth
+  stroke: #6C5CE7 2
+  label: "POST /auth"
+
+  spec {
+    "Authentication flow — form submit to dashboard redirect"
+    accept: "shows loading spinner during request"
+    status: done
+    priority: high
+    tag: auth, flow
+  }
+}
+```
+
+## Trigger Animations (R1.11)
+
+Edges support the same `anim` blocks as nodes:
+
+```fd
+edge @nav_link {
+  from: @page_a to: @page_b
+  stroke: #CCC 1
+
+  anim :hover {
+    stroke: #6C5CE7 3
+    ease: ease_out 200ms
+  }
+}
+```
+
+Supported triggers: `:hover`, `:press`, `:enter` — identical to node animation triggers.
+
+## Flow Animations (R1.12)
+
+Continuous animations that visualize data flow direction:
+
+```fd
+edge @data_pipe {
+  from: @api to: @db
+  flow: pulse 800ms     # traveling dot from → to
+}
+
+edge @sync_channel {
+  from: @client to: @server
+  flow: dash 600ms      # marching dashes from → to
+}
+```
+
+| Flow Type | Visual                                 | Parameters    |
+| --------- | -------------------------------------- | ------------- |
+| `pulse`   | Animated dot traveling along edge path | Duration (ms) |
+| `dash`    | Marching dashes moving along edge path | Duration (ms) |
+
+Flow direction follows `from → to`. Animation loops continuously.
+
+## Rendering (R5.7, R5.8)
+
+### Curve Algorithms
+
+| `curve:`   | Algorithm                             | Use Case             |
+| ---------- | ------------------------------------- | -------------------- |
+| `straight` | Direct line segment                   | Simple connections   |
+| `smooth`   | Cubic Bézier with auto control points | Most edges (default) |
+| `step`     | Right-angle step routing              | Flowcharts, UML      |
+
+### Arrowhead Rendering
+
+Arrowheads are drawn as filled triangles at the edge endpoints:
+
+- Size scales with `stroke` width
+- Arrow at `start` points toward source, arrow at `end` points toward target
+- Both arrows drawn when `arrow: both`
+
+### Label Positioning
+
+Edge labels are positioned at the midpoint of the edge path:
+
+- Horizontally centered on the path
+- Offset slightly above the line to avoid overlap
+- Uses the edge's font settings (or defaults)
+
+### Flow Animation Rendering
+
+**Pulse dot:**
+
+- Small filled circle traveling along the edge path
+- Position interpolated by `(time_ms % duration) / duration`
+- Color matches edge `stroke` color
+
+**Marching dashes:**
+
+- Dash pattern with animated offset
+- `stroke-dashoffset` decremented each frame
+- Speed determined by duration parameter
+
+## Edge Cases
+
+- **Self-referencing edge** (`from: @a to: @a`) → draws a loop arc
+- **Deleted source/target node** → edge becomes orphaned; parser handles gracefully
+- **Overlapping edges between same nodes** → rendered side-by-side with slight offset
+- **Edge label collision** → no automatic avoidance (manual positioning via constraints)
+- **Hover on edge** → hit testing uses distance-to-curve threshold (6px)
+
+## Implementation Notes
+
+| Module     | File                               | Key Functions                     |
+| ---------- | ---------------------------------- | --------------------------------- |
+| Parser     | `crates/fd-core/src/parser.rs`     | `parse_edge()`, `parse_flow()`    |
+| Emitter    | `crates/fd-core/src/emitter.rs`    | `emit_edge()`, `emit_flow()`      |
+| Model      | `crates/fd-core/src/model.rs`      | `Edge`, `EdgeFlow`, `EdgeArrow`   |
+| Rendering  | `crates/fd-wasm/src/render2d.rs`   | `draw_edge()`, `draw_edge_flow()` |
+| Mutations  | `crates/fd-editor/src/commands.rs` | `AddEdge`, `RemoveEdge`           |
+| Arrow tool | `crates/fd-editor/src/tools.rs`    | `ArrowTool`                       |
+
+## Test Coverage
+
+| Test                          | Location     | What it covers                                   |
+| ----------------------------- | ------------ | ------------------------------------------------ |
+| `parse_edge_*`                | `parser.rs`  | Basic edges, properties, annotations             |
+| `emit_edge_*`                 | `emitter.rs` | Edge serialization with all properties           |
+| `roundtrip_edge_*`            | `emitter.rs` | Parse→emit round-trip fidelity                   |
+| `emit_edge_with_trigger_anim` | `emitter.rs` | `:hover`/`:press` animation blocks on edges      |
+| `roundtrip_edge_hover_anim`   | `emitter.rs` | Animation round-trip                             |
+| `emit_edge_flow_*`            | `emitter.rs` | `flow: pulse`/`dash` serialization               |
+| `roundtrip_edge_flow_*`       | `emitter.rs` | Flow animation round-trip                        |
+| `arrow_tool_*`                | `tools.rs`   | Create edge, same-node reject, preview (5 tests) |

--- a/docs/specs/inline-editing.md
+++ b/docs/specs/inline-editing.md
@@ -1,0 +1,111 @@
+# Inline Editing
+
+> R3.27, R3.28 | Status: done
+
+## Inline Text Editing (R3.28)
+
+### Trigger
+
+| Action                                  | Result                                    |
+| --------------------------------------- | ----------------------------------------- |
+| Double-click text node                  | Open inline editor with current text      |
+| Double-click shape (rect/ellipse/frame) | Create text child + open inline editor    |
+| Double-click empty canvas               | Create new text node + open inline editor |
+
+### Editor Overlay
+
+A floating `<textarea>` is positioned over the node in screen coordinates:
+
+- **Position/size** — matches the node's bounding box, scaled by camera zoom
+- **Background** — shape nodes use their `fill` color; text nodes use themed default (`#1E1E2E` dark / `#FFFFFF` light); shapes without fill use themed fallback
+- **Text color** — auto-contrasted against background via luminance threshold (dark bg → white text, light bg → dark text)
+- **Font** — matches node's `font-family`, `font-weight`, `font-size` scaled to zoom level
+- **Border radius** — ellipses use `50%`, rects use actual `corner` value, text nodes use `4px`
+- **Text alignment** — respects node's `align:` property via CSS `text-align`
+- **Vertical alignment** — dynamic `padding-top` based on textarea height vs text height for `top|middle|bottom`
+
+### Keyboard Behavior
+
+| Key           | Action                                    |
+| ------------- | ----------------------------------------- |
+| Enter         | Commit text and close editor              |
+| Escape        | Revert to original value and close editor |
+| Click outside | Commit text and close editor              |
+
+### Live Sync
+
+Every keystroke updates Code Mode in real-time:
+
+1. `input` event fires on textarea
+2. Call `set_node_prop("label", value)` via WASM
+3. WASM creates/updates text child node in SceneGraph
+4. `emit_document()` → new FD source → push to VS Code editor
+5. Canvas re-renders with updated text
+
+If value is unchanged from original → **skip** `set_node_prop` (prevents style flattening from `resolve_style()`).
+
+### Commit Guard
+
+A `committed` flag prevents double-invocation:
+
+- Enter keydown → removes textarea from DOM → triggers blur
+- Blur fires `setTimeout(commit, 100)` which would race
+- The `committed` flag ensures `syncTextToExtension()` runs exactly once
+
+## Layer Rename (R3.27)
+
+### Trigger
+
+Double-click a layer name in the Layers panel → opens inline `<input>` field.
+
+### Behavior
+
+- Input pre-filled with current `@id` (without `@` prefix)
+- Enter → commit rename
+- Escape → cancel
+- Blur → commit
+
+### Scope
+
+Rename updates the `@id` **everywhere** in the document:
+
+- Node declaration (`rect @old_id {` → `rect @new_id {`)
+- Constraint references (`center_in: @old_id` → `center_in: @new_id`)
+- Edge references (`from: @old_id` → `from: @new_id`)
+- Style references (if any)
+
+Uses **word-boundary safe** replacement to avoid partial matches (e.g. renaming `@btn` doesn't break `@btn_label`).
+
+### Sanitization
+
+- Strip leading/trailing whitespace
+- Replace spaces with underscores
+- Remove characters invalid in FD identifiers
+- Reject empty string (keep original)
+
+## Edge Cases
+
+- **Empty text on commit** → removes text child node (shape) or keeps empty text node
+- **Very long text** → textarea scrolls; text wraps within node bounds on canvas
+- **Rename to existing `@id`** → parser rejects duplicate, error shown
+- **Rename while animations reference the `@id`** → `anim` blocks stay attached (they're children, not references)
+- **Double-click during drag** → prevented by dead-zone check (pointer-up at same position = click, not drag)
+- **Press animation suppression** → `clear_pressed()` called before opening editor to prevent shape jump from `:press` animation state
+
+## Implementation Notes
+
+| Module             | File                        | Key Functions                                |
+| ------------------ | --------------------------- | -------------------------------------------- |
+| Inline editor (JS) | `fd-vscode/webview/main.js` | `openInlineEditor()`, `commit()`             |
+| WASM prop setter   | `crates/fd-wasm/src/lib.rs` | `set_node_prop("label", ...)`                |
+| Text child mgmt    | `crates/fd-wasm/src/lib.rs` | Creates/updates/removes `text` child node    |
+| Layer rename (JS)  | `fd-vscode/webview/main.js` | `refreshLayersPanel()` inline rename handler |
+| Graph-wide rename  | `crates/fd-wasm/src/lib.rs` | `set_text()` re-parse with new `@id`         |
+
+## Test Coverage
+
+| Test                | Location         | What it covers                                           |
+| ------------------- | ---------------- | -------------------------------------------------------- |
+| E2E: inline editing | `e2e-ux.test.ts` | Double-click open, enter commit, escape revert (3 tests) |
+| E2E: hex luminance  | `e2e-ux.test.ts` | Auto-contrast text color (1 test)                        |
+| E2E: rename         | `e2e-ux.test.ts` | Sanitization, word-boundary safety (3 tests)             |

--- a/docs/specs/selection.md
+++ b/docs/specs/selection.md
@@ -1,0 +1,106 @@
+# Selection & Manipulation
+
+> R3.1, R3.2, R3.16, R3.24, R3.26 | Status: done
+
+## Behavior
+
+### Click Select (R3.1)
+
+| Action               | Result                                       |
+| -------------------- | -------------------------------------------- |
+| Click node           | Select it (deselect all others)              |
+| Shift+click node     | Toggle it in/out of selection                |
+| Click empty canvas   | Deselect all                                 |
+| Drag on empty canvas | Marquee (rubber-band) selection              |
+| Shift+drag           | Additive marquee — add to existing selection |
+
+Marquee selects any node whose bounding box **intersects** the rectangle (not requires full containment).
+
+### Drag to Move (R3.2)
+
+- Pointer-down on selected node → drag moves all selected nodes
+- If pointer-down on an **unselected** node → select it first, then drag
+- Shift-drag: constrain movement to X or Y axis (whichever has more displacement after 4px dead zone)
+- Drag updates node `x:` / `y:` in FD source via `MoveNode` mutation
+
+### Resize Handles (R3.16)
+
+8-point resize grips appear on selected shapes:
+
+```
+  NW ──── N ──── NE
+  │                │
+  W                E
+  │                │
+  SW ──── S ──── SE
+```
+
+| Handle | Cursor        | Behavior                    |
+| ------ | ------------- | --------------------------- |
+| NW, SE | `nwse-resize` | Diagonal resize from corner |
+| NE, SW | `nesw-resize` | Diagonal resize from corner |
+| N, S   | `ns-resize`   | Vertical resize from edge   |
+| E, W   | `ew-resize`   | Horizontal resize from edge |
+
+- **Opposite corner anchored** — resizing NW anchors SE in place
+- **Shift+resize** → constrain to square proportions
+- **Min size** → 4px prevents collapsing to zero
+- Resize updates `w:` / `h:` and adjusts `x:` / `y:` to keep anchor fixed
+
+### Group Drill-down (R3.24)
+
+State machine for nested group selection (Figma/Sketch behavior):
+
+```
+Click child of UNSELECTED group → selects the GROUP (parent)
+Click child of SELECTED group   → drills into child (selects child)
+Click child of SELECTED child   → stays on that child
+```
+
+Visual feedback:
+
+- **Hover** on group → dashed blue border
+- **Selected** group → solid blue border + `"Group @id"` badge
+- **Drill-down** → child shows its own selection handles
+
+Implementation:
+
+- `effective_target()` in `model.rs` — bubbles up to nearest unselected group
+- Click-vs-drag distinction: pointer-down captures target, pointer-up without drag drills, pointer-up with drag moves the group
+- `is_ancestor_of()` helper for traversing parent chains
+
+### Arrow-Key Nudge (R3.26)
+
+| Key               | Distance |
+| ----------------- | -------- |
+| Arrow key         | 1px      |
+| Shift + arrow key | 10px     |
+
+Nudge applies to all selected nodes. Updates `x:` / `y:` in FD source.
+
+## Edge Cases
+
+- **Marquee on empty doc** → no crash, empty selection
+- **Resize to negative dimensions** → min clamped to 4×4px
+- **Drag a group child that's already selected** → moves only the child, not the parent group
+- **3+ level nested groups** → drill-down works recursively (click outer → click inner → click leaf)
+- **Resize handle hit zone** → 8px radius around visual handle center for touch/trackpad friendliness
+
+## Implementation Notes
+
+| Module      | File                               | Key Functions                                 |
+| ----------- | ---------------------------------- | --------------------------------------------- |
+| Hit testing | `crates/fd-render/src/hit.rs`      | `hit_test_node()`, `hit_test_resize_handle()` |
+| Selection   | `crates/fd-editor/src/tools.rs`    | `SelectTool`, `handle_pointer_down/up()`      |
+| Group logic | `crates/fd-core/src/model.rs`      | `effective_target()`, `is_ancestor_of()`      |
+| Mutations   | `crates/fd-editor/src/commands.rs` | `MoveNode`, `ResizeNode`                      |
+
+## Test Coverage
+
+| Test                 | Location         | What it covers                                      |
+| -------------------- | ---------------- | --------------------------------------------------- |
+| `select_tool_*`      | `tools.rs`       | Click, shift-click, deselect (5 tests)              |
+| `hit_test_*`         | `hit.rs`         | Point→node, nested groups, resize handles (3 tests) |
+| `effective_target_*` | `model.rs`       | Group drill-down, 3-level nesting (5 tests)         |
+| `select_tool_drag`   | `tools.rs`       | Drag moves selection                                |
+| E2E: nudge, resize   | `e2e-ux.test.ts` | Arrow-key 1px/10px, resize proportions (4 tests)    |


### PR DESCRIPTION
## Summary

Overhauls REQUIREMENTS.md into a clean index with inline status and creates detailed spec docs for complex features.

### Changes

**REQUIREMENTS.md restructure:**
- Added inline status tags (`done`/`partial`/`planned`/`future`) to all 60+ requirements
- Reorganized R3 (33 sub-requirements!) into 5 sub-categories:
  - **R3a**: Selection & Manipulation
  - **R3b**: Drawing Tools
  - **R3c**: Navigation & View
  - **R3d**: Panels & UI
  - **R3e**: Export & Media
- Added `→ [spec](specs/...)` cross-links for complex features
- Moved Test Matrix from CHANGELOG into REQUIREMENTS.md

**New `docs/specs/` (5 documents):**
- `selection.md` — click/shift/marquee, drag, resize handles, group drill-down
- `drawing-tools.md` — shape creation, pen tool, pressure, shape recognition
- `inline-editing.md` — text editing overlay, layer rename, live sync
- `edge-system.md` — edge format, animations, flow effects, rendering
- `animation-system.md` — triggers, easing, tween engine, drag-drop picker

**Cleanup:**
- Removed 134 duplicate lines from CHANGELOG (checklist now inline in REQUIREMENTS.md)
- Updated GEMINI.md to reference `docs/specs/`

### Stats

| | Before | After |
|---|---|---|
| REQUIREMENTS.md | 177 lines | 210 lines (with status + sub-categories) |
| CHANGELOG.md | 532 lines | 405 lines (no duplication) |
| docs/specs/ | — | 5 files, 694 lines total |