### PR TITLE
feat(format): canonical node ordering in autoformat pipeline

### DIFF
--- a/.agents/workflows/e2e-ux.md
+++ b/.agents/workflows/e2e-ux.md
@@ -156,3 +156,16 @@ For any failures:
 - Take a screenshot
 - Document expected vs actual behavior
 - File as a bug to fix before deploying
+
+---
+
+## Cleanup
+
+After all phases complete and results are reported:
+
+1. Switch back to main and sync:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```

--- a/crates/fd-core/src/format.rs
+++ b/crates/fd-core/src/format.rs
@@ -6,7 +6,7 @@
 
 use crate::emitter::emit_document;
 use crate::parser::parse_document;
-use crate::transform::dedup_use_styles;
+use crate::transform::{dedup_use_styles, sort_nodes};
 
 // ─── Config ───────────────────────────────────────────────────────────────
 
@@ -23,6 +23,10 @@ pub struct FormatConfig {
     /// This is *structurally destructive* (adds new style names, rewrites nodes),
     /// so it defaults to **false** — users must explicitly opt-in.
     pub hoist_styles: bool,
+
+    /// Reorder top-level nodes by kind: Group/Frame → Rect → Ellipse → Text →
+    /// Path → Generic. Relative order within each kind is preserved. Default: **true**.
+    pub sort_nodes: bool,
 }
 
 impl Default for FormatConfig {
@@ -30,6 +34,7 @@ impl Default for FormatConfig {
         Self {
             dedup_use: true,
             hoist_styles: false,
+            sort_nodes: true,
         }
     }
 }
@@ -51,6 +56,10 @@ pub fn format_document(text: &str, config: &FormatConfig) -> Result<String, Stri
 
     if config.hoist_styles {
         crate::transform::hoist_styles(&mut scene);
+    }
+
+    if config.sort_nodes {
+        sort_nodes(&mut scene);
     }
 
     Ok(emit_document(&scene))
@@ -117,5 +126,60 @@ rect @box {
             output.contains("# This is a section header"),
             "comments must survive formatting"
         );
+    }
+
+    #[test]
+    fn format_document_sorts_nodes_by_kind() {
+        let input = r#"
+text @label "World" {
+  font: "Inter" regular 14
+}
+rect @box {
+  w: 100 h: 50
+}
+group @wrapper {
+  rect @child {
+    w: 50 h: 50
+  }
+}
+"#;
+        let config = FormatConfig::default();
+        let output = format_document(input, &config).expect("format failed");
+        // In the output, group should appear before rect, rect before text
+        let group_pos = output.find("group @wrapper").expect("group not found");
+        let rect_pos = output.find("rect @box").expect("rect not found");
+        let text_pos = output.find("text @label").expect("text not found");
+        assert!(
+            group_pos < rect_pos,
+            "group should come before rect in formatted output"
+        );
+        assert!(
+            rect_pos < text_pos,
+            "rect should come before text in formatted output"
+        );
+    }
+
+    #[test]
+    fn format_document_sort_is_idempotent() {
+        let input = r#"
+text @label "Hello" {
+  font: "Inter" regular 14
+}
+ellipse @circle {
+  w: 60 h: 60
+}
+rect @box {
+  w: 100 h: 50
+}
+group @container {
+  rect @inner {
+    w: 50 h: 50
+  }
+}
+"#;
+        let config = FormatConfig::default();
+        let first = format_document(input, &config).expect("first format failed");
+        let second = format_document(&first, &config).expect("second format failed");
+        assert_eq!(first, second, "sort + format must be idempotent");
     }
 }

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -1145,51 +1145,71 @@ group @form {
         let btn_label = bounds[&graph.index_of(NodeId::intern("btn_label")).unwrap()];
 
         // Text bounds must match parent rect for centering to work
-        eprintln!("email_field: x={:.1} y={:.1} w={:.1} h={:.1}", email_field.x, email_field.y, email_field.width, email_field.height);
-        eprintln!("email_hint:  x={:.1} y={:.1} w={:.1} h={:.1}", email_hint.x, email_hint.y, email_hint.width, email_hint.height);
-        eprintln!("login_btn:   x={:.1} y={:.1} w={:.1} h={:.1}", login_btn.x, login_btn.y, login_btn.width, login_btn.height);
-        eprintln!("btn_label:   x={:.1} y={:.1} w={:.1} h={:.1}", btn_label.x, btn_label.y, btn_label.width, btn_label.height);
+        eprintln!(
+            "email_field: x={:.1} y={:.1} w={:.1} h={:.1}",
+            email_field.x, email_field.y, email_field.width, email_field.height
+        );
+        eprintln!(
+            "email_hint:  x={:.1} y={:.1} w={:.1} h={:.1}",
+            email_hint.x, email_hint.y, email_hint.width, email_hint.height
+        );
+        eprintln!(
+            "login_btn:   x={:.1} y={:.1} w={:.1} h={:.1}",
+            login_btn.x, login_btn.y, login_btn.width, login_btn.height
+        );
+        eprintln!(
+            "btn_label:   x={:.1} y={:.1} w={:.1} h={:.1}",
+            btn_label.x, btn_label.y, btn_label.width, btn_label.height
+        );
 
         assert!(
             (email_hint.x - email_field.x).abs() < 0.01,
             "email_hint x ({}) should match email_field x ({})",
-            email_hint.x, email_field.x
+            email_hint.x,
+            email_field.x
         );
         assert!(
             (email_hint.y - email_field.y).abs() < 0.01,
             "email_hint y ({}) should match email_field y ({})",
-            email_hint.y, email_field.y
+            email_hint.y,
+            email_field.y
         );
         assert!(
             (email_hint.width - email_field.width).abs() < 0.01,
             "email_hint width ({}) should match email_field width ({})",
-            email_hint.width, email_field.width
+            email_hint.width,
+            email_field.width
         );
         assert!(
             (email_hint.height - email_field.height).abs() < 0.01,
             "email_hint height ({}) should match email_field height ({})",
-            email_hint.height, email_field.height
+            email_hint.height,
+            email_field.height
         );
 
         assert!(
             (btn_label.x - login_btn.x).abs() < 0.01,
             "btn_label x ({}) should match login_btn x ({})",
-            btn_label.x, login_btn.x
+            btn_label.x,
+            login_btn.x
         );
         assert!(
             (btn_label.y - login_btn.y).abs() < 0.01,
             "btn_label y ({}) should match login_btn y ({})",
-            btn_label.y, login_btn.y
+            btn_label.y,
+            login_btn.y
         );
         assert!(
             (btn_label.width - login_btn.width).abs() < 0.01,
             "btn_label width ({}) should match login_btn width ({})",
-            btn_label.width, login_btn.width
+            btn_label.width,
+            login_btn.width
         );
         assert!(
             (btn_label.height - login_btn.height).abs() < 0.01,
             "btn_label height ({}) should match login_btn height ({})",
-            btn_label.height, login_btn.height
+            btn_label.height,
+            login_btn.height
         );
     }
 }

--- a/crates/fd-core/src/lib.rs
+++ b/crates/fd-core/src/lib.rs
@@ -13,7 +13,7 @@ pub use id::NodeId;
 pub use layout::{Viewport, resolve_layout};
 pub use lint::{LintDiagnostic, LintSeverity, lint_document};
 pub use model::*;
-pub use transform::{dedup_use_styles, hoist_styles};
+pub use transform::{dedup_use_styles, hoist_styles, sort_nodes};
 
 // Re-export petgraph types so downstream crates don't need a direct dependency
 pub use petgraph::graph::NodeIndex;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@
 - **DOCS**: Benchmark README with metrics table, FD feature matrix, and `compare.sh` auto-metrics script
 - **DOCS**: Feature coverage improvements — added named colors to kanban/org_chart, ellipse avatars + opacity to org_chart, property aliases + import + opacity to design_system; all Excalidraw JSONs normalized to pretty-printed format
 
+### Autoformat: Canonical Node Ordering
+
+- **FEATURE (R4.10)**: Canonical node ordering in autoformat pipeline — `format_document` now reorders top-level nodes by kind priority: Group/Frame → Rect → Ellipse → Text → Path → Generic. Relative order within each kind is preserved (stable sort). Configurable via `FormatConfig.sort_nodes` (default: true)
+- **TESTING**: 5 new tests — `sort_nodes_reorders_by_kind`, `sort_nodes_preserves_relative_order`, `sort_nodes_only_top_level`, `format_document_sorts_nodes_by_kind`, `format_document_sort_is_idempotent`
+- **WORKFLOW**: Updated `/e2e-ux` workflow to switch back to `main` after testing completes
+
 ### v0.8.60
 
 - **FIX**: Text centering in nested layouts — text nodes without explicit coordinates now correctly center within their parent shapes (rect, ellipse, frame) even when nested inside column/row/grid groups

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -99,7 +99,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R4.7** _(done)_: Spec-view export — generate markdown report of `spec` annotations from any `.fd` file
 - **R4.8** _(done)_: AI node refinement — restyle selected nodes, replace anonymous IDs via configurable provider
 - **R4.9** _(done)_: Multi-provider AI — Gemini, OpenAI, Anthropic, Ollama, OpenRouter with per-provider API keys
-- **R4.10** _(done)_: Auto-format pipeline — `format_document` via LSP; lint diagnostics + configurable transforms
+- **R4.10** _(done)_: Auto-format pipeline — `format_document` via LSP; lint diagnostics + configurable transforms; canonical node ordering (Group/Frame → Rect → Ellipse → Text → Path → Generic)
 - **R4.11** _(done)_: Inline Spec View — canvas-embedded spec overlay with node structure + annotations
 - **R4.12** _(done)_: Content-first ordering — emitter outputs children before appearance properties inside node blocks; complex documents get `# ─── Section ───` separators (Styles, Layout, Constraints, Flows)
 - **R4.13** _(done)_: Font weight names — parser/emitter use `bold`, `semibold`, `regular` etc. instead of numeric codes


