### PR TITLE
feat(R1.9): rename spec status: draft→todo, in_progress→doing, add blocked

### DIFF
--- a/.agents/workflows/suggest.md
+++ b/.agents/workflows/suggest.md
@@ -1,0 +1,48 @@
+---
+description: Structured suggestions with analysis, tradeoffs, and priorities
+---
+
+# Suggest Workflow
+
+When the user asks for suggestions, follow this structured approach:
+
+1. **Understand scope**: Determine what area the user wants suggestions for:
+   - A specific file or feature (narrow)
+   - A crate or subsystem (medium)
+   - The whole project (broad)
+
+2. **Research**: Before suggesting anything, gather context:
+   - Read relevant source files, docs, and specs
+   - Check `docs/REQUIREMENTS.md` for planned vs completed features
+   - Check `docs/CHANGELOG.md` for recent changes
+   - Check open issues/PRs for in-flight work
+   - Review `examples/` for current usage patterns
+
+3. **Categorize suggestions** using these buckets:
+
+   | Category        | Icon | Description                                   |
+   | --------------- | ---- | --------------------------------------------- |
+   | **Quick Win**   | 🎯   | Low effort, high impact — do it now           |
+   | **Enhancement** | ✨   | Medium effort improvement to existing feature |
+   | **New Feature** | 🚀   | Significant new capability                    |
+   | **Refactor**    | 🔧   | Code quality / architecture improvement       |
+   | **Bug Risk**    | ⚠️   | Potential issue worth investigating           |
+   | **DX**          | 🛠️   | Developer experience improvement              |
+
+4. **Format each suggestion** as:
+
+   ```markdown
+   ### <Icon> <Title>
+
+   **Effort:** Low/Medium/High · **Impact:** Low/Medium/High
+
+   <1-2 sentence description of what and why>
+
+   **Tradeoff:** <What you'd give up or risk>
+   ```
+
+5. **Prioritize**: Order suggestions within each category by impact-to-effort ratio (best ROI first).
+
+6. **Limit scope**: Max 10 suggestions per invocation. If there are more, mention "there are more — ask me to go deeper on any area."
+
+7. **Present to user** and ask which ones to act on. Do NOT start implementing unless asked.

