### PR TITLE
fix(vscode): restore canvas→code selection sync highlighting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### v0.8.56
 
+- **BUG FIX**: Canvas→Code selection sync restored — clicking a node on canvas once again highlights its `@id` line in Code Mode; fixed stale `lastNotifiedSelectedId` dedup guard that blocked `nodeSelected` messages after cursor-sync round-trips, and restructured `cursorLine === i` guard to only skip cursor move (not decoration)
 - **BUG FIX**: Children inside Column/Row/Grid layouts no longer overflow their parent group — layout solver now skips `Position` constraints for children in managed layouts (the layout mode owns positioning)
 - **BUG FIX**: Group auto-sizing now uses resolved bounds directly instead of adding stale Position offsets, fixing incorrect bounding boxes after constraints shift children
 - **BUG FIX**: Moving a child outside its parent group now expands the group to contain it — `MoveNode` handler recomputes parent group bounds after every move

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -33,7 +33,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R2.2** _(done)_: Text → Canvas: Source edits re-render the canvas in <16ms
 - **R2.3** _(planned)_: Incremental: Only re-parse/re-emit changed regions, not the entire document
 - **R2.4** _(done)_: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
-- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node block in the text editor selects it on canvas; clicking a node on canvas reveals its `@id` line in the text editor
+- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node block in the text editor selects it on canvas; clicking a node on canvas reveals and highlights its `@id` line in the text editor (including re-clicks and cursor-sync round-trips)
 
 ### R3: Human Editing (Canvas)
 
@@ -160,7 +160,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | R1.15       | `emit_bg_shorthand`, `roundtrip_bg_shorthand`                     | ✅                             |
 | R1.16       | `roundtrip_comment_*`                                             | ✅                             |
 | R1.17       | `parse_align_*`, `roundtrip_align*`, `style_merging_align`        | ✅                             |
-| R2.1–R2.4   | `sync::tests::sync_*`, `bidi_sync::*`                             | ✅ 12 sync + 9 integration     |
+| R2.1–R2.5   | `sync::tests::sync_*`, `bidi_sync::*`, `e2e-ux: Canvas→Code`      | ✅ 12 sync + 9 integ + 4 E2E   |
 | R3.1        | `tools::tests::select_tool_*`, `hit::tests::*`                    | ✅ 5 tests + 3 hit tests       |
 | R3.2        | `select_tool_drag`, `select_tool_shift_drag_*`, resize integ.     | ✅ 3 tests                     |
 | R3.3        | `rect_tool_*`, `ellipse_tool_*`, `text_tool_*`                    | ✅ 7 tests                     |

--- a/docs/specs/selection.md
+++ b/docs/specs/selection.md
@@ -104,3 +104,18 @@ Nudge applies to all selected nodes. Updates `x:` / `y:` in FD source.
 | `effective_target_*` | `model.rs`       | Group drill-down, 3-level nesting (5 tests)         |
 | `select_tool_drag`   | `tools.rs`       | Drag moves selection                                |
 | E2E: nudge, resize   | `e2e-ux.test.ts` | Arrow-key 1px/10px, resize proportions (4 tests)    |
+
+### Code ↔ Canvas Selection Sync (R2.5)
+
+The bidirectional sync keeps canvas and text editor selections aligned:
+
+| Direction     | Trigger                          | Handler                       | Invariant                                                       |
+| ------------- | -------------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| Canvas → Code | `nodeSelected` message           | `extension.ts` regex `@id\b`  | Always highlights `@id` line, even if cursor already there      |
+| Code → Canvas | `onDidChangeTextEditorSelection` | `extension.ts` → `selectNode` | Must update `lastNotifiedSelectedId` to prevent dedup staleness |
+
+Key rules:
+
+- `suppressCursorSync` prevents feedback loops (200ms window)
+- `lastNotifiedSelectedId` dedup must be updated by **both** canvas clicks and extension `selectNode` messages
+- Highlight decoration fires unconditionally (1500ms auto-dispose)

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -117,17 +117,17 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
               );
               if (editor) {
                 const cursorLine = editor.selection.active.line;
-                // Skip if cursor is already on this line (prevents jump on re-click)
-                if (cursorLine === i) break;
-                // Suppress cursor→canvas sync to prevent feedback loop
-                suppressCursorSync = true;
-                const pos = new vscode.Position(i, 0);
-                editor.selection = new vscode.Selection(pos, pos);
-                editor.revealRange(
-                  line.range,
-                  vscode.TextEditorRevealType.InCenterIfOutsideViewport
-                );
-                // Briefly highlight the node declaration line
+                // Only move cursor if not already on this line
+                if (cursorLine !== i) {
+                  suppressCursorSync = true;
+                  const pos = new vscode.Position(i, 0);
+                  editor.selection = new vscode.Selection(pos, pos);
+                  editor.revealRange(
+                    line.range,
+                    vscode.TextEditorRevealType.InCenterIfOutsideViewport
+                  );
+                }
+                // Always highlight the node declaration line
                 const decoration = vscode.window.createTextEditorDecorationType({
                   backgroundColor: new vscode.ThemeColor(
                     "editor.findMatchHighlightBackground"

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1088,6 +1088,8 @@ window.addEventListener("message", (event) => {
     case "selectNode": {
       if (!fdCanvas) return;
       if (fdCanvas.select_by_id(message.nodeId || "")) {
+        // Sync dedup state so next canvas click sends nodeSelected correctly
+        lastNotifiedSelectedId = message.nodeId || "";
         render();
       }
       break;


### PR DESCRIPTION
## Summary

Fixes a regression where clicking a node on canvas no longer highlighted its `@id` line in Code Mode.

## Root Cause

Two bugs in the canvas↔code selection sync flow:

1. **Stale `lastNotifiedSelectedId`** in `main.js`: The `selectNode` handler (extension→canvas cursor sync) changed canvas selection without updating `lastNotifiedSelectedId`, causing the dedup guard to block subsequent `nodeSelected` messages.

2. **Overly aggressive `cursorLine === i` guard** in `extension.ts`: The guard prevented ALL processing when cursor was already on the target line, including the highlight decoration.

## Changes

- `main.js`: `selectNode` handler now updates `lastNotifiedSelectedId`
- `extension.ts`: `cursorLine` check now only skips cursor move, not decoration
- 4 new regression tests in `e2e-ux.test.ts`
- Updated R2.5 wording, `selection.md` spec, CHANGELOG

## Testing

- ✅ 166 TypeScript tests pass (89 fd-parse + 77 e2e-ux)
- ✅ 154 Rust tests pass
- ✅ Extension compiles cleanly