### PR TITLE
feat(core): add ReadMode enum and emit_filtered for AI agent token savings

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -274,6 +274,45 @@ anim :hover { scale: 1.03; ease: spring 200ms }
 
 ```
 
+## Read Modes (Filtered Emit for AI Agents)
+
+AI agents can read a filtered view of an `.fd` file, showing only the properties relevant to their task. This saves 50-80% tokens while preserving structural understanding.
+
+### CLI Usage
+
+```bash
+fd-lsp --view structure < file.fd   # Node tree only
+fd-lsp --view layout < file.fd     # Structure + dimensions + constraints
+fd-lsp --view design < file.fd     # Structure + themes + visual styles
+fd-lsp --view spec < file.fd       # Structure + spec blocks
+fd-lsp --view full < file.fd       # Full file (same as emit_document)
+```
+
+### Rust API
+
+```rust
+use fd_core::{ReadMode, emit_filtered, parser::parse_document};
+
+let graph = parse_document(text)?;
+let filtered = emit_filtered(&graph, ReadMode::Structure);
+```
+
+### Mode Reference
+
+| Mode        | Includes                                                        | Excludes                    | Savings |
+| ----------- | --------------------------------------------------------------- | --------------------------- | ------- |
+| `Structure` | Node types, `@id`s, hierarchy                                   | Everything else             | ~80%    |
+| `Layout`    | Structure + `w:`/`h:` + `layout:` + constraints                 | Styles, anims, specs        | ~73%    |
+| `Design`    | Structure + themes + `fill:`/`stroke:`/`font:`/`corner:`/`use:` | Dims, layout, specs, anims  | ~53%    |
+| `Spec`      | Structure + `spec {}` blocks                                    | Styles, dims, layout, anims | ~49%    |
+
+### When to Use Each Mode
+
+- **Structure** → Restructuring, renaming, adding/removing nodes
+- **Layout** → Repositioning, resizing, changing spatial relationships
+- **Design** → Theming, brand audits, creating dark mode variants
+- **Spec** → QA testing, writing acceptance tests, reviewing requirements
+
 ## Crate Locations
 
 - Parser: `crates/fd-core/src/parser.rs`

--- a/crates/fd-core/src/lib.rs
+++ b/crates/fd-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod parser;
 pub mod resolve;
 pub mod transform;
 
+pub use emitter::{ReadMode, emit_filtered};
 pub use format::{FormatConfig, format_document};
 pub use id::NodeId;
 pub use layout::{Viewport, resolve_layout};


### PR DESCRIPTION
## What

Add filtered emit modes that let AI agents read only what they need from `.fd` files, saving 50-80% tokens.

## ReadMode variants

| Mode | Includes | Token Savings |
|---|---|---|
| `Structure` | Node types, `@id`s, hierarchy | ~80% |
| `Layout` | Structure + `w:`/`h:` + `layout:` + constraints | ~73% |
| `Design` | Structure + themes + visual styles | ~53% |
| `Spec` | Structure + `spec {}` blocks | ~49% |
| `Full` | Everything (identical to `emit_document`) | 0% |

## API

**Rust:**
```rust
let filtered = emit_filtered(&graph, ReadMode::Structure);
```

**CLI:**
```bash
fd-lsp --view structure < file.fd
```

## Changes

- `crates/fd-core/src/emitter.rs` — `ReadMode` enum, `emit_filtered`, `emit_node_filtered`, `emit_layout_mode`, `emit_dimensions` + 5 tests
- `crates/fd-core/src/lib.rs` — re-export
- `crates/fd-lsp/src/main.rs` — `--view <mode>` CLI flag
- `.agents/skills/fd-format/SKILL.md` — Read Modes documentation

## Testing

- 5 new unit tests (all pass)
- Full workspace: `cargo test --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