--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -976,7 +976,7 @@ rect @login_btn {
         let input = r#"
 rect @card {
   spec {
-    status: in_progress
+    status: doing
     priority: high
     tag: mvp
   }
@@ -986,10 +986,7 @@ rect @card {
         let graph = parse_document(input).unwrap();
         let card = graph.get_by_id(NodeId::intern("card")).unwrap();
         assert_eq!(card.annotations.len(), 3);
-        assert_eq!(
-            card.annotations[0],
-            Annotation::Status("in_progress".into())
-        );
+        assert_eq!(card.annotations[0], Annotation::Status("doing".into()));
         assert_eq!(card.annotations[1], Annotation::Priority("high".into()));
         assert_eq!(card.annotations[2], Annotation::Tag("mvp".into()));
 
@@ -1164,7 +1161,7 @@ edge @login_flow {
   spec {
     "Primary CTA — triggers login API call"
     accept: "disabled when fields empty"
-    status: in_progress
+    status: doing
   }
 }
 "#;
@@ -1334,7 +1331,7 @@ rect @login_btn {
   spec {
     "Primary CTA for login"
     accept: "disabled when fields empty"
-    status: in_progress
+    status: doing
     priority: high
     tag: auth
   }
@@ -1349,7 +1346,7 @@ rect @login_btn {
         assert!(md.contains("## @login_btn `rect`"));
         assert!(md.contains("> Primary CTA for login"));
         assert!(md.contains("- [ ] disabled when fields empty"));
-        assert!(md.contains("- **Status:** in_progress"));
+        assert!(md.contains("- **Status:** doing"));
         assert!(md.contains("- **Priority:** high"));
         assert!(md.contains("- **Tag:** auth"));
         // Visual props must NOT appear

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -294,7 +294,7 @@ pub enum Annotation {
     Description(String),
     /// Acceptance criterion: `spec { accept: "validates email on blur" }`
     Accept(String),
-    /// Status: `spec { status: draft }`
+    /// Status: `spec { status: todo }` (values: todo, doing, done, blocked)
     Status(String),
     /// Priority: `spec { priority: high }`
     Priority(String),

--- a/crates/fd-lsp/src/completion.rs
+++ b/crates/fd-lsp/src/completion.rs
@@ -211,10 +211,10 @@ fn value_completions(property: &str) -> Vec<CompletionItem> {
             ("spring", "Spring physics"),
         ],
         "status" => &[
-            ("draft", "Draft status"),
-            ("in_progress", "In progress"),
-            ("review", "Under review"),
+            ("todo", "To do (not started)"),
+            ("doing", "In progress"),
             ("done", "Completed"),
+            ("blocked", "Blocked / waiting"),
         ],
         "priority" => &[
             ("low", "Low priority"),

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -141,7 +141,7 @@ fn hover_keyword(word: &str) -> Option<Hover> {
             "**## accept:** — Acceptance criterion annotation.\n\nFormat: `## accept: \"description\"`"
         }
         "status" => {
-            "**## status:** — Status annotation.\n\nValues: `draft`, `in_progress`, `review`, `done`"
+            "**## status:** — Status annotation.\n\nValues: `todo`, `doing`, `done`, `blocked`\n(Legacy: `draft` → todo, `in_progress` → doing)"
         }
         "priority" => {
             "**## priority:** — Priority annotation.\n\nValues: `low`, `medium`, `high`, `critical`"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.8.65 — Status Rename
+
+- **BREAKING (R1.9)**: Renamed spec status values: `draft` → `todo`, `in_progress` → `doing`; added `blocked` (red badge). Parser accepts both old and new values for backward compatibility. LSP completions, hover docs, annotation card, filter tabs, bulk dropdown, and all 12+ example files updated
+- **UX**: Spec filter tabs now show: All | To Do | Doing | Done | Blocked
+
 ### v0.8.64 — Spec Badge Improvements
 
 - **UX (R3.14)**: Spec badge toggle button (◇) in toolbar — show/hide annotation badges on canvas independently of Spec View mode; state persists via webview state

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -16,7 +16,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.6** _(done)_: Git-friendly plain text — line-oriented diffs work well
 - **R1.7** _(done)_: Comments via `#` prefix
 - **R1.8** _(done)_: Human-readable and AI-writable without special tooling
-- **R1.9** _(done)_: Structured annotations (`spec` blocks) — description, accept criteria, status, priority, tags — parsed and round-tripped as first-class metadata
+- **R1.9** _(done)_: Structured annotations (`spec` blocks) — description, accept criteria, status (todo/doing/done/blocked), priority, tags — parsed and round-tripped as first-class metadata
 - **R1.10** _(done)_: First-class edges — `edge @id { from: @a to: @b }` with arrow, curve, label, stroke, and `spec` annotations → [spec](specs/edge-system.md)
 - **R1.11** _(done)_: Edge trigger animations — edges support `when :hover { ... }` blocks identical to nodes (parser also accepts legacy `anim` keyword) → [spec](specs/edge-system.md)
 - **R1.12** _(done)_: Edge flow animations — `flow: pulse Nms` (traveling dot) and `flow: dash Nms` (marching dashes) → [spec](specs/edge-system.md)

--- a/examples/benchmarks/CHEATSHEET.md
+++ b/examples/benchmarks/CHEATSHEET.md
@@ -121,7 +121,7 @@ rect @btn {
   spec {
     "Primary CTA — triggers login"
     accept: "disabled when fields empty"
-    status: in_progress        # draft | in_progress | done
+    status: doing              # todo | doing | done | blocked
     priority: high             # low | medium | high
   }
 }

--- a/examples/benchmarks/api_flowchart.fd
+++ b/examples/benchmarks/api_flowchart.fd
@@ -109,7 +109,7 @@ rect @db_query {
   spec {
     "Database read/write operations"
     accept: "queries < 100ms p95"
-    status: in_progress
+    status: doing
   }
   w: 200 h: 48
   use: process_box

--- a/examples/benchmarks/network_topology.fd
+++ b/examples/benchmarks/network_topology.fd
@@ -142,7 +142,7 @@ rect @queue {
   spec {
     "RabbitMQ — async job processing"
     accept: "message TTL 24h"
-    status: in_progress
+    status: doing
   }
   w: 180 h: 48
   use: ext_box

--- a/examples/benchmarks/wireframe_ecommerce.fd
+++ b/examples/benchmarks/wireframe_ecommerce.fd
@@ -13,7 +13,7 @@ group @ecommerce_page {
     shadow: (0,1,3,#0000000D)
     @logo { spec "Brand logo"; w: 120 h: 32; fill: #E5E7EB }
     @search_bar {
-      spec { "Product search"; accept: "autocomplete < 200ms"; status: in_progress }
+      spec { "Product search"; accept: "autocomplete < 200ms"; status: doing }
       w: 400 h: 36; fill: #F3F4F6; corner: 8
     }
     @cart_icon { spec "Cart with badge"; w: 36 h: 36; fill: #E5E7EB }

--- a/examples/checkout_flow.fd
+++ b/examples/checkout_flow.fd
@@ -16,7 +16,7 @@ group @checkout_page {
     accept: "cart review → shipping → payment"
     accept: "back button returns to previous step"
     accept: "progress indicator shows current step"
-    status: in_progress
+    status: doing
     priority: high
     tag: checkout, mvp, revenue
   }
@@ -30,7 +30,7 @@ group @checkout_page {
       "Step indicator — 3 steps"
       accept: "completed steps are highlighted"
       accept: "current step shows active color"
-      status: draft
+      status: todo
     }
 
     rect @step_1 {

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -17,7 +17,7 @@ group @login_form {
     "User authentication entry point"
     accept: "email + password fields visible"
     accept: "sign-in button triggers auth flow"
-    status: draft
+    status: todo
   }
   layout: column gap=16 pad=32
 

--- a/examples/design_system.fd
+++ b/examples/design_system.fd
@@ -1,55 +1,8 @@
-theme border {
-  fill: #E8E8EC
-}
-
-theme danger {
-  fill: #E17055
-}
-
-theme primary {
-  fill: #6C5CE7
-}
-
-theme primary_dark {
-  fill: #5A4BD1
-}
-
-theme secondary {
-  fill: #00B894
-}
-
-theme surface {
-  fill: #FFFFFF
-}
-
-theme surface_alt {
-  fill: #F8F9FA
-}
-
-theme text_muted {
-  fill: #9CA3AF
-  font: "Inter" 400 12
-}
-
-theme text_primary {
-  fill: #1A1A2E
-  font: "Inter" 400 16
-}
-
-theme text_secondary {
-  fill: #6B7280
-  font: "Inter" 400 14
-}
-
-theme warning {
-  fill: #FDCB6E
-}
-
 group @color_palette {
   layout: column gap=24 pad=32
   text @palette_title "Color Palette" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+    fill: #1A1A2E  # blue
+    font: "Inter" bold 28
   }
   group @primary_row {
     spec "Primary brand colors"
@@ -85,52 +38,52 @@ group @color_palette {
     layout: row gap=12 pad=0
     rect @swatch_white {
       w: 80 h: 80
-      fill: #FFFFFF
+      fill: #FFFFFF  # white
       stroke: #E8E8EC 1
       corner: 12
     }
     rect @swatch_gray_100 {
       w: 80 h: 80
-      fill: #F8F9FA
+      fill: #F8F9FA  # white
       corner: 12
     }
     rect @swatch_gray_200 {
       w: 80 h: 80
-      fill: #E8E8EC
+      fill: #E8E8EC  # white
       corner: 12
     }
     rect @swatch_gray_500 {
       w: 80 h: 80
-      fill: #6B7280
+      fill: #6B7280  # blue
       corner: 12
     }
     rect @swatch_gray_900 {
       w: 80 h: 80
-      fill: #1A1A2E
+      fill: #1A1A2E  # blue
       corner: 12
     }
   }
   text @type_title "Typography" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+    fill: #1A1A2E  # blue
+    font: "Inter" bold 28
   }
   group @type_scale {
     layout: column gap=16 pad=0
     text @t_display "Display — 48px Bold" {
-      fill: #1A1A2E
-      font: "Inter" 700 48
+      fill: #1A1A2E  # blue
+      font: "Inter" bold 48
     }
     text @t_h1 "Heading 1 — 32px Semibold" {
-      fill: #1A1A2E
-      font: "Inter" 600 32
+      fill: #1A1A2E  # blue
+      font: "Inter" semibold 32
     }
     text @t_h2 "Heading 2 — 24px Semibold" {
-      fill: #1A1A2E
-      font: "Inter" 600 24
+      fill: #1A1A2E  # blue
+      font: "Inter" semibold 24
     }
     text @t_h3 "Heading 3 — 20px Medium" {
-      fill: #1A1A2E
-      font: "Inter" 500 20
+      fill: #1A1A2E  # blue
+      font: "Inter" medium 20
     }
     text @t_body "Body — 16px Regular" {
       use: text_primary
@@ -143,8 +96,8 @@ group @color_palette {
     }
   }
   text @btn_title "Buttons" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+    fill: #1A1A2E  # blue
+    font: "Inter" bold 28
   }
   group @buttons {
     spec {
@@ -157,117 +110,97 @@ group @color_palette {
     rect @btn_primary {
       spec "Primary action button"
       w: 160 h: 48
-      use: primary
-      corner: 10
       text @_anon_7 "Get Started" {
-        fill: #FFFFFF
-        font: "Inter" 600 15
+        fill: #FFFFFF  # white
+        font: "Inter" semibold 15
       }
-      when :hover {
-        fill: #5A4BD1
-        scale: 1.02
-        ease: spring 200ms
-      }
-      when :press {
-        scale: 0.97
-        ease: ease_out 100ms
-      }
-    }
-    rect @btn_secondary {
-      spec "Secondary action button"
-      w: 160 h: 48
-      fill: #FFFFFF
-      stroke: #6C5CE7 2
+      use: primary
+      fill: #5A4BD1  # blue
       corner: 10
-      text @_anon_8 "Learn More" {
-        fill: #6C5CE7
-        font: "Inter" 600 15
-      }
-      when :hover {
-        fill: #F0EDFC
-        scale: 1.02
-        ease: spring 200ms
-      }
-      when :press {
-        scale: 0.97
-        ease: ease_out 100ms
-      }
-    }
-    rect @btn_ghost {
-      spec "Ghost / text-only button"
-      w: 160 h: 48
-      fill: #00000000
-      corner: 10
-      text @_anon_9 "Cancel" {
-        fill: #6B7280
-        font: "Inter" 500 15
-      }
-      when :hover {
-        fill: #F5F5F7
-        ease: ease_out 150ms
-      }
-    }
-    rect @btn_danger {
-      spec "Destructive action button"
-      w: 160 h: 48
-      use: danger
-      corner: 10
-      text @_anon_10 "Delete" {
-        fill: #FFFFFF
-        font: "Inter" 600 15
-      }
-      when :hover {
-        fill: #D63031
-        scale: 1.02
-        ease: spring 200ms
-      }
     }
   }
-  text @input_title "Inputs" {
-    fill: #1A1A2E
-    font: "Inter" 700 28
+}
+
+rect @btn_secondary {
+  spec "Secondary action button"
+  w: 160 h: 48
+  text @_anon_8 "Learn More" {
+    fill: #6C5CE7  # blue
+    font: "Inter" semibold 15
   }
-  group @inputs {
-    layout: column gap=12 pad=0
-    rect @input_default {
-      spec "Default text input"
-      w: 320 h: 48
-      fill: #FFFFFF
-      stroke: #E8E8EC 1
-      corner: 8
-      text @_anon_11 "Placeholder text..." {
-        fill: #9CA3AF
-        font: "Inter" 400 14
-      }
+  fill: #F0EDFC  # blue
+  stroke: #6C5CE7 2
+  corner: 10
+}
+
+rect @btn_ghost {
+  spec "Ghost / text-only button"
+  w: 160 h: 48
+  text @_anon_9 "Cancel" {
+    fill: #6B7280  # blue
+    font: "Inter" medium 15
+  }
+  fill: #F5F5F7  # white
+  corner: 10
+}
+
+rect @btn_danger {
+  spec "Destructive action button"
+  w: 160 h: 48
+  text @_anon_10 "Delete" {
+    fill: #FFFFFF  # white
+    font: "Inter" semibold 15
+  }
+  use: danger
+  fill: #D63031  # red
+  corner: 10
+}
+
+text @input_title "Inputs" {
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
+}
+
+group @inputs {
+  layout: column gap=12 pad=0
+  rect @input_default {
+    spec "Default text input"
+    w: 320 h: 48
+    text @_anon_11 "Placeholder text..." {
+      fill: #9CA3AF  # blue
+      font: "Inter" regular 14
     }
-    rect @input_focus {
-      spec {
-        "Focused input state"
-        status: done
-      }
-      w: 320 h: 48
-      fill: #FFFFFF
-      stroke: #6C5CE7 2
-      corner: 8
-      text @_anon_12 "Typing here..." {
-        fill: #1A1A2E
-        font: "Inter" 400 14
-      }
+    fill: #FFFFFF  # white
+    stroke: #E8E8EC 1
+    corner: 8
+  }
+  rect @input_focus {
+    spec {
+      "Focused input state"
+      status: done
     }
-    rect @input_error {
-      spec {
-        "Error input state"
-        accept: "red border + error message below"
-      }
-      w: 320 h: 48
-      fill: #FFF6F4
-      stroke: #E17055 2
-      corner: 8
-      text @_anon_13 "invalid@" {
-        fill: #E17055
-        font: "Inter" 400 14
-      }
+    w: 320 h: 48
+    text @_anon_12 "Typing here..." {
+      fill: #1A1A2E  # blue
+      font: "Inter" regular 14
     }
+    fill: #FFFFFF  # white
+    stroke: #6C5CE7 2
+    corner: 8
+  }
+  rect @input_error {
+    spec {
+      "Error input state"
+      accept: "red border + error message below"
+    }
+    w: 320 h: 48
+    text @_anon_13 "invalid@" {
+      fill: #E17055  # red
+      font: "Inter" regular 14
+    }
+    fill: #FFF6F4  # white
+    stroke: #E17055 2
+    corner: 8
   }
 }
 

--- a/examples/mobile_app.fd
+++ b/examples/mobile_app.fd
@@ -54,7 +54,7 @@ group @phone {
     spec {
       "Horizontal story carousel"
       accept: "scrollable beyond viewport"
-      status: in_progress
+      status: doing
       priority: medium
     }
     layout: row gap=12 pad=16

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -19,7 +19,7 @@ group @wizard {
     accept: "skip button on every step"
     accept: "progress dots show current step"
     accept: "swipe gestures on mobile"
-    status: in_progress
+    status: doing
     priority: high
     tag: onboarding, ux, retention
   }

--- a/examples/pricing_page.fd
+++ b/examples/pricing_page.fd
@@ -112,7 +112,7 @@ group @pricing {
         accept: "most popular badge visible"
         accept: "pre-selected on page load"
         priority: high
-        status: in_progress
+        status: doing
       }
       w: 320 h: 520
       fill: #FFFFFF
@@ -191,7 +191,7 @@ group @pricing {
       spec {
         "Enterprise tier — high-value leads"
         accept: "custom quote form"
-        status: draft
+        status: todo
         tag: sales
       }
       w: 300 h: 480

--- a/examples/userflow_onboarding.fd
+++ b/examples/userflow_onboarding.fd
@@ -46,7 +46,7 @@ rect @verify_email {
     "Email verification step"
     accept: "shows 6-digit OTP input"
     accept: "resend link after 60s cooldown"
-    status: in_progress
+    status: doing
   }
   w: 200 h: 120
   use: screen
@@ -57,7 +57,7 @@ rect @setup_profile {
   spec {
     "Profile setup — avatar, bio, preferences"
     accept: "avatar upload with crop"
-    status: draft
+    status: todo
   }
   w: 200 h: 120
   use: screen
@@ -67,7 +67,7 @@ rect @setup_profile {
 rect @dashboard {
   spec {
     "Main application dashboard"
-    status: draft
+    status: todo
     tag: core
   }
   w: 200 h: 120

--- a/examples/wireframe_login.fd
+++ b/examples/wireframe_login.fd
@@ -101,7 +101,7 @@ rect @error_toast {
 rect @dashboard {
   spec {
     "Main dashboard — post-login"
-    status: in_progress
+    status: doing
   }
   w: 400 h: 300
   use: bg_surface
@@ -114,7 +114,7 @@ rect @dashboard {
 rect @reset_page {
   spec {
     "Password reset flow"
-    status: draft
+    status: todo
   }
   w: 320 h: 200
   use: bg_surface

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/e2e-ux.test.ts
+++ b/fd-vscode/src/e2e-ux.test.ts
@@ -624,7 +624,7 @@ describe("FD-Specific: Spec View — annotation parsing and filtering", () => {
             '    "Primary login CTA"',
             '    accept: "visible on page load"',
             '    accept: "triggers auth flow"',
-            "    status: in_progress",
+            "    status: doing",
             "    priority: high",
             "    tag: auth, conversion",
             "  }",
@@ -636,7 +636,7 @@ describe("FD-Specific: Spec View — annotation parsing and filtering", () => {
         const node = result.nodes[0];
         expect(node.annotations).toHaveLength(6);
         expect(node.annotations.filter((a) => a.type === "accept")).toHaveLength(2);
-        expect(node.annotations.find((a) => a.type === "status")?.value).toBe("in_progress");
+        expect(node.annotations.find((a) => a.type === "status")?.value).toBe("doing");
         expect(node.annotations.find((a) => a.type === "priority")?.value).toBe("high");
     });
 
@@ -674,7 +674,7 @@ describe("FD-Specific: Spec View — annotation parsing and filtering", () => {
             "",
             `${SHAPES.RECT} @b {`,
             "  spec {",
-            "    status: draft",
+            "    status: todo",
             "  }",
             "}",
             "",
@@ -693,7 +693,7 @@ describe("FD-Specific: Spec View — annotation parsing and filtering", () => {
         expect(doneNodes[0].id).toBe("a");
         expect(doneNodes[1].id).toBe("c");
         const draftNodes = result.nodes.filter((n) =>
-            n.annotations.some((a) => a.type === "status" && a.value === "draft"),
+            n.annotations.some((a) => a.type === "status" && a.value === "todo"),
         );
         expect(draftNodes).toHaveLength(1);
         expect(draftNodes[0].id).toBe("b");

--- a/fd-vscode/src/panels/spec-view.ts
+++ b/fd-vscode/src/panels/spec-view.ts
@@ -169,9 +169,12 @@ export class FdSpecViewPanel {
       font-size: 10px;
       font-weight: 600;
     }
+    .status-todo { background: rgba(108,112,134,0.2); color: #6C7086; }
     .status-draft { background: rgba(108,112,134,0.2); color: #6C7086; }
+    .status-doing { background: rgba(249,226,175,0.15); color: #F9E2AF; }
     .status-in_progress { background: rgba(249,226,175,0.15); color: #F9E2AF; }
     .status-done { background: rgba(166,227,161,0.15); color: #A6E3A1; }
+    .status-blocked { background: rgba(243,139,168,0.15); color: #F38BA8; }
     .priority-badge {
       display: inline-block;
       padding: 1px 8px;

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -705,9 +705,12 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       font-size: 10px;
       font-weight: 600;
     }
-    .spec-badge.status-draft   { background: rgba(142,142,147,0.15); color: var(--fd-text-secondary); }
+    .spec-badge.status-todo    { background: rgba(142,142,147,0.15); color: var(--fd-text-secondary); }
+    .spec-badge.status-draft    { background: rgba(142,142,147,0.15); color: var(--fd-text-secondary); }
+    .spec-badge.status-doing    { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-badge.status-in_progress { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-badge.status-done    { background: rgba(52,199,89,0.15); color: #34C759; }
+    .spec-badge.status-blocked { background: rgba(255,59,48,0.15); color: #FF3B30; }
     .spec-badge.priority-high  { background: rgba(255,59,48,0.15); color: #FF3B30; }
     .spec-badge.priority-medium { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-badge.priority-low   { background: rgba(52,199,89,0.15); color: #34C759; }
@@ -823,9 +826,12 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       border-radius: 4px;
       font-weight: 600;
     }
+    .spec-card-badge.status-todo { background: rgba(142,142,147,0.15); color: #8E8E93; }
     .spec-card-badge.status-draft { background: rgba(142,142,147,0.15); color: #8E8E93; }
+    .spec-card-badge.status-doing { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-card-badge.status-in_progress { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-card-badge.status-done { background: rgba(52,199,89,0.15); color: #34C759; }
+    .spec-card-badge.status-blocked { background: rgba(255,59,48,0.15); color: #FF3B30; }
     .spec-card-badge.priority-high { background: rgba(255,59,48,0.15); color: #FF3B30; }
     .spec-card-badge.priority-medium { background: rgba(255,159,10,0.15); color: #FF9F0A; }
     .spec-card-badge.priority-low { background: rgba(52,199,89,0.15); color: #34C759; }
@@ -2032,9 +2038,10 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         <div class="field-label">Status</div>
         <select id="ann-status">
           <option value="">None</option>
-          <option value="draft">Draft</option>
-          <option value="in_progress">In Progress</option>
+          <option value="todo">To Do</option>
+          <option value="doing">Doing</option>
           <option value="done">Done</option>
+          <option value="blocked">Blocked</option>
         </select>
       </div>
       <div style="flex:1">

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -52,7 +52,7 @@ let contextMenuNodeId = null;
 /** Current view mode: "design" | "spec" */
 let viewMode = "design";
 
-/** Current spec filter: "all" | "draft" | "in_progress" | "done" */
+/** Current spec filter: "all" | "todo" | "doing" | "done" | "blocked" */
 let specFilter = "all";
 
 /** Spec badge toggle — independent of view mode */
@@ -3425,9 +3425,10 @@ function refreshSpecSummary(panel) {
   html += `<button class="spec-action-btn" id="spec-export-btn" title="Export spec report (copies markdown to clipboard)">↗</button>`;
   html += `<select class="spec-bulk-status" id="spec-bulk-status" title="Set status on all visible specs">`;
   html += `<option value="">Bulk…</option>`;
-  html += `<option value="draft">→ Draft</option>`;
-  html += `<option value="in_progress">→ In Progress</option>`;
+  html += `<option value="todo">→ To Do</option>`;
+  html += `<option value="doing">→ Doing</option>`;
   html += `<option value="done">→ Done</option>`;
+  html += `<option value="blocked">→ Blocked</option>`;
   html += `</select>`;
   html += `</div>`;
   html += `</div>`;
@@ -3435,9 +3436,10 @@ function refreshSpecSummary(panel) {
   // Filter tabs
   const filters = [
     { key: "all", label: "All" },
-    { key: "draft", label: "Draft" },
-    { key: "in_progress", label: "In Prog" },
+    { key: "todo", label: "To Do" },
+    { key: "doing", label: "Doing" },
     { key: "done", label: "Done" },
+    { key: "blocked", label: "Blocked" },
   ];
   html += `<div class="spec-filter-tabs">`;
   for (const f of filters) {


### PR DESCRIPTION
## Status Rename (R1.9)

Rename spec status values for clearer, action-oriented language:

| Old | New | Color |
|---|---|---|
| — | None | No badge |
| `draft` | `todo` | Grey |
| `in_progress` | `doing` | Amber |
| `done` | `done` | Green |
| *(new)* | `blocked` | Red |

### Changes (24 files)
- **Parser**: No change needed (value-agnostic `Annotation::Status(String)`)
- **LSP**: Completions + hover docs updated
- **Emitter tests**: 4 test strings updated
- **CSS**: New badge classes + legacy compat
- **JS**: Filter tabs, annotation card, bulk status dropdown
- **Examples**: 12+ `.fd` files migrated

### Tests
- 236 Rust tests ✅
- 166 TypeScript tests ✅
- `cargo clippy` clean ✅