### PR DESCRIPTION
## Summary

Add `sort_nodes` transform to the autoformat pipeline that reorders top-level nodes by kind priority:

**Group/Frame → Rect → Ellipse → Text → Path → Generic**

Relative order within each kind group is preserved (stable sort). Only affects root-level children — nested children stay in document order.

## Changes

- **`crates/fd-core/src/transform.rs`**: New `sort_nodes()` + `kind_priority()` helper
- **`crates/fd-core/src/format.rs`**: `FormatConfig.sort_nodes` flag (default: true), wired into pipeline
- **`crates/fd-core/src/lib.rs`**: Re-export `sort_nodes`
- **`docs/REQUIREMENTS.md`**: Extended R4.10 description
- **`docs/CHANGELOG.md`**: New entry
- **`.agents/workflows/e2e-ux.md`**: Added cleanup step to switch to main after testing

## Tests

5 new tests:
- `sort_nodes_reorders_by_kind` — Groups before rects, rects before text
- `sort_nodes_preserves_relative_order` — Two rects keep document order
- `sort_nodes_only_top_level` — Nested children not affected
- `format_document_sorts_nodes_by_kind` — End-to-end format verification
- `format_document_sort_is_idempotent` — Double-format produces identical output

## CI

- ✅ `cargo check --workspace`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`