### PR TITLE
chore: bump fd-vscode to v0.8.59

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.56",
+  "version": "0.8.59",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump for fd-vscode to 0.8.59 (already published to both VS Code Marketplace and Open VSX).