### PR TITLE
feat(vscode): toolbar consolidation — insert dropdown, zen icon-only, remove palette & overflow

### DIFF
--- a/.agents/workflows/suggest.md
+++ b/.agents/workflows/suggest.md
@@ -2,47 +2,137 @@
 description: Structured suggestions with analysis, tradeoffs, and priorities
 ---
 
-# Suggest Workflow
+# /suggest - Smart Suggestions
 
-When the user asks for suggestions, follow this structured approach:
+$ARGUMENTS
 
-1. **Understand scope**: Determine what area the user wants suggestions for:
-   - A specific file or feature (narrow)
-   - A crate or subsystem (medium)
-   - The whole project (broad)
+---
 
-2. **Research**: Before suggesting anything, gather context:
-   - Read relevant source files, docs, and specs
-   - Check `docs/REQUIREMENTS.md` for planned vs completed features
-   - Check `docs/CHANGELOG.md` for recent changes
-   - Check open issues/PRs for in-flight work
-   - Review `examples/` for current usage patterns
+## Purpose
 
-3. **Categorize suggestions** using these buckets:
+Research the codebase thoroughly, then provide structured, prioritized suggestions. Never auto-implement — present options and wait for the user's pick.
 
-   | Category        | Icon | Description                                   |
-   | --------------- | ---- | --------------------------------------------- |
-   | **Quick Win**   | 🎯   | Low effort, high impact — do it now           |
-   | **Enhancement** | ✨   | Medium effort improvement to existing feature |
-   | **New Feature** | 🚀   | Significant new capability                    |
-   | **Refactor**    | 🔧   | Code quality / architecture improvement       |
-   | **Bug Risk**    | ⚠️   | Potential issue worth investigating           |
-   | **DX**          | 🛠️   | Developer experience improvement              |
+---
 
-4. **Format each suggestion** as:
+## Workflow
 
-   ```markdown
-   ### <Icon> <Title>
+### 1. Research First
 
-   **Effort:** Low/Medium/High · **Impact:** Low/Medium/High
+// turbo-all
 
-   <1-2 sentence description of what and why>
+Before suggesting anything, read relevant context:
 
-   **Tradeoff:** <What you'd give up or risk>
-   ```
+```bash
+# Recent changes
+git log --oneline -20
 
-5. **Prioritize**: Order suggestions within each category by impact-to-effort ratio (best ROI first).
+# Open issues / TODOs
+grep -rn "TODO\|FIXME\|HACK\|XXX" crates/ fd-vscode/src/ --include="*.rs" --include="*.ts" | head -30
+```
 
-6. **Limit scope**: Max 10 suggestions per invocation. If there are more, mention "there are more — ask me to go deeper on any area."
+Also read:
 
