### PR TITLE
feat(R3.14): spec badge toggle, faint/active visibility, context menu View/Remove Spec

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.64 — Spec Badge Improvements
+
+- **UX (R3.14)**: Spec badge toggle button (◇) in toolbar — show/hide annotation badges on canvas independently of Spec View mode; state persists via webview state
+- **UX (R3.14)**: Spec badges use faint/active visibility pattern — unselected nodes show badges at 25% opacity, selected node's badge is bright and scaled; reduces visual clutter while preserving coverage overview
+- **UX (R3.14)**: Context menu adapts to spec state — nodes without specs show "Add Spec"; nodes with specs show "View Spec" (opens annotation card) and "Remove Spec" (deletes spec block from source)
+- **UX**: Badge positioning now accounts for zoom level — badges stay pinned to node corners at all zoom levels
+
 ### v0.8.62 — Sort Fix + LSP Theme/When + Tree-sitter Regen
 
 - **FIX (R4.10)**: Fixed `sort_nodes` which was a silent no-op — `children()` sorts by `NodeIndex` (insertion order) making edge remove/re-add ineffective. Added `sorted_child_order` field to `SceneGraph` for clean override

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -62,7 +62,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 - **R3.6** _(done)_: Pan (Space+drag, middle-click, ⌘-hold), zoom (see R3.20), grid (see R3.21)
 - **R3.13** _(done)_: Light/dark theme toggle — toolbar button, preference persists via VS Code state
-- **R3.14** _(done)_: Design | Spec view toggle — segmented control; Spec View shows annotations overlay
+- **R3.14** _(done)_: Design | Spec view toggle — segmented control; Spec View shows annotations overlay; spec badge toggle button (◇) for persistent badge visibility in Design mode; context menu shows View Spec / Remove Spec for annotated nodes; badges use faint/active states based on selection
 - **R3.20** _(done)_: Zoom — ⌘+/⌘−, ⌘0 zoom-to-fit, pinch-to-zoom; zoom indicator in toolbar
 - **R3.21** _(done)_: Grid overlay — toggleable dot/line grid with adaptive spacing; keyboard shortcut `G`
 - **R3.25** _(done)_: Minimap — thumbnail in bottom-right with draggable viewport rectangle (Figma/Miro-style)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -615,11 +615,24 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       font-weight: 700;
       font-family: inherit;
       box-shadow: 0 2px 8px rgba(0, 122, 255, 0.35);
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
       z-index: 9;
     }
     .spec-badge-pin:hover {
       transform: scale(1.18);
+      box-shadow: 0 3px 12px rgba(0, 122, 255, 0.5);
+    }
+    .spec-badge-pin.faint {
+      opacity: 0.25;
+      transform: scale(0.8);
+    }
+    .spec-badge-pin.faint:hover {
+      opacity: 0.6;
+      transform: scale(1.0);
+    }
+    .spec-badge-pin.active {
+      opacity: 1;
+      transform: scale(1.1);
       box-shadow: 0 3px 12px rgba(0, 122, 255, 0.5);
     }
     .spec-badge-count {
@@ -970,6 +983,17 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       justify-content: center;
     }
     #grid-toggle-btn.grid-on {
+      color: var(--fd-accent);
+      background: var(--fd-accent-dim);
+    }
+
+    /* ── Spec Badge Toggle Button ── */
+    #spec-badge-toggle-btn {
+      font-size: 13px;
+      min-width: 32px;
+      justify-content: center;
+    }
+    #spec-badge-toggle-btn.spec-on {
       color: var(--fd-accent);
       background: var(--fd-accent-dim);
     }
@@ -1826,6 +1850,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
     <div class="tool-sep zen-full-only"></div>
     <button class="tool-btn zen-full-only" id="grid-toggle-btn" title="Toggle grid overlay (G)">⊞</button>
+    <button class="tool-btn zen-full-only" id="spec-badge-toggle-btn" title="Toggle spec badges on canvas">◇</button>
 
     <!-- Export Dropdown -->
     <div class="export-dropdown-container zen-full-only" id="export-dropdown-container">
@@ -2030,6 +2055,8 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <div id="context-menu">
     <div class="menu-item" id="ctx-ai-refine"><span class="menu-icon">✦</span><span class="menu-label">AI Assist</span></div>
     <div class="menu-item" id="ctx-add-annotation"><span class="menu-icon">◇</span><span class="menu-label">Add Spec</span></div>
+    <div class="menu-item" id="ctx-view-spec" style="display:none"><span class="menu-icon">◈</span><span class="menu-label">View Spec</span><span class="menu-shortcut">⌘I</span></div>
+    <div class="menu-item" id="ctx-remove-spec" style="display:none"><span class="menu-icon">◇</span><span class="menu-label">Remove Spec</span></div>
     <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-cut" data-action="cut"><span class="menu-icon">✂</span><span class="menu-label">Cut</span><span class="menu-shortcut">⌘X</span></div>
     <div class="menu-item" id="ctx-copy" data-action="copy"><span class="menu-icon">⎘</span><span class="menu-label">Copy</span><span class="menu-shortcut">⌘C</span></div>


### PR DESCRIPTION
## Spec Badge Improvements (R3.14)

- **◇ Toolbar toggle** — show/hide spec badges on canvas independently of Spec View mode; state persists
- **Faint/Active visibility** — unselected nodes show badges at 25% opacity, selected node's badge glows bright and scales up
- **Context menu** — adapts to spec state: "Add Spec" for clean nodes, "View Spec" + "Remove Spec" for annotated nodes
- **Zoom-aware** — badges stay pinned to node corners at all zoom levels

### Tests
- 166 TS tests passing
- 236 Rust tests passing
- `cargo clippy` clean