### PR TITLE
fix(zed): add rev field to grammars.fd in extension.toml

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -12,4 +12,5 @@ languages = ["FD"]
 
 [grammars.fd]
 repository = "https://github.com/khangnghiem/fast-draft"
+rev = "1e43a46"
 path = "tree-sitter-fd"


### PR DESCRIPTION
Fixes Zed CI error: missing field `rev` in `[grammars.fd]`.