### PR TITLE
fix(zed): use branch ref 'main' for grammar rev

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -12,5 +12,5 @@ languages = ["FD"]
 
 [grammars.fd]
 repository = "https://github.com/khangnghiem/fast-draft"
-rev = "4e08f80b59be33b03c14656a9cca8b645f3bb38d"
+rev = "main"
 path = "tree-sitter-fd"


### PR DESCRIPTION
Zed's builder does `git fetch --depth 1 origin <rev>` — GitHub only supports shallow fetch of branch/tag tips, not arbitrary SHAs.