### PR TITLE
fix(layout): nested group auto-sizing in column/row/grid layouts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### Fix Nested Group Auto-Sizing
+
+- **BUG FIX**: Groups inside Column/Row/Grid layouts now take up their correct resolved size — previously `intrinsic_size()` returned `(0,0)` for groups, causing siblings to overlap. Layout solver now uses a two-pass approach: pass 1 recurses to resolve nested group sizes bottom-up, pass 2 repositions children using their actual dimensions with `shift_subtree` to maintain correct absolute positions for all descendants.
+- **TESTING**: New regression tests `layout_nested_group_auto_size` and `layout_group_child_inside_column_parent` in `layout.rs`
+
 ### Remove R7 Collaboration
 
 - **REMOVED**: R7 (Collaboration) — removed `R7.1` (real-time multiplayer) and `R7.2` (shareable links) from requirements; deleted 👥 Share button, shareDialog handler, collaborative cursor CSS/JS placeholder from `extension.ts` and `main.js`; removed R7 section + index entry from `REQUIREMENTS.md`

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -20,6 +20,8 @@ group @wizard {
     tag: onboarding, ux, retention
   }
   layout: column gap=0 pad=0
+  x: 457.98
+  y: 165.41
   rect @step_card {
     w: 480 h: 520
     fill: #FFFFFF
@@ -71,6 +73,8 @@ group @wizard {
       }
       group @dots {
         layout: row gap=8 pad=0
+        x: 370.85
+        y: 498.43
         ellipse @dot_1 {
           w: 10 h: 10
           fill: #6C5CE7
@@ -129,8 +133,7 @@ group @wizard {
 rect @_anon_6 {
   w: 100 h: 80
   fill: #CCCCD9
+  x: 486
+  y: 1140.92
 }
 
-@_anon_6 -> absolute: 486, 1140.92
-@wizard -> center_in: canvas
-@dots -> absolute: 370.85, 498.43


### PR DESCRIPTION
## Problem

Groups inside Column/Row/Grid layouts took up zero space because `intrinsic_size()` returned `(0,0)` for `Group` nodes. This caused siblings to overlap — e.g., in `onboarding.fd`, the `@_anon_3` group visually overflowed its parent `@wizard`.

## Fix

Refactored `resolve_children()` in `layout.rs` to use a **two-pass** approach for Column/Row/Grid:

- **Pass 1**: Initialize children at parent origin, recurse to resolve nested groups bottom-up (so groups get their actual auto-sized bounds)
- **Pass 2**: Reposition children using their *resolved* dimensions with `shift_subtree` to maintain correct absolute positions for all descendants

Added `shift_subtree` helper that recursively applies a `(dx, dy)` delta to a node and all its descendants.

## Tests

- ✅ `layout_nested_group_auto_size` — verifies group siblings in column layout don't overlap
- ✅ `layout_group_child_inside_column_parent` — verifies the onboarding.fd pattern works
- ✅ `cargo test --workspace` — all existing tests pass
- ✅ `cargo clippy --workspace -- -D warnings` — zero warnings
- ✅ `cargo fmt --all -- --check` — clean