### PR TITLE
refactor(vscode): remove R7 collaboration feature

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### Remove R7 Collaboration
+
+- **REMOVED**: R7 (Collaboration) — removed `R7.1` (real-time multiplayer) and `R7.2` (shareable links) from requirements; deleted 👥 Share button, shareDialog handler, collaborative cursor CSS/JS placeholder from `extension.ts` and `main.js`; removed R7 section + index entry from `REQUIREMENTS.md`
+
 ### Requirements Overhaul
 
 - **DOCS**: Restructured `REQUIREMENTS.md` — inline status tags on all 60+ requirements, R3 reorganized into 5 sub-categories (R3a–R3e: Selection, Drawing, Navigation, Panels, Export)
@@ -39,11 +43,6 @@
 - **UX**: Two-finger pan (no Space key needed), pinch-to-zoom with smooth inertia, long-press opens context menu.
 - **UX**: Three-finger swipe left/right for undo/redo.
 - **UX**: Palm rejection when Apple Pencil is detected.
-
-### v0.8.45
-
-- **FEATURE**: Collaborative Cursors Placeholder — colored cursor dot with workspace name label follows the mouse, signaling collaboration-readiness.
-- **UX**: Added 👥 Share button in the toolbar. Shows a "Real-time collaboration is coming!" dialog with Git sharing guidance.
 
 ### v0.8.44
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -117,11 +117,6 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 
-### R7: Collaboration
-
-- **R7.1** _(future)_: Real-time multiplayer — CRDT-based conflict resolution, cursor presence, live sync
-- **R7.2** _(future)_: Shareable links — URL to share read-only or editable view without IDE
-
 ## Non-Functional Requirements
 
 | Requirement        | Target                                    |
@@ -231,5 +226,5 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | group / drill-down  | R3.24                                 |
 | image               | R3.32                                 |
 | library             | R3.33                                 |
-| collaboration       | R7.1, R7.2                            |
-| mermaid             | R1.18                                 |
+
+| mermaid | R1.18 |

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -135,7 +135,6 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
           webviewPanel.webview.postMessage({
             type: "setText",
             text: document.getText(),
-            workspaceName: vscode.workspace.name || "Collaborator",
           });
           break;
         }
@@ -186,10 +185,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
           }
           break;
         }
-        case "shareDialog": {
-          vscode.window.showInformationMessage("Real-time collaboration is coming! For now, share the .fd file via Git.");
-          break;
-        }
+
       }
     });
 
@@ -1453,37 +1449,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       letter-spacing: -0.01em;
     }
 
-    /* ── Collaborative Cursors ── */
-    #collab-cursor {
-      position: absolute;
-      pointer-events: none;
-      z-index: 9999;
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      transform: translate(12px, 12px); /* Offset from true mouse pos */
-    }
-    .cursor-arrow {
-      width: 0; 
-      height: 0; 
-      border-left: 6px solid transparent;
-      border-right: 6px solid transparent;
-      border-bottom: 12px solid #E91E63;
-      transform: rotate(-30deg);
-      margin-left: -2px;
-      filter: drop-shadow(0 1px 2px rgba(0,0,0,0.5));
-    }
-    .cursor-label {
-      background: #E91E63;
-      color: white;
-      padding: 3px 8px;
-      border-radius: 4px;
-      font-size: 11px;
-      font-weight: 500;
-      white-space: nowrap;
-      margin-top: -2px;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-    }
+
 
     @keyframes fd-spin {
       to { transform: rotate(360deg); }
@@ -2180,8 +2146,6 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
         <button class="export-menu-item disabled" title="Coming soon">🔗 Copy as link</button>
       </div>
     </div>
-    <div class="tool-sep zen-full-only"></div>
-    <button class="tool-btn zen-full-only" id="share-btn" title="Share and collaborate">👥 Share</button>
     <div class="tool-sep zen-full-only"></div>
     <button class="tool-btn" id="sketchy-toggle-btn" title="Toggle sketchy hand-drawn mode">✏️</button>
     <button class="tool-btn zen-full-only" id="theme-toggle-btn" title="Toggle light/dark canvas theme">🌙</button>

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1083,10 +1083,6 @@ window.addEventListener("message", (event) => {
       render();
       suppressTextSync = false;
 
-      // Handle collaborative cursor setup if present
-      if (message.workspaceName) {
-        setupCollaborativeCursor(message.workspaceName);
-      }
       break;
     }
     case "selectNode": {
@@ -4756,46 +4752,7 @@ async function copySelectionAsPng() {
   }, "image/png");
 }
 
-// ─── Collaborative Cursor Placeholder ──────────────────────────────────────
 
-let collabCursorEl = null;
-
-function setupCollaborativeCursor(name) {
-  if (!collabCursorEl) {
-    collabCursorEl = document.createElement("div");
-    collabCursorEl.id = "collab-cursor";
-    collabCursorEl.className = "collab-cursor";
-
-    const arrow = document.createElement("div");
-    arrow.className = "cursor-arrow";
-
-    const label = document.createElement("div");
-    label.className = "cursor-label";
-
-    collabCursorEl.appendChild(arrow);
-    collabCursorEl.appendChild(label);
-
-    document.body.appendChild(collabCursorEl);
-
-    // Track mouse
-    document.addEventListener("pointermove", (e) => {
-      // Small offset to simulate network latency / other user
-      collabCursorEl.style.left = e.clientX + "px";
-      collabCursorEl.style.top = e.clientY + "px";
-    });
-  }
-
-  collabCursorEl.querySelector(".cursor-label").textContent = name;
-}
-
-// ─── Share Button ──────────────────────────────────────────────────────────
-
-const shareBtn = document.getElementById("share-btn");
-if (shareBtn) {
-  shareBtn.addEventListener("click", () => {
-    vscode.postMessage({ type: "shareDialog" });
-  });
-}
 // ─── Start ───────────────────────────────────────────────────────────────────
 
 main();


### PR DESCRIPTION
## Summary\n\nRemove R7 Collaboration feature entirely — it was future-only placeholder code with no user demand.\n\n### Removed\n- 👥 Share button + `shareDialog` handler in `extension.ts`\n- Collaborative cursor CSS (#collab-cursor, .cursor-arrow, .cursor-label) in `extension.ts`\n- `setupCollaborativeCursor()` function + Share button listener in `main.js`\n- `workspaceName` from the `ready` message payload\n- R7 section (R7.1 + R7.2) and index entry from `REQUIREMENTS.md`\n- v0.8.45 changelog entry from `CHANGELOG.md`\n\n### Verification\n- ✅ `cargo check --workspace`\n- ✅ `cargo test --workspace`\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all -- --check`\n- ✅ `pnpm compile` (extension builds)\n- ✅ `pnpm test` (162 tests pass)\n\n4 files changed, 8 insertions, 93 deletions."