-7. **Present to user** and ask which ones to act on. Do NOT start implementing unless asked.
+- Relevant source files related to `$ARGUMENTS`
+- `docs/REQUIREMENTS.md` for planned features and coverage gaps (⚠️ / ❌ rows)
+- `docs/CHANGELOG.md` for recent changes
+- `docs/LESSONS.md` for known pitfalls
+- Any related test files for coverage gaps
+- Open issues/PRs for in-flight work
+- `examples/` for current usage patterns
+
+### 2. Categorize Suggestions
+
+Use these categories:
+
+| Emoji | Category        | Description                            |
+| ----- | --------------- | -------------------------------------- |
+| 🎯    | **Quick Win**   | Low effort, immediate value            |
+| ✨    | **Enhancement** | Improve existing feature               |
+| 🚀    | **New Feature** | Something that doesn't exist yet       |
+| 🔧    | **Refactor**    | Better code structure, no new behavior |
+| ⚠️    | **Bug Risk**    | Potential issue before it bites        |
+| 🛠️    | **DX**          | Developer experience improvement       |
+
+### 3. Structure Each Suggestion
+
+For each suggestion, provide:
+
+```markdown
+### [Emoji] [Title]
+
+**Effort:** 🟢 Low / 🟡 Medium / 🔴 High
+**Impact:** 🟢 Low / 🟡 Medium / 🔴 High
+**ROI:** ⭐⭐⭐⭐⭐ (impact ÷ effort)
+
+[2-3 sentence description of what and why]
+
+**Tradeoffs:**
+
+- ✅ Pro: [benefit]
+- ⚠️ Con: [risk or cost]
+```
+
+### 4. Prioritize by ROI
+
+- Rank suggestions by ROI (impact-to-effort ratio)
+- 🎯 Quick Wins with high impact go first
+- ⚠️ Bug Risks get priority regardless of effort
+- Cap at **10 suggestions max** to avoid overwhelm
+
+### 5. Present and Wait
+
+Format the final output as:
+
+```markdown
+## 💡 Suggestions for [Topic]
+
+Based on analysis of [what was reviewed].
+
+[Ranked list of suggestions]
+
+---
+
+**Want to go deeper on any of these?** Pick a number and I'll:
+
+- Create a detailed spec (`/spec`)
+- Design the UI (`/design`)
+- Jump straight to building (`/build`)
+```
+
+---
+
+## Rules
+
+| Rule                     | Description                                             |
+| ------------------------ | ------------------------------------------------------- |
+| **Research first**       | Never suggest without reading relevant code             |
+| **No auto-implement**    | Present and wait for user's pick                        |
+| **Max 10**               | Cap suggestions to avoid overwhelm                      |
+| **Be specific**          | Reference actual file paths and line numbers            |
+| **Consider stack**       | Suggestions must fit Rust/WASM + VS Code extension arch |
+| **Respect requirements** | Check `REQUIREMENTS.md` before suggesting duplicates    |
+
+---
+
+## Scope Modifiers
+
+The user can narrow scope with keywords:
+
+| Modifier             | Focus                                       |
+| -------------------- | ------------------------------------------- |
+| `/suggest parser`    | fd-core parser, emitter, round-trips        |
+| `/suggest renderer`  | fd-render, fd-wasm, canvas rendering        |
+| `/suggest editor`    | fd-editor tools, sync, commands             |
+| `/suggest extension` | fd-vscode TypeScript, webview, panels       |
+| `/suggest tests`     | Test coverage gaps, test quality            |
+| `/suggest perf`      | Performance bottlenecks, 16ms budget        |
+| `/suggest dx`        | Developer experience, tooling, CI, workflow |
+| `/suggest [feature]` | Specific feature area (e.g., `edges`, `ai`) |
+
+---
+
+## Integration
+
+```
+/suggest → pick suggestion → /spec → /design → /build → /pr
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.66 — Toolbar Consolidation
+
+- **UX**: Replaced bottom shape palette with `＋ Insert` dropdown in top bar — glassmorphism popover with Shapes (Rect, Ellipse, Line, Arrow) and Layout (Frame, Text) sections; clicking activates the tool; hidden in Zen mode
+- **UX**: Zen mode toolbar now icon-only — text labels and keyboard hint badges hidden, compact 8px padding, tooltips on hover
+- **UX**: Removed floating action bar overflow menu (⋯) — Group/Ungroup/Duplicate/Delete remain via context menu and shortcuts; floating bar is now purely a property editor (Fill, Stroke, Opacity, Font Size)
+- **CLEANUP**: Removed ~170 lines of dead CSS/HTML/JS (shape palette, fab overflow, palette drag handlers)
+
 ### v0.8.65 — Status Rename
 
 - **BREAKING (R1.9)**: Renamed spec status values: `draft` → `todo`, `in_progress` → `doing`; added `blocked` (red badge). Parser accepts both old and new values for backward compatibility. LSP completions, hover docs, annotation card, filter tabs, bulk dropdown, and all 12+ example files updated

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -72,7 +72,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 - **R3.7** _(done)_: Undo/redo — full command stack, works across text and canvas edits
 - **R3.8** _(done)_: Properties panel — frosted glass inspector for position, size, fill, stroke, corner, opacity
-- **R3.9** _(done)_: Shape palette — drag-and-drop for Rect, Ellipse, Text, Frame, Line, Arrow
+- **R3.9** _(done)_: Insert dropdown — `＋ Insert` button in top bar with shape/layout popover; replaces bottom shape palette
 - **R3.10** _(done)_: Apple Pencil Pro squeeze — toggle between last two tools
 - **R3.11** _(done)_: Per-tool cursor feedback (crosshair, text cursor, default)
 - **R3.12** _(done)_: Annotation pins — badge dots on annotated nodes with inline edit card

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "fast-draft",
   "displayName": "Fast Draft",
-  "description": "Syntax highlighting, live parser validation, and interactive canvas editor for .fd (Fast Draft) files",
-  "version": "0.8.65",
+  "description": "Design Specs as Code",
+  "version": "0.8.66",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -244,44 +244,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       background: var(--fd-accent);
       cursor: pointer;
     }
-    .fab-btn {
-      background: transparent;
-      border: none;
-      color: #aaa;
-      font-size: 13px;
-      cursor: pointer;
-      padding: 2px 4px;
-      border-radius: 4px;
-      line-height: 1;
-    }
-    .fab-btn:hover { background: rgba(255,255,255,0.1); color: #fff; }
-    /* Overflow menu */
-    #fab-overflow-menu {
-      position: absolute;
-      bottom: calc(100% + 4px);
-      right: 0;
-      background: rgba(30,30,30,0.95);
-      border: 1px solid rgba(255,255,255,0.12);
-      border-radius: 8px;
-      padding: 4px;
-      display: none;
-      flex-direction: column;
-      gap: 1px;
-      min-width: 120px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-    }
-    #fab-overflow-menu.visible { display: flex; }
-    .fab-menu-item {
-      background: transparent;
-      border: none;
-      color: #ccc;
-      font-size: 11px;
-      padding: 6px 10px;
-      text-align: left;
-      cursor: pointer;
-      border-radius: 4px;
-    }
-    .fab-menu-item:hover { background: rgba(255,255,255,0.1); color: #fff; }
+
 
     /* ── Onboarding Overlay ── */
     #onboarding-overlay {
@@ -1024,6 +987,37 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     .export-menu-item:hover { background: #007FD4; color: #FFF; }
     .export-menu-sep { height: 1px; background: #404040; margin: 4px 0; }
 
+    /* ── Insert Dropdown (shape/element insertion) ── */
+    .insert-dropdown-container { position: relative; display: inline-block; }
+    .insert-menu {
+      display: none; position: absolute; top: 100%; left: 0; margin-top: 4px;
+      background: var(--fd-surface);
+      backdrop-filter: blur(24px) saturate(180%);
+      -webkit-backdrop-filter: blur(24px) saturate(180%);
+      border: 0.5px solid var(--fd-border);
+      border-radius: 8px;
+      box-shadow: var(--fd-shadow-lg);
+      flex-direction: column;
+      z-index: 1000; min-width: 160px; padding: 4px;
+    }
+    .insert-menu.visible { display: flex; }
+    .insert-section-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: var(--fd-text-secondary);
+      padding: 6px 10px 3px;
+      font-weight: 600;
+    }
+    .insert-menu-item {
+      background: none; border: none; padding: 5px 10px;
+      color: var(--fd-text); font-size: 12px; cursor: pointer; text-align: left;
+      border-radius: 5px; display: flex; align-items: center; gap: 8px;
+      transition: none;
+    }
+    .insert-menu-item:hover { background: var(--fd-accent); color: var(--fd-accent-fg); }
+    .insert-menu-sep { height: 1px; background: var(--fd-border); margin: 3px 8px; }
+
     /* ── Minimap ── */
     #minimap-container {
       position: absolute;
@@ -1358,73 +1352,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       font-weight: 500;
     }
 
-    /* ── Shape Palette (Freeform-style) ── */
-    #shape-palette {
-      position: absolute;
-      bottom: 16px;
-      left: 50%;
-      transform: translateX(-50%);
-      display: flex;
-      flex-direction: row;
-      gap: 2px;
-      z-index: 50;
-      background: var(--fd-surface);
-      backdrop-filter: blur(24px) saturate(180%);
-      -webkit-backdrop-filter: blur(24px) saturate(180%);
-      border: 0.5px solid var(--fd-border);
-      border-radius: 12px;
-      padding: 5px;
-      box-shadow: var(--fd-shadow-md);
-      align-items: center;
-    }
-    .palette-sep {
-      width: 1px;
-      height: 24px;
-      background: var(--fd-border);
-      margin: 0 3px;
-      opacity: 0.6;
-      flex-shrink: 0;
-    }
-    .palette-item {
-      width: 38px;
-      height: 38px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 9px;
-      cursor: grab;
-      color: var(--fd-text-secondary);
-      font-size: 18px;
-      transition: all 0.18s cubic-bezier(0.25, 0.1, 0.25, 1);
-      user-select: none;
-      position: relative;
-    }
-    .palette-item:hover {
-      background: var(--fd-surface-hover);
-      color: var(--fd-text);
-    }
-    .palette-item:active {
-      cursor: grabbing;
-      transform: scale(0.90);
-      background: var(--fd-surface-active);
-    }
-    .palette-item .palette-label {
-      display: none;
-      position: absolute;
-      bottom: 46px;
-      background: var(--fd-surface-solid);
-      padding: 4px 10px;
-      border-radius: 6px;
-      font-size: 11px;
-      font-weight: 500;
-      white-space: nowrap;
-      pointer-events: none;
-      box-shadow: var(--fd-shadow-sm);
-      color: var(--fd-text);
-    }
-    .palette-item:hover .palette-label {
-      display: block;
-    }
+
 
     /* ── Annotation Card ── */
     #annotation-card {
@@ -1822,9 +1750,18 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     .zen-mode #layers-panel { display: none !important; }
     .zen-mode #props-panel { display: none !important; }
     .zen-mode #minimap-container { display: none !important; }
-    .zen-mode #shape-palette { display: none !important; }
     .zen-mode #selection-bar { display: none !important; }
     .zen-mode #spec-overlay { display: none !important; }
+
+    /* ── Zen mode: icon-only toolbar ── */
+    .zen-mode .tool-btn > .tool-key { display: none; }
+    .zen-mode .tool-btn {
+      padding: 5px 8px;
+      font-size: 0; /* hides text labels */
+    }
+    .zen-mode .tool-btn > .tool-icon {
+      font-size: 14px;
+    }
 
     /* Panel toggle via keyboard in zen mode */
     .zen-mode #layers-panel.zen-visible {
@@ -1847,6 +1784,20 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <button class="tool-btn" data-tool="text"><span class="tool-icon">T</span>Text<span class="tool-key">T</span></button>
     <button class="tool-btn" data-tool="frame"><span class="tool-icon">⊞</span>Frame<span class="tool-key">F</span></button>
     <div class="tool-sep zen-full-only"></div>
+    <div class="insert-dropdown-container zen-full-only" id="insert-dropdown-container">
+      <button class="tool-btn" id="insert-menu-btn" title="Insert shape or element"><span class="tool-icon">＋</span>Insert</button>
+      <div class="insert-menu" id="insert-menu">
+        <div class="insert-section-label">Shapes</div>
+        <button class="insert-menu-item" data-insert="rect">▢ Rectangle</button>
+        <button class="insert-menu-item" data-insert="ellipse">◯ Ellipse</button>
+        <button class="insert-menu-item" data-insert="line">━ Line</button>
+        <button class="insert-menu-item" data-insert="arrow">→ Arrow</button>
+        <div class="insert-menu-sep"></div>
+        <div class="insert-section-label">Layout</div>
+        <button class="insert-menu-item" data-insert="frame">⊞ Frame</button>
+        <button class="insert-menu-item" data-insert="text">T Text</button>
+      </div>
+    </div>
     <button class="tool-btn zen-full-only" id="ai-refine-btn" title="AI Assist selected node (rename + restyle)">&#x2728; Assist</button>
     <button class="tool-btn zen-full-only" id="ai-refine-all-btn" title="AI Assist all anonymous nodes">&#x2728; All</button>
     <div class="tool-sep zen-full-only"></div>
@@ -1874,19 +1825,11 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <button class="tool-btn" id="sketchy-toggle-btn" title="Toggle sketchy hand-drawn mode">✏️</button>
     <button class="tool-btn zen-full-only" id="theme-toggle-btn" title="Toggle light/dark canvas theme">🌙</button>
     <button class="zen-full-only" id="zoom-level" title="Zoom level (click to reset to 100%)">100%</button>
-    <button class="tool-btn zen-full-only" id="tool-help-btn" title="Keyboard shortcuts">?</button>
+    <button class="tool-btn zen-full-only" id="tool-help-btn" title="Keyboard shortcuts">⌨️ Shortcuts</button>
     <span class="zen-full-only" id="status">Loading WASM…</span>
   </div>
   <div id="canvas-container">
-    <div id="shape-palette">
-      <div class="palette-item" draggable="true" data-shape="rect">▢<span class="palette-label">Rectangle</span></div>
-      <div class="palette-item" draggable="true" data-shape="ellipse">◯<span class="palette-label">Ellipse</span></div>
-      <div class="palette-item" draggable="true" data-shape="text">T<span class="palette-label">Text</span></div>
-      <div class="palette-sep"></div>
-      <div class="palette-item" draggable="true" data-shape="frame">▣<span class="palette-label">Frame</span></div>
-      <div class="palette-item" draggable="true" data-shape="line">━<span class="palette-label">Line</span></div>
-      <div class="palette-item" draggable="true" data-shape="arrow">→<span class="palette-label">Arrow</span></div>
-    </div>
+
     <div id="onboarding-overlay">
       <div class="onboard-heading">Start drawing</div>
       <div class="onboard-sub">Create something beautiful</div>
@@ -1923,15 +1866,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <div class="fab-sep fab-text-only"></div>
       <span class="fab-label fab-text-only">Size</span>
       <input type="number" id="fab-font-size" class="fab-input fab-text-only" min="8" max="200" step="1" value="16" title="Font size">
-      <div class="fab-sep"></div>
-      <button class="fab-btn" id="fab-more-btn" title="More actions">⋯</button>
-      <div id="fab-overflow-menu">
-        <button class="fab-menu-item" data-action="group">⌘G ◻ Group</button>
-        <button class="fab-menu-item" data-action="ungroup">⌘⇧G ◫ Ungroup</button>
-        <button class="fab-menu-item" data-action="duplicate">⌘D Duplicate</button>
-        <button class="fab-menu-item" data-action="copy-png">⌘⇧C Copy as PNG</button>
-        <button class="fab-menu-item" data-action="delete" style="color:#e57373">⌫ Delete</button>
-      </div>
+
     </div>
     <canvas id="fd-canvas" class="tool-select"></canvas>
     <div id="dimension-tooltip"></div>


### PR DESCRIPTION
## Summary

Consolidate the three shape-access UI surfaces into a cleaner architecture.

### Changes

- **＋ Insert dropdown** — replaces the bottom shape palette with a glassmorphism popover in the top bar (Shapes: Rect, Ellipse, Line, Arrow + Layout: Frame, Text). Clicking activates the drawing tool. Hidden in Zen mode.
- **Zen mode icon-only toolbar** — text labels and keyboard hint badges hidden in Zen mode; compact padding; tooltips on hover.
- **Remove floating bar overflow** — the ⋯ button + overflow menu (Group/Ungroup/Duplicate/Delete) removed from the floating action bar. These actions remain accessible via context menu and keyboard shortcuts. FAB is now purely a property editor.
- **~170 lines dead code removed** — palette CSS/HTML/JS, fab overflow CSS/HTML/JS, palette drag handlers.

### Files Changed

- `fd-vscode/src/webview-html.ts` — CSS/HTML changes
- `fd-vscode/webview/main.js` — JS handler changes
- `fd-vscode/package.json` — version 0.8.66
- `docs/CHANGELOG.md` — v0.8.66 entry
- `docs/REQUIREMENTS.md` — R3.9 updated

### Verification

- ✅ cargo check/clippy/test/fmt
- ✅ pnpm test (166/166)
- ✅ pnpm compile