### PR TITLE
🎨 Palette: Use semantic buttons for onboarding cards

### DIFF
--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -635,6 +635,8 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       margin-bottom: 40px;
     }
     .onboard-card {
+      appearance: none;
+      display: block;
       width: 140px;
       padding: 20px 16px;
       background: rgba(255,255,255,0.06);
@@ -643,12 +645,18 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       text-align: center;
       cursor: pointer;
       transition: all 0.2s ease;
+      font-family: inherit;
+      color: inherit;
     }
     .onboard-card:hover {
       background: rgba(255,255,255,0.12);
       border-color: var(--fd-accent);
       transform: translateY(-4px);
       box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+    }
+    .onboard-card:focus-visible {
+      outline: 2px solid var(--fd-accent);
+      outline-offset: 2px;
     }
     .onboard-card-icon { font-size: 28px; display: block; margin-bottom: 10px; }
     .onboard-card-title {
@@ -2166,21 +2174,21 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
       <div class="onboard-heading">Start drawing</div>
       <div class="onboard-sub">Create something beautiful</div>
       <div class="onboard-cards">
-        <div class="onboard-card" data-tool="rect">
+        <button class="onboard-card" type="button" data-tool="rect">
           <span class="onboard-card-icon">📐</span>
           <div class="onboard-card-title">Draw shapes</div>
           <div class="onboard-card-desc">Rectangles, ellipses, frames</div>
-        </div>
-        <div class="onboard-card" data-tool="pen">
+        </button>
+        <button class="onboard-card" type="button" data-tool="pen">
           <span class="onboard-card-icon">✏️</span>
           <div class="onboard-card-title">Sketch freely</div>
           <div class="onboard-card-desc">Freehand pen drawings</div>
-        </div>
-        <div class="onboard-card" data-tool="text">
+        </button>
+        <button class="onboard-card" type="button" data-tool="text">
           <span class="onboard-card-icon">📝</span>
           <div class="onboard-card-title">Type text</div>
           <div class="onboard-card-desc">Labels, headings, notes</div>
-        </div>
+        </button>
       </div>
       <div class="onboard-hint">Press <kbd>?</kbd> for all shortcuts</div>
     </div>


### PR DESCRIPTION
This PR improves the accessibility of the onboarding overlay by converting the interactive cards from `div` elements to semantic `button` elements.

**Changes:**
- Replaced `<div class="onboard-card">` with `<button class="onboard-card" type="button">`.
- Updated CSS to:
    - Reset default button styles (appearance, font, color).
    - Add `display: block` and `width: 140px` to maintain layout.
    - Add a `:focus-visible` style (`outline: 2px solid var(--fd-accent)`) to clearly indicate keyboard focus.

**Why:**
- **Accessibility:** Using `<button>` ensures these interactive elements are naturally focusable via keyboard (Tab) and have the correct role for screen readers.
- **UX:** Users navigating by keyboard can now select an onboarding tool without needing a mouse.

**Testing:**
- Verified code changes in `fd-vscode/src/extension.ts`.
- Ran `pnpm test` to ensure no regressions in existing logic.
- Ran `pnpm lint` to check for syntax issues.

---
*PR created automatically by Jules for task [9162961726115797564](https://jules.google.com/task/9162961726115797564) started by @khangnghiem*