### PR TITLE
docs: update style/anim → theme/when references across all docs

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -98,7 +98,7 @@ crates/
 | **Semantic IDs**            | `@login_form` not `@rect_17` — intent over auto-generated names            |
 | **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300` — relationships > pixels           |
 | **Accurate comments**       | `#` for context — wrong comments hurt more than no comments                |
-| **Style reuse**             | Define `style` blocks, reference with `use:` — consistency > ad-hoc        |
+| **Theme reuse**             | Define `theme` blocks, reference with `use:` — consistency > ad-hoc        |
 | **Spec for intent**         | `spec { ... }` metadata (status, priority, accept) — structured > freeform |
 | **Shorthand OK**            | `w:` / `h:` / `#FFF` are fine — unambiguous in context                     |
 

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -224,7 +224,7 @@ pub enum TextVAlign {
     Bottom,
 }
 
-/// A reusable style set that nodes can reference via `use: style_name`.
+/// A reusable theme set that nodes can reference via `use: theme_name`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Style {
     pub fill: Option<Paint>,
@@ -445,7 +445,7 @@ pub struct SceneNode {
     /// Inline style overrides on this node.
     pub style: Style,
 
-    /// Named style references (`use: base_text`).
+    /// Named theme references (`use: base_text`).
     pub use_styles: SmallVec<[NodeId; 2]>,
 
     /// Constraint-based positioning.
@@ -491,7 +491,7 @@ pub struct SceneGraph {
     /// The root node index.
     pub root: NodeIndex,
 
-    /// Named style definitions (`style base_text { ... }`).
+    /// Named theme definitions (`theme base_text { ... }`).
     pub styles: HashMap<NodeId, Style>,
 
     /// Index from NodeId → NodeIndex for fast lookup.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ The document is a **DAG** (Directed Acyclic Graph) stored as `petgraph::StableDi
 | ---------- | ------------------------------ | ------------------------------------- |
 | `graph`    | `StableDiGraph<SceneNode, ()>` | Parent→child containment edges        |
 | `root`     | `NodeIndex`                    | The invisible root node               |
-| `styles`   | `HashMap<NodeId, Style>`       | Named `style` block definitions       |
+| `styles`   | `HashMap<NodeId, Style>`       | Named `theme` block definitions       |
 | `id_index` | `HashMap<NodeId, NodeIndex>`   | Fast `@id` → index lookup             |
 | `edges`    | `Vec<Edge>`                    | Visual connections between nodes      |
 | `imports`  | `Vec<Import>`                  | `import "file.fd" as ns` declarations |
@@ -92,7 +92,7 @@ A single element in the scene graph.
 | `id`          | `NodeId`                      | Interned string ID (e.g. `@login_form`)                        |
 | `kind`        | `NodeKind`                    | Root, Generic, Group, Frame, Rect, Ellipse, Path, Text         |
 | `style`       | `Style`                       | Inline fill, stroke, font, corner, opacity, shadow, text-align |
-| `use_styles`  | `SmallVec<[NodeId; 2]>`       | Named style references (`use: base_text`)                      |
+| `use_styles`  | `SmallVec<[NodeId; 2]>`       | Named theme references (`use: base_text`)                      |
 | `constraints` | `SmallVec<[Constraint; 2]>`   | CenterIn, Offset, FillParent, Position                         |
 | `animations`  | `SmallVec<[AnimKeyframe; 2]>` | `:hover`, `:press`, `:enter` animations                        |
 | `annotations` | `Vec<Annotation>`             | `spec { ... }` metadata                                        |
@@ -131,7 +131,7 @@ render_scene(ctx, graph, bounds, ...) [render2d.rs]
   ├── draw grid overlay (if enabled)
   ├── for each root child (z-order):
   │     render_node(ctx, idx, bounds, ...)
-  │       ├── resolve style (use: + inline + anim)
+  │       ├── resolve style (use: + inline + when)
   │       ├── apply opacity
   │       ├── draw shape (rect/ellipse/text/path/group/frame/generic)
   │       ├── draw annotation badge (if annotated)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -11,20 +11,20 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.1** _(done)_: Token-efficient text DSL — ~5× fewer tokens than SVG for equivalent content
 - **R1.2** _(done)_: Graph-based document model (DAG) — nodes reference by `@id`, not coordinates
 - **R1.3** _(done)_: Constraint-based layout (`center_in`, `offset`, `fill_parent`) — no absolute coordinates until render time
-- **R1.4** _(done)_: Reusable styles via `style` blocks and `use:` references
+- **R1.4** _(done)_: Reusable themes via `theme` blocks and `use:` references (parser also accepts legacy `style` keyword)
 - **R1.5** _(done)_: Animation declarations with triggers (`:hover`, `:press`, `:enter`) and easing → [spec](specs/animation-system.md)
 - **R1.6** _(done)_: Git-friendly plain text — line-oriented diffs work well
 - **R1.7** _(done)_: Comments via `#` prefix
 - **R1.8** _(done)_: Human-readable and AI-writable without special tooling
 - **R1.9** _(done)_: Structured annotations (`spec` blocks) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
 - **R1.10** _(done)_: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `spec` annotations → [spec](specs/edge-system.md)
-- **R1.11** _(done)_: Edge trigger animations — edges support `anim :hover { ... }` blocks identical to nodes → [spec](specs/edge-system.md)
+- **R1.11** _(done)_: Edge trigger animations — edges support `when :hover { ... }` blocks identical to nodes (parser also accepts legacy `anim` keyword) → [spec](specs/edge-system.md)
 - **R1.12** _(done)_: Edge flow animations — `flow: pulse Nms` (traveling dot) and `flow: dash Nms` (marching dashes) → [spec](specs/edge-system.md)
 - **R1.13** _(done)_: Generic nodes — `@id { ... }` without explicit kind keyword for abstract/placeholder elements
 - **R1.14** _(done)_: Namespaced imports — `import "path.fd" as ns` for cross-file style/node reuse with `ns.style_name` references
 - **R1.15** _(done)_: Background shorthand — `bg: #FFF corner=12 shadow=(0,4,20,#0002)` for combined fill, corner, and shadow in one line
 - **R1.16** _(done)_: Comment preservation — `# text` lines attached to the following node survive all parse/emit round-trips and format passes
-- **R1.17** _(done)_: Text alignment — `align: left|center|right [top|middle|bottom]` property; defaults to `center middle`; reusable via `style` blocks and `use:` inheritance
+- **R1.17** _(done)_: Text alignment — `align: left|center|right [top|middle|bottom]` property; defaults to `center middle`; reusable via `theme` blocks and `use:` inheritance
 - **R1.18** _(planned)_: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges
 
 ### R2: Bidirectional Sync
@@ -107,6 +107,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R4.15** _(done)_: Named colors — `fill: purple` etc. accepted (17 Tailwind palette colors)
 - **R4.16** _(done)_: Property aliases — `background:`/`color:` → fill, `rounded:`/`radius:` → corner
 - **R4.17** _(done)_: Dimension units — `w: 320px` accepted, `px` stripped by parser
+- **R4.18** _(done)_: Theme/When rename + emitter reorder — `style` → `theme`, `anim` → `when` for clarity; emitter order: spec → children → style → when; old keywords accepted for backward compatibility
 
 ### R5: Rendering
 
@@ -226,8 +227,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | ai / refinement     | R4.7, R4.8, R4.9, R4.10, R4.12, R4.13, R4.14, R4.15, R4.16, R4.17 |
 | edge                | R1.10, R1.11, R1.12, R4.6, R5.7, R5.8                             |
 | import              | R1.14, R1.18                                                      |
-| style               | R1.4, R4.3                                                        |
-| animation           | R1.5, R1.11, R1.12, R3.29, R5.6, R5.8                             |
+| style / theme       | R1.4, R4.3, R4.18                                                 |
+| animation           | R1.5, R1.11, R1.12, R3.29, R4.18, R5.6, R5.8                      |
 | rendering           | R5.1, R5.2, R5.4, R5.5                                            |
 | platform            | R6.1, R6.2, R6.3, R6.4                                            |
 | inline editing      | R3.28                                                             |

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -1,4 +1,4 @@
-# ─── Styles ───
+# ─── Themes ───
 
 theme accent {
   fill: #6C5CE7  # blue


### PR DESCRIPTION
Updates all documentation references from `style`/`anim` to `theme`/`when` keywords.

**Files:**
- `model.rs` — 3 doc-strings
- `GEMINI.md` + zed copy — FD Format Rules table
- `REQUIREMENTS.md` — R1.4, R1.11, R1.17 + new R4.18 + index
- `ARCHITECTURE.md` — 3 data model references
- `demo.fd` — section separator comment

✅ All tests pass (cargo test + clippy + fmt)