### PR TITLE
feat(vscode): context menu overhaul — AI Assist rename, expanded menu, icon swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ rect @login_btn { ... }
 - 👆 **Touch & gestures** — two-finger pan, pinch-to-zoom, Apple Pencil support
 - 🎬 **Drag-and-drop animations** — drag a shape onto another to add hover/press effects
 - 📤 **Export** — PNG, SVG, clipboard copy, or raw `.fd` source
-- 🤖 **AI Refine** — press ⌘I to improve designs with AI (supports 5 providers)
+- 🤖 **AI Assist** — press ⌘I to improve designs with AI (supports 5 providers)
 - 📋 **Spec View** — requirements dashboard with status filters and coverage tracking
 - 🎯 **Sticky styles** — your last-used colors and fonts are remembered per tool
 - ↗️ **Arrows & connectors** — draw connections between shapes with smooth curves

--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -1719,10 +1719,7 @@ rect @btn {
         let output = emit_document(&graph);
 
         // Emitter should output `when`, not `anim`
-        assert!(
-            output.contains("when :hover"),
-            "should emit `when` keyword"
-        );
+        assert!(output.contains("when :hover"), "should emit `when` keyword");
         assert!(
             !output.contains("anim :hover"),
             "should NOT emit `anim` keyword"
@@ -1731,7 +1728,11 @@ rect @btn {
         // Round-trip: re-parse emitted output
         let graph2 = parse_document(&output).expect("re-parse of when output failed");
         let node = graph2.get_by_id(NodeId::intern("btn")).unwrap();
-        assert_eq!(node.animations.len(), 1, "animation should survive roundtrip");
+        assert_eq!(
+            node.animations.len(),
+            1,
+            "animation should survive roundtrip"
+        );
         assert_eq!(
             node.animations[0].trigger,
             AnimTrigger::Hover,

--- a/crates/fd-lsp/src/completion.rs
+++ b/crates/fd-lsp/src/completion.rs
@@ -246,7 +246,10 @@ mod tests {
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"rect"));
         assert!(labels.contains(&"group"));
-        assert!(labels.contains(&"theme"), "should suggest `theme` not `style`");
+        assert!(
+            labels.contains(&"theme"),
+            "should suggest `theme` not `style`"
+        );
     }
 
     #[test]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -303,7 +303,7 @@
 
 ### v0.8.15
 
-- **UX**: AI Refine error messages now include an **"Open Settings"** action button — clicking it opens VS Code settings filtered to `fd.ai` for quick API key configuration or provider switching
+- **UX**: AI Assist error messages now include an **"Open Settings"** action button — clicking it opens VS Code settings filtered to `fd.ai` for quick API key configuration or provider switching
 - **UX**: Error messages are now provider-agnostic — each warns which key is missing and reminds users they can switch to any of the 5 supported providers (Gemini, OpenAI, Anthropic, Ollama, OpenRouter)
 
 ### v0.8.14

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -128,7 +128,7 @@ Defaults **reset** on page reload (session only, not saved to `.fd` file).
 | Click 🧘/🔧 toggle (top-right) | Switch between Zen ↔ Full mode          |
 | `L`                            | Toggle Layers panel (works in Zen mode) |
 
-Zen mode hides: Layers, Properties, Minimap, AI Refine, Grid, Export, Theme, Zoom, Help, Status.
+Zen mode hides: Layers, Properties, Minimap, AI Assist, Grid, Export, Theme, Zoom, Help, Status.
 Zen mode keeps: 6 core tools (Select, Rect, Ellipse, Pen, Arrow, Text), Sketchy toggle.
 
 ---

--- a/examples/animations.fd
+++ b/examples/animations.fd
@@ -1,284 +1,244 @@
-# FD v1
-# Animation showcase — demonstrates all trigger types and easing functions
-
-theme card {
-  fill: #FFFFFF
-  corner: 16
-}
-
 # ─── Animation Catalog ────────────────────────────────────────────────────
-
 group @hover_demos {
   layout: column gap=24 pad=32
-
   text @section_hover "Hover Effects" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+    fill: #1A1A2E  # blue
+    font: "Inter" bold 28
   }
-
   group @hover_row {
     layout: row gap=20 pad=0
-
     rect @scale_hover {
       spec "Scale animation"
       w: 140 h: 100
-      fill: #6C5CE7
-      corner: 12
       text @scale_label "Scale" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
+        fill: #FFFFFF  # white
+        font: "Inter" semibold 14
       }
-      when :hover { scale: 1.1; ease: spring 300ms }
-    }
-
-    rect @fade_hover {
-      w: 140 h: 100
-      fill: #00B894
+      fill: #6C5CE7  # blue
       corner: 12
-      text @fade_label "Opacity" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :hover { opacity: 0.6; ease: ease_in_out 200ms }
-    }
-
-    rect @color_hover {
-      w: 140 h: 100
-      fill: #E17055
-      corner: 12
-      text @color_label "Color" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :hover { fill: #D63031; ease: ease_out 250ms }
-    }
-
-    rect @rotate_hover {
-      w: 140 h: 100
-      fill: #FDCB6E
-      corner: 12
-      text @rotate_label "Rotate" {
-        fill: #333333
-        font: "Inter" 600 14
-      }
-      when :hover { rotate: 5; ease: spring 400ms }
     }
   }
-
-  # ── Press / Tap Effects ──
-
-  text @section_press "Press / Tap Effects" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+  rect @fade_hover {
+    w: 140 h: 100
+    text @fade_label "Opacity" {
+      fill: #FFFFFF  # white
+      font: "Inter" semibold 14
+    }
+    fill: #00B894  # teal
+    corner: 12
   }
+}
 
-  group @press_row {
-    layout: row gap=20 pad=0
-
-    rect @squish_press {
-      spec "Press-down squish for tactile feedback"
-      w: 140 h: 100
-      fill: #A29BFE
-      corner: 12
-      text @squish_label "Squish" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :press { scale: 0.88; ease: spring 150ms }
-    }
-
-    rect @dim_press {
-      w: 140 h: 100
-      fill: #74B9FF
-      corner: 12
-      text @dim_label "Dim" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :press { opacity: 0.5; ease: ease_out 100ms }
-    }
-
-    rect @flash_press {
-      w: 140 h: 100
-      fill: #FF6B6B
-      corner: 12
-      text @flash_label "Flash" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :press { fill: #FFFFFF; ease: linear 80ms }
-    }
+rect @color_hover {
+  w: 140 h: 100
+  text @color_label "Color" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 14
   }
+  fill: #E17055  # red
+  corner: 12
+}
 
-  # ── Entrance Animations ──
-
-  text @section_enter "Entrance Animations" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+rect @rotate_hover {
+  w: 140 h: 100
+  text @rotate_label "Rotate" {
+    fill: #333333  # gray
+    font: "Inter" semibold 14
   }
+  fill: #FDCB6E  # orange
+  corner: 12
+}
 
-  group @enter_row {
-    spec {
-      "Triggered when element enters viewport"
-      accept: "plays once on scroll into view"
-      tag: animation, ux
-    }
-    layout: row gap=20 pad=0
+# ── Press / Tap Effects ──
+text @section_press "Press / Tap Effects" {
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
+}
 
-    rect @fade_enter {
-      w: 140 h: 100
-      fill: #6C5CE7
-      corner: 12
-      opacity: 0
-      text @fade_enter_label "Fade In" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :enter { opacity: 1; ease: ease_out 500ms }
+group @press_row {
+  layout: row gap=20 pad=0
+  rect @squish_press {
+    spec "Press-down squish for tactile feedback"
+    w: 140 h: 100
+    text @squish_label "Squish" {
+      fill: #FFFFFF  # white
+      font: "Inter" semibold 14
     }
-
-    rect @scale_enter {
-      w: 140 h: 100
-      fill: #00B894
-      corner: 12
-      opacity: 0
-      text @scale_enter_label "Pop In" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :enter { opacity: 1; scale: 1; ease: spring 600ms }
-    }
-
-    rect @slide_enter {
-      w: 140 h: 100
-      fill: #E17055
-      corner: 12
-      opacity: 0
-      text @slide_enter_label "Slide Up" {
-        fill: #FFFFFF
-        font: "Inter" 600 14
-      }
-      when :enter { opacity: 1; ease: ease_in_out 400ms }
-    }
+    fill: #A29BFE  # blue
+    corner: 12
   }
+}
 
-  # ── Easing Functions ──
-
-  text @section_easing "Easing Functions" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+rect @dim_press {
+  w: 140 h: 100
+  text @dim_label "Dim" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 14
   }
+  fill: #74B9FF  # blue
+  corner: 12
+}
 
-  group @easing_row {
-    layout: row gap=16 pad=0
-
-    rect @ease_linear {
-      w: 120 h: 80
-      fill: #DFE6E9
-      corner: 10
-      text @linear_label "Linear" {
-        fill: #333333
-        font: "Inter" 500 12
-      }
-      when :hover { scale: 1.15; ease: linear 300ms }
-    }
-
-    rect @ease_in {
-      w: 120 h: 80
-      fill: #DFE6E9
-      corner: 10
-      text @in_label "Ease In" {
-        fill: #333333
-        font: "Inter" 500 12
-      }
-      when :hover { scale: 1.15; ease: ease_in 300ms }
-    }
-
-    rect @ease_out {
-      w: 120 h: 80
-      fill: #DFE6E9
-      corner: 10
-      text @out_label "Ease Out" {
-        fill: #333333
-        font: "Inter" 500 12
-      }
-      when :hover { scale: 1.15; ease: ease_out 300ms }
-    }
-
-    rect @ease_in_out {
-      w: 120 h: 80
-      fill: #DFE6E9
-      corner: 10
-      text @inout_label "Ease In/Out" {
-        fill: #333333
-        font: "Inter" 500 12
-      }
-      when :hover { scale: 1.15; ease: ease_in_out 300ms }
-    }
-
-    rect @ease_spring {
-      w: 120 h: 80
-      fill: #DFE6E9
-      corner: 10
-      text @spring_label "Spring" {
-        fill: #333333
-        font: "Inter" 500 12
-      }
-      when :hover { scale: 1.15; ease: spring 300ms }
-    }
+rect @flash_press {
+  w: 140 h: 100
+  text @flash_label "Flash" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 14
   }
+  fill: #FF6B6B  # red
+  corner: 12
+}
 
-  # ── Combined Animations ──
+# ── Entrance Animations ──
+text @section_enter "Entrance Animations" {
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
+}
 
-  text @section_combined "Combined Animations" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+group @enter_row {
+  spec {
+    "Triggered when element enters viewport"
+    accept: "plays once on scroll into view"
+    tag: animation, ux
   }
-
-  group @combined_row {
-    layout: row gap=20 pad=0
-
-    rect @combo_1 {
-      spec "Hover: scale + color + shadow lift"
-      w: 180 h: 120
-      fill: #6C5CE7
-      corner: 16
-      shadow: (0,4,20,#6C5CE740)
-      text @combo1_label "Lift & Glow" {
-        fill: #FFFFFF
-        font: "Inter" 600 15
-      }
-      when :hover { fill: #5A4BD1; scale: 1.06; ease: spring 400ms }
+  layout: row gap=20 pad=0
+  rect @fade_enter {
+    w: 140 h: 100
+    text @fade_enter_label "Fade In" {
+      fill: #FFFFFF  # white
+      font: "Inter" semibold 14
     }
-
-    rect @combo_2 {
-      spec "Press: squish + dim"
-      w: 180 h: 120
-      fill: #00B894
-      corner: 16
-      shadow: (0,4,20,#00B89440)
-      text @combo2_label "Squish & Dim" {
-        fill: #FFFFFF
-        font: "Inter" 600 15
-      }
-      when :hover { scale: 1.04; ease: ease_out 200ms }
-      when :press { opacity: 0.7; scale: 0.92; ease: spring 150ms }
-    }
-
-    rect @combo_3 {
-      spec "Hover + press combo"
-      w: 180 h: 120
-      fill: #FF6B6B
-      corner: 16
-      shadow: (0,4,20,#FF6B6B40)
-      text @combo3_label "Full Feedback" {
-        fill: #FFFFFF
-        font: "Inter" 600 15
-      }
-      when :hover { fill: #E55050; scale: 1.05; ease: spring 300ms }
-      when :press { scale: 0.9; rotate: -2; ease: spring 200ms }
-    }
+    fill: #6C5CE7  # blue
+    corner: 12
+    opacity: 0
   }
+}
+
+rect @scale_enter {
+  w: 140 h: 100
+  text @scale_enter_label "Pop In" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 14
+  }
+  fill: #00B894  # teal
+  corner: 12
+  opacity: 0
+}
+
+rect @slide_enter {
+  w: 140 h: 100
+  text @slide_enter_label "Slide Up" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 14
+  }
+  fill: #E17055  # red
+  corner: 12
+  opacity: 0
+}
+
+# ── Easing Functions ──
+text @section_easing "Easing Functions" {
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
+}
+
+group @easing_row {
+  layout: row gap=16 pad=0
+  rect @ease_linear {
+    w: 120 h: 80
+    text @linear_label "Linear" {
+      fill: #333333  # gray
+      font: "Inter" medium 12
+    }
+    fill: #DFE6E9  # white
+    corner: 10
+  }
+}
+
+rect @ease_in {
+  w: 120 h: 80
+  text @in_label "Ease In" {
+    fill: #333333  # gray
+    font: "Inter" medium 12
+  }
+  fill: #DFE6E9  # white
+  corner: 10
+}
+
+rect @ease_out {
+  w: 120 h: 80
+  text @out_label "Ease Out" {
+    fill: #333333  # gray
+    font: "Inter" medium 12
+  }
+  fill: #DFE6E9  # white
+  corner: 10
+}
+
+rect @ease_in_out {
+  w: 120 h: 80
+  text @inout_label "Ease In/Out" {
+    fill: #333333  # gray
+    font: "Inter" medium 12
+  }
+  fill: #DFE6E9  # white
+  corner: 10
+}
+
+rect @ease_spring {
+  w: 120 h: 80
+  text @spring_label "Spring" {
+    fill: #333333  # gray
+    font: "Inter" medium 12
+  }
+  fill: #DFE6E9  # white
+  corner: 10
+}
+
+# ── Combined Animations ──
+text @section_combined "Combined Animations" {
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
+}
+
+group @combined_row {
+  layout: row gap=20 pad=0
+  rect @combo_1 {
+    spec "Hover: scale + color + shadow lift"
+    w: 180 h: 120
+    text @combo1_label "Lift & Glow" {
+      fill: #FFFFFF  # white
+      font: "Inter" semibold 15
+    }
+    fill: #6C5CE7  # blue
+    corner: 16
+    shadow: (0,4,20,#6C5CE740)
+  }
+}
+
+rect @combo_2 {
+  spec "Press: squish + dim"
+  w: 180 h: 120
+  text @combo2_label "Squish & Dim" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 15
+  }
+  fill: #00B894  # teal
+  corner: 16
+  shadow: (0,4,20,#00B89440)
+}
+
+rect @combo_3 {
+  spec "Hover + press combo"
+  w: 180 h: 120
+  text @combo3_label "Full Feedback" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 15
+    y: -2.01
+  }
+  fill: #FF6B6B  # red
+  corner: 16
+  shadow: (0,4,20,#FF6B6B40)
 }
 
 @hover_demos -> center_in: canvas

--- a/fd-vscode/CHANGELOG.md
+++ b/fd-vscode/CHANGELOG.md
@@ -39,7 +39,7 @@
 - **Apple Pencil Pro modifier+squeeze combos**: `Shift+squeeze` → Pen, `Ctrl+squeeze` → Select, `Alt+squeeze` → Rect, `Ctrl+Shift+squeeze` → Ellipse.
 - **Comment preservation** (`R1.16`): `#` comment lines are now round-tripped through parse and emit, preserving them in the `.fd` file.
 - **Lint diagnostics** (`R4.10`): `lint_document` checks for anonymous IDs, duplicate `use:` references, and unused `style {}` blocks.
-- **AI Refine** (`fd.aiRefine` / `fd.aiRefineAll`): AI-powered node restyling and semantic ID assignment via Gemini, OpenAI, Anthropic, Ollama, or OpenRouter.
+- **AI Assist** (`fd.aiRefine` / `fd.aiRefineAll`): AI-powered node restyling and semantic ID assignment via Gemini, OpenAI, Anthropic, Ollama, or OpenRouter.
 - **Spec View** (`FD: Show Spec View`): displays structured annotations (`## description / status / priority / accept / tag`).
 - **Export Spec** (`FD: Export Spec to Markdown`): generates a markdown requirements report from `##` annotations.
 - **Annotation pins**: interactive badge dots on canvas nodes for viewing/editing annotations inline.

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -173,12 +173,12 @@
       },
       {
         "command": "fd.aiRefine",
-        "title": "FD: AI Refine Selection",
+        "title": "FD: AI Assist Selection",
         "icon": "$(sparkle)"
       },
       {
         "command": "fd.aiRefineAll",
-        "title": "FD: AI Refine All Anonymous Nodes",
+        "title": "FD: AI Assist All",
         "icon": "$(wand)"
       },
       {

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -250,7 +250,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     });
   }
 
-  // ─── AI Refine Handler ─────────────────────────────────────────────
+  // ─── AI Assist Handler ─────────────────────────────────────────────
 
   private async handleAiRefine(
     document: vscode.TextDocument,
@@ -278,7 +278,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
     if (result.error) {
       const action = result.needsSettings ? "Open Settings" : undefined;
       const chosen = await vscode.window.showWarningMessage(
-        `AI Refine: ${result.error}`,
+        `AI Assist: ${result.error}`,
         ...(action ? [action] : [])
       );
       if (chosen === "Open Settings") {
@@ -306,7 +306,7 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
 
     webviewPanel.webview.postMessage({ type: "aiRefineComplete" });
     vscode.window.showInformationMessage(
-      `AI Refine: ${nodeIds.length} node(s) refined.`
+      `AI Assist: ${nodeIds.length} node(s) refined.`
     );
   }
 
@@ -890,13 +890,13 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  // Register AI Refine command (selected nodes via cursor position)
+  // Register AI Assist command (selected nodes via cursor position)
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_AI_REFINE, async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor || editor.document.languageId !== "fd") {
         vscode.window.showInformationMessage(
-          "Open a .fd file first to use AI Refine."
+          "Open a .fd file first to use AI Assist."
         );
         return;
       }
@@ -911,7 +911,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (result.error) {
         const action = result.needsSettings ? "Open Settings" : undefined;
         const chosen = await vscode.window.showWarningMessage(
-          `AI Refine: ${result.error}`,
+          `AI Assist: ${result.error}`,
           ...(action ? [action] : [])
         );
         if (chosen === "Open Settings") {
@@ -931,18 +931,18 @@ export function activate(context: vscode.ExtensionContext) {
       );
       await vscode.workspace.applyEdit(edit);
       vscode.window.showInformationMessage(
-        `AI Refine: ${nodeIds.length} node(s) refined.`
+        `AI Assist: ${nodeIds.length} node(s) refined.`
       );
     })
   );
 
-  // Register AI Refine All command (all _anon_ nodes)
+  // Register AI Assist All command (all _anon_ nodes)
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_AI_REFINE_ALL, async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor || editor.document.languageId !== "fd") {
         vscode.window.showInformationMessage(
-          "Open a .fd file first to use AI Refine All."
+          "Open a .fd file first to use AI Assist All."
         );
         return;
       }
@@ -955,7 +955,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (result.error) {
         const action = result.needsSettings ? "Open Settings" : undefined;
         const chosen = await vscode.window.showWarningMessage(
-          `AI Refine: ${result.error}`,
+          `AI Assist: ${result.error}`,
           ...(action ? [action] : [])
         );
         if (chosen === "Open Settings") {
@@ -975,7 +975,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
       await vscode.workspace.applyEdit(edit);
       vscode.window.showInformationMessage(
-        `AI Refine All: ${nodeIds.length} node(s) refined.`
+        `AI Assist All: ${nodeIds.length} node(s) refined.`
       );
     })
   );

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -1817,8 +1817,8 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <button class="tool-btn" data-tool="text"><span class="tool-icon">T</span>Text<span class="tool-key">T</span></button>
     <button class="tool-btn" data-tool="frame"><span class="tool-icon">⊞</span>Frame<span class="tool-key">F</span></button>
     <div class="tool-sep zen-full-only"></div>
-    <button class="tool-btn zen-full-only" id="ai-refine-btn" title="AI Refine selected node (rename + restyle)">&#x2728; Refine</button>
-    <button class="tool-btn zen-full-only" id="ai-refine-all-btn" title="AI Refine all anonymous nodes">&#x2728; All</button>
+    <button class="tool-btn zen-full-only" id="ai-refine-btn" title="AI Assist selected node (rename + restyle)">&#x2728; Assist</button>
+    <button class="tool-btn zen-full-only" id="ai-refine-all-btn" title="AI Assist all anonymous nodes">&#x2728; All</button>
     <div class="tool-sep zen-full-only"></div>
     <div class="view-toggle zen-full-only" id="view-toggle">
       <button class="view-btn active" id="view-design" title="Design View — full canvas">Design</button>
@@ -1895,8 +1895,8 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <div class="fab-sep"></div>
       <button class="fab-btn" id="fab-more-btn" title="More actions">⋯</button>
       <div id="fab-overflow-menu">
-        <button class="fab-menu-item" data-action="group">⌘G Group</button>
-        <button class="fab-menu-item" data-action="ungroup">⌘⇧G Ungroup</button>
+        <button class="fab-menu-item" data-action="group">⌘G ◻ Group</button>
+        <button class="fab-menu-item" data-action="ungroup">⌘⇧G ◫ Ungroup</button>
         <button class="fab-menu-item" data-action="duplicate">⌘D Duplicate</button>
         <button class="fab-menu-item" data-action="copy-png">⌘⇧C Copy as PNG</button>
         <button class="fab-menu-item" data-action="delete" style="color:#e57373">⌫ Delete</button>
@@ -2028,12 +2028,23 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
   </div>
   <div id="context-menu">
+    <div class="menu-item" id="ctx-ai-refine"><span class="menu-icon">✦</span><span class="menu-label">AI Assist</span></div>
     <div class="menu-item" id="ctx-add-annotation"><span class="menu-icon">◇</span><span class="menu-label">Add Spec</span></div>
-    <div class="menu-item" id="ctx-ai-refine"><span class="menu-icon">✦</span><span class="menu-label">AI Refine</span></div>
+    <div class="menu-separator"></div>
+    <div class="menu-item" id="ctx-cut" data-action="cut"><span class="menu-icon">✂</span><span class="menu-label">Cut</span><span class="menu-shortcut">⌘X</span></div>
+    <div class="menu-item" id="ctx-copy" data-action="copy"><span class="menu-icon">⎘</span><span class="menu-label">Copy</span><span class="menu-shortcut">⌘C</span></div>
+    <div class="menu-item" id="ctx-paste" data-action="paste"><span class="menu-icon">📋</span><span class="menu-label">Paste</span><span class="menu-shortcut">⌘V</span></div>
+    <div class="menu-item" id="ctx-copy-png" data-action="copy-png"><span class="menu-icon">🖼</span><span class="menu-label">Copy as PNG</span><span class="menu-shortcut">⌘⇧C</span></div>
     <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-duplicate" data-action="duplicate"><span class="menu-icon">⊕</span><span class="menu-label">Duplicate</span><span class="menu-shortcut">⌘D</span></div>
-    <div class="menu-item" id="ctx-group" data-action="group"><span class="menu-icon">◫</span><span class="menu-label">Group</span><span class="menu-shortcut">⌘G</span></div>
-    <div class="menu-item" id="ctx-ungroup" data-action="ungroup"><span class="menu-icon">◻</span><span class="menu-label">Ungroup</span><span class="menu-shortcut">⇧⌘G</span></div>
+    <div class="menu-item" id="ctx-group" data-action="group"><span class="menu-icon">◻</span><span class="menu-label">Group</span><span class="menu-shortcut">⌘G</span></div>
+    <div class="menu-item" id="ctx-ungroup" data-action="ungroup"><span class="menu-icon">◫</span><span class="menu-label">Ungroup</span><span class="menu-shortcut">⇧⌘G</span></div>
+    <div class="menu-item" id="ctx-frame" data-action="frame-selection"><span class="menu-icon">⊞</span><span class="menu-label">Frame Selection</span></div>
+    <div class="menu-separator"></div>
+    <div class="menu-item" id="ctx-bring-front" data-action="bring-front"><span class="menu-icon">↑</span><span class="menu-label">Bring to Front</span><span class="menu-shortcut">⌘⇧]</span></div>
+    <div class="menu-item" id="ctx-send-back" data-action="send-back"><span class="menu-icon">↓</span><span class="menu-label">Send to Back</span><span class="menu-shortcut">⌘⇧[</span></div>
+    <div class="menu-item disabled" id="ctx-lock" data-action="lock"><span class="menu-icon">🔒</span><span class="menu-label">Lock</span></div>
+    <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-delete" data-action="delete"><span class="menu-icon">⊖</span><span class="menu-label">Delete</span><span class="menu-shortcut">⌫</span></div>
   </div>
   <div id="anim-picker">
@@ -2048,7 +2059,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     window.vscodeApi = acquireVsCodeApi();
   </script>
   <script nonce="{nonce}">
-    // ─── AI Refine toolbar + context menu handlers ─────────
+    // ─── AI Assist toolbar + context menu handlers ─────────
     (function() {
       const vscodeApi = window.vscodeApi;
       let selectedNodeId = null;
@@ -2067,27 +2078,27 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         if (e.data.type === 'aiRefineComplete') {
           const btn = document.getElementById('ai-refine-btn');
           const allBtn = document.getElementById('ai-refine-all-btn');
-          if (btn) { btn.textContent = '✨ Refine'; btn.disabled = false; }
+          if (btn) { btn.textContent = '✨ Assist'; btn.disabled = false; }
           if (allBtn) { allBtn.disabled = false; }
         }
       });
 
-      // Refine selected node
+      // Assist selected node
       document.getElementById('ai-refine-btn')?.addEventListener('click', () => {
         if (selectedNodeId) {
           vscodeApi.postMessage({ type: 'aiRefine', nodeIds: [selectedNodeId] });
         } else {
-          // No selection — refine all anon nodes
+          // No selection — assist all anon nodes
           vscodeApi.postMessage({ type: 'aiRefineAll' });
         }
       });
 
-      // Refine all anonymous nodes
+      // Assist all anonymous nodes
       document.getElementById('ai-refine-all-btn')?.addEventListener('click', () => {
         vscodeApi.postMessage({ type: 'aiRefineAll' });
       });
 
-      // Context menu: AI Refine
+      // Context menu: AI Assist
       document.getElementById('ctx-ai-refine')?.addEventListener('click', () => {
         if (selectedNodeId) {
           vscodeApi.postMessage({ type: 'aiRefine', nodeIds: [selectedNodeId] });

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -2120,8 +2120,85 @@ function setupContextMenu() {
     closeContextMenu();
   });
 
+  // Cut via context menu
+  document.getElementById("ctx-cut")?.addEventListener("click", () => {
+    if (fdCanvas && contextMenuNodeId) {
+      copySelectedAsFd();
+      const changed = fdCanvas.delete_selected();
+      if (changed) {
+        render();
+        syncTextToExtension();
+      }
+    }
+    closeContextMenu();
+  });
+
+  // Copy via context menu
+  document.getElementById("ctx-copy")?.addEventListener("click", () => {
+    if (fdCanvas) {
+      copySelectedAsFd();
+    }
+    closeContextMenu();
+  });
+
+  // Paste via context menu
+  document.getElementById("ctx-paste")?.addEventListener("click", () => {
+    if (fdCanvas) {
+      pasteFromClipboard();
+    }
+    closeContextMenu();
+  });
+
+  // Copy as PNG via context menu
+  document.getElementById("ctx-copy-png")?.addEventListener("click", () => {
+    if (fdCanvas) {
+      copySelectionAsPng();
+    }
+    closeContextMenu();
+  });
+
+  // Frame Selection via context menu
+  document.getElementById("ctx-frame")?.addEventListener("click", () => {
+    if (fdCanvas && contextMenuNodeId) {
+      // Simulate ⌘+frame by wrapping selected nodes in a frame via handle_key
+      const resultJson = fdCanvas.handle_key("f", false, false, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) {
+        render();
+        syncTextToExtension();
+      }
+    }
+    closeContextMenu();
+  });
+
+  // Bring to Front via context menu
+  document.getElementById("ctx-bring-front")?.addEventListener("click", () => {
+    if (fdCanvas && contextMenuNodeId) {
+      const resultJson = fdCanvas.handle_key("]", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) {
+        render();
+        syncTextToExtension();
+      }
+    }
+    closeContextMenu();
+  });
+
+  // Send to Back via context menu
+  document.getElementById("ctx-send-back")?.addEventListener("click", () => {
+    if (fdCanvas && contextMenuNodeId) {
+      const resultJson = fdCanvas.handle_key("[", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) {
+        render();
+        syncTextToExtension();
+      }
+    }
+    closeContextMenu();
+  });
+
   // Delete via context menu
-  document.getElementById("ctx-delete").addEventListener("click", () => {
+  document.getElementById("ctx-delete")?.addEventListener("click", () => {
     if (fdCanvas && contextMenuNodeId) {
       fdCanvas.select_by_id(contextMenuNodeId);
       const changed = fdCanvas.delete_selected();
@@ -3066,7 +3143,7 @@ function parseAnnotatedNodes(source) {
 // ─── Layers Panel (Tree View) ────────────────────────────────────────────
 
 const LAYER_ICONS = {
-  group: "◫",
+  group: "◻",
   frame: "▣",
   rect: "▢",
   ellipse: "○",
@@ -3262,7 +3339,7 @@ function refreshSpecSummary(panel) {
     html += `<div class="spec-empty-state">`;
     html += `<div style="font-size:24px;margin-bottom:8px;opacity:0.4">◇</div>`;
     html += `<div style="opacity:0.5;font-size:12px">No spec annotations yet</div>`;
-    html += `<div style="opacity:0.35;font-size:11px;margin-top:4px">Right-click a node → Add Annotation, or press ⌘I</div>`;
+    html += `<div style="opacity:0.35;font-size:11px;margin-top:4px">Right-click a node → Add Spec, or press ⌘I</div>`;
     html += `</div>`;
     panel.innerHTML = html;
     return;


### PR DESCRIPTION
## Summary

Enhanced canvas context menu to match industry standards (Figma, Excalidraw, Freeform).

### Changes
- **AI Refine → AI Assist**: Renamed all user-facing labels (toolbar, context menu, messages, command titles, docs). Internal API/function names unchanged.
- **Expanded context menu**: 7 → 16 items. Added: Cut (⌘X), Copy (⌘C), Paste (⌘V), Copy as PNG (⌘⇧C), Frame Selection, Bring to Front (⌘⇧]), Send to Back (⌘⇧[), Lock (disabled placeholder)
- **Icon swap**: Group icon = ◻ (unified shape), Ungroup icon = ◫ (fragmented shape) — more intuitive visual metaphor
- **Reordered**: AI Assist moved above Add Spec for discoverability
- **Empty state text**: "Add Annotation" → "Add Spec"
- **Synced** all changes to Zed extension copies

### Files changed
11 files across fd-vscode, zed-extensions, and docs

### Testing
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace` (17/17)
- ✅ `cargo fmt --all -- --check`
- ✅ `pnpm test` (fd-vscode)