### PR TITLE
fix(lsp): update hover/completion for theme/when keywords

### DIFF
--- a/crates/fd-lsp/src/completion.rs
+++ b/crates/fd-lsp/src/completion.rs
@@ -86,9 +86,9 @@ fn top_level_completions() -> Vec<CompletionItem> {
         ),
         ("path", "Freeform path", "path @${1:name} {\n  $0\n}"),
         (
-            "style",
-            "Reusable style block",
-            "style ${1:name} {\n  fill: #${2:6C5CE7}\n}",
+            "theme",
+            "Reusable theme definition (legacy: style)",
+            "theme ${1:name} {\n  fill: #${2:6C5CE7}\n}",
         ),
     ];
 
@@ -173,10 +173,10 @@ fn node_body_completions() -> Vec<CompletionItem> {
 
     // Animation block
     items.push(CompletionItem {
-        label: "anim".to_string(),
+        label: "when".to_string(),
         kind: Some(CompletionItemKind::SNIPPET),
-        detail: Some("Animation block".to_string()),
-        insert_text: Some("anim :${1|hover,press,enter|} {\n  $0\n}".to_string()),
+        detail: Some("Animation block (legacy: anim)".to_string()),
+        insert_text: Some("when :${1|hover,press,enter|} {\n  $0\n}".to_string()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         ..Default::default()
     });
@@ -246,7 +246,7 @@ mod tests {
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"rect"));
         assert!(labels.contains(&"group"));
-        assert!(labels.contains(&"style"));
+        assert!(labels.contains(&"theme"), "should suggest `theme` not `style`");
     }
 
     #[test]
@@ -256,7 +256,7 @@ mod tests {
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"w:"));
         assert!(labels.contains(&"fill:"));
-        assert!(labels.contains(&"anim"));
+        assert!(labels.contains(&"when"), "should suggest `when` not `anim`");
     }
 
     #[test]

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -104,8 +104,8 @@ fn hover_keyword(word: &str) -> Option<Hover> {
             "**text** — Text label node.\n\nInline content: `text @id \"content\" { ... }`\nProperties: `font:` `fill:` `opacity:`"
         }
         "path" => "**path** — Freeform vector path.\n\nSupports SVG-like path commands.",
-        "style" => {
-            "**style** — Reusable style definition.\n\nDefine once, apply to nodes with `use: style_name`."
+        "style" | "theme" => {
+            "**theme** — Reusable style definition.\n\nDefine once, apply to nodes with `use: theme_name`.\n(Legacy keyword `style` also accepted.)"
         }
         // Properties
         "w" | "width" => "**w:** — Width of the element in pixels.",
@@ -129,8 +129,8 @@ fn hover_keyword(word: &str) -> Option<Hover> {
         "row" => "**row** — Horizontal stack layout.\n\nModifiers: `gap=N` `pad=N`",
         "grid" => "**grid** — Grid layout.\n\nModifiers: `cols=N` `gap=N` `pad=N`",
         // Animation
-        "anim" => {
-            "**anim** — Animation block.\n\nFormat: `anim :trigger { props }`\nTriggers: `:hover`, `:press`, `:enter`"
+        "anim" | "when" => {
+            "**when** — Animation block.\n\nFormat: `when :trigger { props }`\nTriggers: `:hover`, `:press`, `:enter`\n(Legacy keyword `anim` also accepted.)"
         }
         "ease" => {
             "**ease:** — Easing function.\n\nValues: `linear`, `ease_in`, `ease_out`, `ease_in_out`, `spring`\nFormat: `ease: spring 300ms`"
@@ -192,5 +192,17 @@ mod tests {
         let graph = fd_core::parser::parse_document(text).ok();
         let result = compute_hover(text, Position::new(0, 6), graph.as_ref());
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn hover_on_theme_keyword() {
+        let result = hover_keyword("theme");
+        assert!(result.is_some(), "should have hover info for `theme`");
+    }
+
+    #[test]
+    fn hover_on_when_keyword() {
+        let result = hover_keyword("when");
+        assert!(result.is_some(), "should have hover info for `when`");
     }
 }


### PR DESCRIPTION
Updates the LSP hover and completion providers to use the new `theme`/`when` keywords:

**hover.rs:**
- `theme` and `when` keywords now return hover info (alongside legacy `style`/`anim`)
- 2 new tests: `hover_on_theme_keyword`, `hover_on_when_keyword`

**completion.rs:**
- Top-level completion suggests `theme` instead of `style`
- Node body completion suggests `when` instead of `anim`
- Updated 2 test assertions

✅ All 236 Rust tests pass