### PR TITLE
feat(site): GitHub Pages landing site with live WASM playground

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build WASM + Site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        run: wasm-pack build crates/fd-wasm --target web --out-dir ../../site/wasm
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,8 @@ ftd-vscode/out/
 ftd-vscode/wasm/
 *.vsix
 
+# GitHub Pages WASM build output (built by CI)
+site/wasm/
+
 # Environment secrets
 .env

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### GitHub Pages — Live Playground
+
+- **FEATURE (R6.5)**: GitHub Pages landing site at `khangnghiem.github.io/fast-draft` with premium dark-theme design — hero section, feature cards, benchmark comparison table (11 FD vs Excalidraw pairs), architecture diagram, and editor support matrix
+- **FEATURE (R6.5)**: Live WASM playground — embedded split-pane editor + canvas powered by `fd-wasm`; 3 pre-loaded examples (Card, Login Form, Welcome), theme toggle (dark/light), sketchy mode toggle, real-time rendering on keystroke
+- **CI**: GitHub Actions workflow `pages.yml` — auto-builds WASM via `wasm-pack` and deploys `site/` to GitHub Pages on every push to `main`
+
 ### v0.8.66 — Toolbar Consolidation
 
 - **UX**: Replaced bottom shape palette with `＋ Insert` dropdown in top bar — glassmorphism popover with Shapes (Rect, Ellipse, Line, Arrow) and Layout (Frame, Text) sections; clicking activates the tool; hidden in Zen mode

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -126,6 +126,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.2** _(future)_: Desktop app via Tauri (macOS, Windows, Linux)
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
+- **R6.5** _(done)_: GitHub Pages landing site with live WASM playground and auto-deploy via GitHub Actions
 
 ## Non-Functional Requirements
 
@@ -230,7 +231,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | style / theme       | R1.4, R4.3, R4.18                                                 |
 | animation           | R1.5, R1.11, R1.12, R3.29, R4.18, R5.6, R5.8                      |
 | rendering           | R5.1, R5.2, R5.4, R5.5                                            |
-| platform            | R6.1, R6.2, R6.3, R6.4                                            |
+| platform            | R6.1, R6.2, R6.3, R6.4, R6.5                                      |
 | inline editing      | R3.28                                                             |
 | text alignment      | R1.17, R3.28, R3.36                                               |
 | layout / centering  | R3.36                                                             |

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fast Draft — Design as Code</title>
+  <meta name="description" content="Fast Draft is a file format and canvas for drawing, design, and animation — right inside your code editor. Draw it or code it? Both." />
+  <meta name="keywords" content="design tool, code editor, AI-friendly, WASM, canvas, VS Code, design as code" />
+  <meta property="og:title" content="Fast Draft — Design as Code" />
+  <meta property="og:description" content="A file format and canvas for drawing, design, and animation — right inside your code editor." />
+  <meta property="og:type" content="website" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <!-- ─── Navigation ─── -->
+  <nav id="navbar">
+    <div class="nav-inner">
+      <a href="#" class="nav-logo">
+        <span class="logo-icon">⚡</span>
+        <span class="logo-text">Fast Draft</span>
+      </a>
+      <div class="nav-links">
+        <a href="#playground">Playground</a>
+        <a href="#features">Features</a>
+        <a href="#benchmarks">Benchmarks</a>
+        <a href="#architecture">Architecture</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install Extension</a>
+      </div>
+      <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Toggle menu">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <!-- ─── Hero ─── -->
+  <header id="hero">
+    <div class="hero-bg">
+      <div class="hero-gradient"></div>
+      <div class="hero-grid"></div>
+    </div>
+    <div class="hero-content">
+      <div class="hero-badge">Open Source · MIT License</div>
+      <h1>Design as <span class="gradient-text">Code</span></h1>
+      <p class="hero-sub">A file format and canvas for drawing, design, and animation — right inside your code editor. Draw it or code it? <strong>Both.</strong></p>
+      <div class="hero-cta">
+        <a href="#playground" class="btn btn-primary">
+          <span class="btn-icon">▶</span> Try Playground
+        </a>
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener" class="btn btn-ghost">
+          <span class="btn-icon">★</span> View on GitHub
+        </a>
+      </div>
+      <div class="hero-stats">
+        <div class="stat">
+          <span class="stat-value">5×</span>
+          <span class="stat-label">fewer tokens than SVG</span>
+        </div>
+        <div class="stat-divider"></div>
+        <div class="stat">
+          <span class="stat-value">6.5×</span>
+          <span class="stat-label">smaller than Excalidraw</span>
+        </div>
+        <div class="stat-divider"></div>
+        <div class="stat">
+          <span class="stat-value">331</span>
+          <span class="stat-label">tests passing</span>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <!-- ─── Code Preview ─── -->
+  <section id="code-preview" class="section">
+    <div class="container">
+      <div class="code-window">
+        <div class="code-titlebar">
+          <div class="code-dots">
+            <span class="dot red"></span>
+            <span class="dot yellow"></span>
+            <span class="dot green"></span>
+          </div>
+          <span class="code-filename">hello.fd</span>
+        </div>
+        <pre class="code-content"><code><span class="c-comment"># A card with a hover button</span>
+
+<span class="c-keyword">theme</span> <span class="c-id">accent</span> {
+  <span class="c-prop">fill:</span> <span class="c-color">#6C5CE7</span>
+}
+
+<span class="c-keyword">group</span> <span class="c-id">@card</span> {
+  <span class="c-prop">layout:</span> column gap=16 pad=24
+  <span class="c-prop">bg:</span> <span class="c-color">#FFF</span> corner=12 shadow=(0,4,20,<span class="c-color">#0002</span>)
+
+  <span class="c-keyword">text</span> <span class="c-id">@title</span> <span class="c-string">"Hello World"</span> {
+    <span class="c-prop">font:</span> <span class="c-string">"Inter"</span> bold 24
+    <span class="c-prop">fill:</span> <span class="c-color">#1A1A2E</span>
+  }
+
+  <span class="c-keyword">rect</span> <span class="c-id">@button</span> {
+    <span class="c-prop">w:</span> <span class="c-num">200</span> <span class="c-prop">h:</span> <span class="c-num">48</span>
+    <span class="c-prop">use:</span> accent
+    <span class="c-keyword">when</span> <span class="c-trigger">:hover</span> {
+      <span class="c-prop">fill:</span> <span class="c-color">#5A4BD1</span>
+      <span class="c-prop">scale:</span> <span class="c-num">1.02</span>
+      <span class="c-prop">ease:</span> spring 300ms
+    }
+  }
+}
+
+<span class="c-id">@card</span> -> <span class="c-prop">center_in:</span> canvas</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Live Playground ─── -->
+  <section id="playground" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>Live <span class="gradient-text">Playground</span></h2>
+        <p>Edit the code below and watch the canvas update in real-time — powered by Rust + WebAssembly.</p>
+      </div>
+      <div class="playground-toolbar">
+        <div class="toolbar-left">
+          <label for="example-select" class="toolbar-label">Example:</label>
+          <select id="example-select" class="toolbar-select">
+            <option value="card">Card Component</option>
+            <option value="login">Login Form</option>
+            <option value="welcome">Welcome Screen</option>
+          </select>
+        </div>
+        <div class="toolbar-right">
+          <button id="sketchy-toggle" class="toolbar-btn" title="Toggle sketchy mode">
+            ✏️ Sketchy
+          </button>
+          <button id="theme-toggle" class="toolbar-btn" title="Toggle theme">
+            🌙 Dark
+          </button>
+        </div>
+      </div>
+      <div id="playground-container" class="playground-split">
+        <div class="playground-editor">
+          <div class="editor-header">
+            <span class="editor-dot"></span> Code Mode
+          </div>
+          <textarea id="fd-editor" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
+        </div>
+        <div class="playground-canvas">
+          <div class="editor-header">
+            <span class="editor-dot canvas-dot"></span> Canvas Mode
+          </div>
+          <div id="canvas-wrapper">
+            <canvas id="fd-canvas"></canvas>
+            <div id="canvas-loading" class="canvas-loading">
+              <div class="loading-spinner"></div>
+              <p>Loading WASM engine…</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Features ─── -->
+  <section id="features" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>Why <span class="gradient-text">Fast Draft</span>?</h2>
+        <p>Built for both humans and AI agents — design and code in perfect sync.</p>
+      </div>
+      <div class="features-grid">
+        <div class="feature-card">
+          <div class="feature-icon">🤖</div>
+          <h3>AI-Friendly</h3>
+          <p>Compact text DSL — ~5× fewer tokens than SVG. LLMs read, write, and reason about entire UIs in a single prompt.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">↔️</div>
+          <h3>Two-Way Sync</h3>
+          <p>Edit code or canvas — the other updates instantly in &lt;16ms. One source of truth, zero conflicts.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">📋</div>
+          <h3>Specs Built In</h3>
+          <p>Attach requirements, status, and acceptance criteria directly to visual elements with <code>spec</code> blocks.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🎨</div>
+          <h3>GPU Canvas</h3>
+          <p>Vello + wgpu rendering engine. Smart guides, resize handles, sketchy mode, animations — Figma-grade tools.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">🔀</div>
+          <h3>Git-Friendly</h3>
+          <p>Plain text format — <code>git diff</code>, <code>git merge</code>, and code review all work naturally.</p>
+        </div>
+        <div class="feature-card">
+          <div class="feature-icon">⚡</div>
+          <h3>6 Editors</h3>
+          <p>VS Code, Cursor, Zed, Neovim, Sublime, Helix, Emacs. Canvas in VS Code, syntax highlighting everywhere.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Two Modes ─── -->
+  <section id="modes" class="section section-dark">
+    <div class="container">
+      <div class="section-header">
+        <h2>Two Modes, <span class="gradient-text">One File</span></h2>
+        <p>Each mode is designed for a different audience — but they edit the same file.</p>
+      </div>
+      <div class="modes-grid">
+        <div class="mode-card">
+          <div class="mode-badge">🤖 Code Mode</div>
+          <h3>The AI Interface</h3>
+          <p>LLMs and coding agents read, write, and reason about <code>.fd</code> text directly. Uses ~5× fewer tokens than Excalidraw JSON.</p>
+          <ul class="mode-list">
+            <li>Semantic node names (<code>@login_form</code>)</li>
+            <li>Constraint-based layout (no pixel coords)</li>
+            <li>Structured spec blocks</li>
+            <li>Named colors and property aliases</li>
+          </ul>
+        </div>
+        <div class="mode-card">
+          <div class="mode-badge">🎨 Canvas Mode</div>
+          <h3>The Human Interface</h3>
+          <p>Designers draw, drag, and resize on a fast, GPU-powered canvas inside VS Code. No code knowledge needed.</p>
+          <ul class="mode-list">
+            <li>Smart guides and resize handles</li>
+            <li>Drag-and-drop animations</li>
+            <li>Floating toolbar and properties panel</li>
+            <li>Touch and Apple Pencil support</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Benchmarks ─── -->
+  <section id="benchmarks" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>The <span class="gradient-text">Numbers</span></h2>
+        <p>Real designs compared: FD vs Excalidraw JSON. Measured across 11 benchmark pairs.</p>
+      </div>
+      <div class="benchmark-table-wrap">
+        <table class="benchmark-table">
+          <thead>
+            <tr>
+              <th>Design</th>
+              <th>FD Size</th>
+              <th>Excalidraw Size</th>
+              <th>Ratio</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Login Form</td><td>2.4 KB</td><td>15.8 KB</td><td><span class="ratio">6.6×</span></td></tr>
+            <tr><td>Dashboard Card</td><td>0.8 KB</td><td>7.3 KB</td><td><span class="ratio">9.1×</span></td></tr>
+            <tr><td>Kanban Board</td><td>3.7 KB</td><td>18.9 KB</td><td><span class="ratio">5.1×</span></td></tr>
+            <tr><td>Org Chart</td><td>4.1 KB</td><td>15.5 KB</td><td><span class="ratio">3.8×</span></td></tr>
+            <tr><td>API Flowchart</td><td>3.3 KB</td><td>27.9 KB</td><td><span class="ratio">8.5×</span></td></tr>
+            <tr><td>Mobile Onboarding</td><td>3.5 KB</td><td>18.7 KB</td><td><span class="ratio">5.3×</span></td></tr>
+            <tr><td>Pricing Table</td><td>4.4 KB</td><td>24.5 KB</td><td><span class="ratio">5.6×</span></td></tr>
+            <tr><td>Network Topology</td><td>4.6 KB</td><td>28.6 KB</td><td><span class="ratio">6.2×</span></td></tr>
+            <tr><td>Data Dashboard</td><td>4.6 KB</td><td>36.0 KB</td><td><span class="ratio">7.8×</span></td></tr>
+            <tr><td>Design System</td><td>5.7 KB</td><td>28.4 KB</td><td><span class="ratio">5.0×</span></td></tr>
+            <tr><td>Wireframe eCommerce</td><td>2.3 KB</td><td>19.0 KB</td><td><span class="ratio">8.3×</span></td></tr>
+          </tbody>
+          <tfoot>
+            <tr>
+              <td><strong>Average</strong></td>
+              <td></td>
+              <td></td>
+              <td><span class="ratio ratio-avg">6.5×</span></td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Architecture ─── -->
+  <section id="architecture" class="section section-dark">
+    <div class="container">
+      <div class="section-header">
+        <h2>Under the <span class="gradient-text">Hood</span></h2>
+        <p>Five Rust crates, one TypeScript extension, zero compromises.</p>
+      </div>
+      <div class="arch-diagram">
+        <pre class="arch-ascii">┌─────────────────────────────────────────────────────┐
+│  .fd file (text DSL)                                │
+├─────────────────────────────────────────────────────┤
+│  fd-core        Parser ↔ SceneGraph (DAG) ↔ Emitter │
+│                  Layout solver (constraints → coords) │
+├─────────────────────────────────────────────────────┤
+│  fd-render      Vello + wgpu → GPU canvas           │
+│                  Hit testing (point → node)           │
+├─────────────────────────────────────────────────────┤
+│  fd-editor      Bidi sync engine                    │
+│                  Tools (select, rect, pen, text)      │
+│                  Undo/redo command stack               │
+├─────────────────────────────────────────────────────┤
+│  tree-sitter-fd Tree-sitter grammar for editors     │
+├─────────────────────────────────────────────────────┤
+│  fd-vscode      VS Code Custom Editor (WASM webview)│
+│  editors/       Zed, Neovim, Sublime, Helix, Emacs  │
+└─────────────────────────────────────────────────────┘</pre>
+      </div>
+      <div class="crate-grid">
+        <div class="crate-card">
+          <h4>fd-core</h4>
+          <p>Data model, winnow parser, emitter, constraint layout solver</p>
+        </div>
+        <div class="crate-card">
+          <h4>fd-render</h4>
+          <p>Vello/wgpu 2D renderer + hit testing</p>
+        </div>
+        <div class="crate-card">
+          <h4>fd-editor</h4>
+          <p>Bidirectional sync, tool system, undo/redo, input abstraction</p>
+        </div>
+        <div class="crate-card">
+          <h4>fd-wasm</h4>
+          <p>WASM bridge — powers this playground and the VS Code extension</p>
+        </div>
+        <div class="crate-card">
+          <h4>fd-lsp</h4>
+          <p>Language server — hover, completions, format, diagnostics</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Editor Support ─── -->
+  <section id="editors" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>Editor <span class="gradient-text">Support</span></h2>
+        <p>Syntax highlighting everywhere, full canvas in VS Code.</p>
+      </div>
+      <div class="editor-table-wrap">
+        <table class="editor-table">
+          <thead>
+            <tr>
+              <th>Editor</th>
+              <th>Syntax</th>
+              <th>LSP</th>
+              <th>Canvas</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>VS Code / Cursor</td><td>✅</td><td>—</td><td>✅</td></tr>
+            <tr><td>Zed</td><td>✅</td><td>✅</td><td>—</td></tr>
+            <tr><td>Neovim</td><td>✅</td><td>—</td><td>—</td></tr>
+            <tr><td>Sublime Text</td><td>✅</td><td>—</td><td>—</td></tr>
+            <tr><td>Helix</td><td>✅</td><td>—</td><td>—</td></tr>
+            <tr><td>Emacs</td><td>✅</td><td>—</td><td>—</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── CTA ─── -->
+  <section id="cta" class="section section-dark">
+    <div class="container cta-container">
+      <h2>Ready to <span class="gradient-text">design as code</span>?</h2>
+      <p>Install the VS Code extension and start drawing in 30 seconds.</p>
+      <div class="hero-cta">
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn btn-primary">
+          Install Extension
+        </a>
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener" class="btn btn-ghost">
+          Star on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ─── Footer ─── -->
+  <footer id="footer">
+    <div class="container footer-inner">
+      <div class="footer-brand">
+        <span class="logo-icon">⚡</span>
+        <span class="logo-text">Fast Draft</span>
+      </div>
+      <div class="footer-links">
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener">VS Code Marketplace</a>
+        <a href="https://github.com/khangnghiem/fast-draft/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+      </div>
+      <p class="footer-copy">Made with Rust, WASM, and ❤️ by <a href="https://github.com/khangnghiem" target="_blank" rel="noopener">Khang Nghiêm</a></p>
+    </div>
+  </footer>
+
+  <script type="module" src="playground.js"></script>
+  <script>
+    // Mobile menu toggle
+    document.getElementById('mobile-menu-btn').addEventListener('click', function() {
+      document.querySelector('.nav-links').classList.toggle('open');
+      this.classList.toggle('open');
+    });
+
+    // Navbar scroll effect
+    window.addEventListener('scroll', function() {
+      document.getElementById('navbar').classList.toggle('scrolled', window.scrollY > 50);
+    });
+
+    // Smooth scroll for anchor links
+    document.querySelectorAll('a[href^="#"]').forEach(a => {
+      a.addEventListener('click', function(e) {
+        e.preventDefault();
+        const target = document.querySelector(this.getAttribute('href'));
+        if (target) {
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          document.querySelector('.nav-links').classList.remove('open');
+          document.getElementById('mobile-menu-btn').classList.remove('open');
+        }
+      });
+    });
+
+    // Animate elements on scroll
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+        }
+      });
+    }, { threshold: 0.1 });
+
+    document.querySelectorAll('.feature-card, .mode-card, .crate-card, .section-header, .code-window').forEach(el => {
+      el.classList.add('animate-in');
+      observer.observe(el);
+    });
+  </script>
+</body>
+</html>

--- a/site/playground.js
+++ b/site/playground.js
@@ -1,0 +1,289 @@
+// ─── FD Playground — WASM-powered live editor ───
+
+const EXAMPLES = {
+  card: `# A card with a button that reacts on hover
+
+theme accent {
+  fill: #6C5CE7
+}
+
+group @card {
+  layout: column gap=16 pad=24
+  bg: #FFF corner=12 shadow=(0,4,20,#0002)
+
+  text @title "Hello World" {
+    font: "Inter" bold 24
+    fill: #1A1A2E
+  }
+
+  rect @button {
+    w: 200 h: 48
+    corner: 10
+    use: accent
+
+    when :hover {
+      fill: #5A4BD1
+      scale: 1.02
+      ease: spring 300ms
+    }
+  }
+}
+
+@card -> center_in: canvas`,
+
+  login: `# Login form with spec annotations
+
+theme accent {
+  fill: #6C5CE7
+  corner: 10
+}
+
+theme base_text {
+  fill: #333333
+  font: "Inter" regular 14
+}
+
+group @login_form {
+  spec {
+    "User authentication entry point"
+    accept: "email + password fields visible"
+    status: todo
+  }
+  text @title "Welcome Back" {
+    fill: #1A1A2E
+    font: "Inter" bold 24
+  }
+  rect @email_field {
+    text @email_hint "Email" {
+      use: base_text
+      fill: #999999
+    }
+    w: 280 h: 44
+    stroke: #DDDDDD 1
+    corner: 8
+  }
+  rect @pass_field {
+    text @pass_hint "Password" {
+      use: base_text
+      fill: #999999
+    }
+    w: 280 h: 44
+    stroke: #DDDDDD 1
+    corner: 8
+  }
+  rect @login_btn {
+    spec {
+      "Primary CTA"
+      accept: "disabled when fields empty"
+      status: done
+      priority: high
+    }
+    text @btn_label "Sign In" {
+      fill: #FFFFFF
+      font: "Inter" semibold 16
+    }
+    w: 280 h: 48
+    use: accent
+    fill: #5A4BD1
+    when :hover {
+      fill: #4A3BC1
+      scale: 1.02
+      ease: spring 200ms
+    }
+  }
+  layout: column gap=16 pad=32
+}
+
+@login_form -> center_in: canvas`,
+
+  welcome: `# Welcome to Fast Draft!
+
+theme accent { fill: #6C5CE7 }
+theme soft { fill: #DFE6E9; corner: 12 }
+theme label_style { font: "Inter" 500 14; fill: #2D3436 }
+
+text @welcome_title "Welcome to Fast Draft" {
+  x: 180  y: 40
+  font: "Inter" 700 28
+  fill: #2D3436
+}
+
+text @welcome_sub "Edit this code to see changes live!" {
+  x: 180  y: 80
+  font: "Inter" 400 14
+  fill: #636E72
+}
+
+rect @step1_bg {
+  x: 60  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step1_title "1. Draw Shapes" {
+  x: 80  y: 160
+  use: label_style
+}
+
+rect @step1_demo {
+  x: 220  y: 200
+  w: 30  h: 30
+  use: accent
+  corner: 6
+  when :hover { scale: 1.1; ease: spring 200ms }
+}
+
+rect @step2_bg {
+  x: 300  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step2_title "2. Add Text" {
+  x: 320  y: 160
+  use: label_style
+}
+
+rect @step3_bg {
+  x: 540  y: 140
+  w: 200  h: 140
+  use: soft
+}
+
+text @step3_title "3. Style It" {
+  x: 560  y: 160
+  use: label_style
+}
+
+ellipse @step3_demo {
+  x: 700  y: 200
+  w: 20  h: 20
+  fill: #E17055
+  when :hover { fill: #00B894; ease: ease_out 300ms }
+}`
+};
+
+let fdCanvas = null;
+let isDark = true;
+let isSketchy = false;
+let animFrameId = null;
+
+async function initPlayground() {
+  const editor = document.getElementById('fd-editor');
+  const canvas = document.getElementById('fd-canvas');
+  const loading = document.getElementById('canvas-loading');
+  const wrapper = document.getElementById('canvas-wrapper');
+
+  // Load initial example
+  editor.value = EXAMPLES.card;
+
+  try {
+    // Load WASM module
+    const wasm = await import('./wasm/fd_wasm.js');
+    await wasm.default('./wasm/fd_wasm_bg.wasm');
+
+    // Size the canvas
+    const resizeCanvas = () => {
+      const rect = wrapper.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = rect.width + 'px';
+      canvas.style.height = rect.height + 'px';
+
+      if (fdCanvas) {
+        fdCanvas.resize(rect.width, rect.height);
+      }
+    };
+
+    resizeCanvas();
+
+    // Create the FdCanvas instance
+    const rect = wrapper.getBoundingClientRect();
+    fdCanvas = new wasm.FdCanvas(rect.width, rect.height);
+    fdCanvas.set_theme(isDark);
+    fdCanvas.set_text(editor.value);
+
+    // Get canvas 2D context
+    const ctx = canvas.getContext('2d');
+
+    // Render loop
+    const renderLoop = (time) => {
+      const dpr = window.devicePixelRatio || 1;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      fdCanvas.render(ctx, time);
+      animFrameId = requestAnimationFrame(renderLoop);
+    };
+
+    animFrameId = requestAnimationFrame(renderLoop);
+
+    // Hide loading overlay
+    loading.classList.add('hidden');
+
+    // Wire editor input
+    let debounceTimer = null;
+    editor.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        if (fdCanvas) {
+          fdCanvas.set_text(editor.value);
+        }
+      }, 50);
+    });
+
+    // Resize observer
+    const resizeObserver = new ResizeObserver(() => {
+      resizeCanvas();
+    });
+    resizeObserver.observe(wrapper);
+
+    // Example selector
+    document.getElementById('example-select').addEventListener('change', (e) => {
+      const example = EXAMPLES[e.target.value];
+      if (example) {
+        editor.value = example;
+        if (fdCanvas) {
+          fdCanvas.set_text(example);
+        }
+      }
+    });
+
+    // Theme toggle
+    document.getElementById('theme-toggle').addEventListener('click', function() {
+      isDark = !isDark;
+      if (fdCanvas) {
+        fdCanvas.set_theme(isDark);
+      }
+      this.textContent = isDark ? '🌙 Dark' : '☀️ Light';
+      this.classList.toggle('active', !isDark);
+    });
+
+    // Sketchy toggle
+    document.getElementById('sketchy-toggle').addEventListener('click', function() {
+      isSketchy = !isSketchy;
+      if (fdCanvas) {
+        fdCanvas.set_sketchy_mode(isSketchy);
+      }
+      this.classList.toggle('active', isSketchy);
+    });
+
+  } catch (err) {
+    console.error('Failed to load WASM:', err);
+    loading.innerHTML = `
+      <p style="color: var(--text-secondary); text-align: center; max-width: 320px;">
+        <strong>Playground requires WebAssembly</strong><br><br>
+        Install the
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank">VS Code extension</a>
+        for the full canvas experience, or
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank">build from source</a>.
+      </p>
+    `;
+  }
+}
+
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPlayground);
+} else {
+  initPlayground();
+}

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,780 @@
+/* ─── Design Tokens ─── */
+:root {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --bg-card-hover: #21262D;
+  --text-primary: #E6EDF3;
+  --text-secondary: #8B949E;
+  --text-muted: #484F58;
+  --accent: #6C5CE7;
+  --accent-hover: #5A4BD1;
+  --accent-glow: rgba(108, 92, 231, 0.3);
+  --accent-2: #0984E3;
+  --border: #30363D;
+  --border-light: #21262D;
+  --success: #10B981;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-sm: 8px;
+  --shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  --shadow-glow: 0 0 40px rgba(108, 92, 231, 0.15);
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --max-width: 1200px;
+}
+
+/* ─── Reset ─── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; scroll-padding-top: 80px; }
+body {
+  font-family: var(--font);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+a { color: var(--accent); text-decoration: none; transition: color var(--transition); }
+a:hover { color: var(--accent-hover); }
+code {
+  font-family: var(--mono);
+  background: var(--bg-card);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: var(--accent);
+}
+
+/* ─── Nav ─── */
+#navbar {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  background: transparent;
+  transition: background var(--transition), backdrop-filter var(--transition), box-shadow var(--transition);
+}
+#navbar.scrolled {
+  background: rgba(13, 17, 23, 0.85);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow: 0 1px 0 var(--border);
+}
+.nav-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+.logo-icon { font-size: 1.4rem; }
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+.nav-links a {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color var(--transition);
+}
+.nav-links a:hover { color: var(--text-primary); }
+.btn-nav {
+  background: var(--accent) !important;
+  color: #fff !important;
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600 !important;
+  transition: background var(--transition), transform var(--transition) !important;
+}
+.btn-nav:hover {
+  background: var(--accent-hover) !important;
+  transform: translateY(-1px);
+}
+.mobile-menu-btn {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+.mobile-menu-btn span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background: var(--text-primary);
+  border-radius: 2px;
+  transition: transform var(--transition), opacity var(--transition);
+}
+.mobile-menu-btn.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.mobile-menu-btn.open span:nth-child(2) { opacity: 0; }
+.mobile-menu-btn.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* ─── Hero ─── */
+#hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 120px 24px 80px;
+  overflow: hidden;
+}
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+.hero-gradient {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(108, 92, 231, 0.15), transparent),
+    radial-gradient(ellipse 60% 80% at 80% 60%, rgba(9, 132, 227, 0.1), transparent),
+    radial-gradient(ellipse 40% 40% at 20% 80%, rgba(108, 92, 231, 0.08), transparent);
+}
+.hero-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(48, 54, 61, 0.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(48, 54, 61, 0.3) 1px, transparent 1px);
+  background-size: 60px 60px;
+  mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, black, transparent);
+  -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, black, transparent);
+}
+.hero-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  max-width: 800px;
+}
+.hero-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: rgba(108, 92, 231, 0.1);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  margin-bottom: 24px;
+  letter-spacing: 0.02em;
+}
+#hero h1 {
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 800;
+  line-height: 1.1;
+  margin-bottom: 20px;
+  letter-spacing: -0.03em;
+}
+.gradient-text {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.hero-sub {
+  font-size: 1.2rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto 32px;
+  line-height: 1.7;
+}
+.hero-cta {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 48px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 28px;
+  border-radius: var(--radius);
+  font-weight: 600;
+  font-size: 1rem;
+  transition: all var(--transition);
+  cursor: pointer;
+  border: none;
+  text-decoration: none;
+}
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 4px 20px rgba(108, 92, 231, 0.3);
+}
+.btn-primary:hover {
+  background: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(108, 92, 231, 0.4);
+  color: #fff;
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+.btn-ghost:hover {
+  background: var(--bg-card);
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+  transform: translateY(-2px);
+}
+.btn-icon { font-size: 0.9em; }
+.hero-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+.stat { text-align: center; }
+.stat-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+.stat-divider {
+  width: 1px;
+  height: 40px;
+  background: var(--border);
+}
+
+/* ─── Sections ─── */
+.section { padding: 100px 24px; }
+.section-dark { background: var(--bg-secondary); }
+.container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+.section-header {
+  text-align: center;
+  margin-bottom: 56px;
+}
+.section-header h2 {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.section-header p {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* ─── Code Preview ─── */
+.code-window {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  overflow: hidden;
+  box-shadow: var(--shadow), var(--shadow-glow);
+  max-width: 640px;
+  margin: -40px auto 0;
+}
+.code-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(22, 27, 34, 0.8);
+  border-bottom: 1px solid var(--border);
+}
+.code-dots { display: flex; gap: 6px; }
+.dot {
+  width: 12px; height: 12px;
+  border-radius: 50%;
+}
+.dot.red { background: #FF5F57; }
+.dot.yellow { background: #FEBC2E; }
+.dot.green { background: #28C840; }
+.code-filename {
+  flex: 1;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  font-family: var(--mono);
+}
+.code-content {
+  padding: 20px 24px;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.7;
+  overflow-x: auto;
+  color: var(--text-primary);
+}
+.c-comment { color: #6A737D; }
+.c-keyword { color: #FF79C6; font-weight: 600; }
+.c-id { color: #79B8FF; }
+.c-prop { color: #B392F0; }
+.c-color { color: #FFAB70; }
+.c-string { color: #9ECBFF; }
+.c-num { color: #79B8FF; }
+.c-trigger { color: #F97583; }
+
+/* ─── Playground ─── */
+.playground-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.toolbar-left, .toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.toolbar-label {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+.toolbar-select {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font);
+  font-size: 0.9rem;
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--transition);
+}
+.toolbar-select:focus { border-color: var(--accent); }
+.toolbar-btn {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+.toolbar-btn:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+.toolbar-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.playground-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--border);
+  box-shadow: var(--shadow);
+  min-height: 480px;
+}
+.playground-editor, .playground-canvas {
+  background: var(--bg-card);
+  display: flex;
+  flex-direction: column;
+}
+.editor-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.editor-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.canvas-dot { background: var(--success); }
+#fd-editor {
+  flex: 1;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.7;
+  padding: 16px 20px;
+  tab-size: 2;
+}
+#canvas-wrapper {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+#fd-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.canvas-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+.canvas-loading.hidden { display: none; }
+.loading-spinner {
+  width: 32px; height: 32px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ─── Features ─── */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+}
+.feature-card {
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  transition: all var(--transition);
+}
+.feature-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+  transform: translateY(-4px);
+}
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 16px;
+}
+.feature-card h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.feature-card p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* ─── Modes ─── */
+.modes-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 24px;
+}
+.mode-card {
+  padding: 36px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  transition: all var(--transition);
+}
+.mode-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+  transform: translateY(-4px);
+}
+.mode-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 100px;
+  background: rgba(108, 92, 231, 0.15);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+.mode-card h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.mode-card p {
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+.mode-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mode-list li {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  padding-left: 20px;
+  position: relative;
+}
+.mode-list li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* ─── Benchmarks ─── */
+.benchmark-table-wrap { overflow-x: auto; }
+.benchmark-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+.benchmark-table th, .benchmark-table td {
+  padding: 14px 20px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.benchmark-table thead th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.benchmark-table tbody tr { transition: background var(--transition); }
+.benchmark-table tbody tr:hover { background: var(--bg-card); }
+.ratio {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 100px;
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--success);
+  font-weight: 700;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+}
+.ratio-avg {
+  font-size: 1rem;
+  background: rgba(108, 92, 231, 0.15);
+  color: var(--accent);
+}
+.benchmark-table tfoot td {
+  border-top: 2px solid var(--border);
+  font-weight: 700;
+}
+
+/* ─── Architecture ─── */
+.arch-diagram {
+  margin-bottom: 48px;
+  overflow-x: auto;
+}
+.arch-ascii {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  padding: 32px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: var(--bg-primary);
+  text-align: center;
+  white-space: pre;
+  display: inline-block;
+  width: 100%;
+}
+.crate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+.crate-card {
+  padding: 24px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-primary);
+  transition: all var(--transition);
+}
+.crate-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+}
+.crate-card h4 {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.crate-card p {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+/* ─── Editor Table ─── */
+.editor-table-wrap { overflow-x: auto; }
+.editor-table {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-collapse: collapse;
+}
+.editor-table th, .editor-table td {
+  padding: 14px 20px;
+  text-align: center;
+  border-bottom: 1px solid var(--border);
+}
+.editor-table th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.editor-table td:first-child { text-align: left; font-weight: 500; }
+
+/* ─── CTA ─── */
+.cta-container {
+  text-align: center;
+  max-width: 600px;
+}
+.cta-container h2 {
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 12px;
+}
+.cta-container p {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  margin-bottom: 32px;
+}
+
+/* ─── Footer ─── */
+#footer {
+  border-top: 1px solid var(--border);
+  padding: 40px 24px;
+}
+.footer-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+}
+.footer-links {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.footer-links a {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  transition: color var(--transition);
+}
+.footer-links a:hover { color: var(--text-primary); }
+.footer-copy {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+.footer-copy a {
+  color: var(--text-secondary);
+}
+
+/* ─── Animations ─── */
+.animate-in {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ─── Responsive ─── */
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0; right: 0;
+    flex-direction: column;
+    background: rgba(13, 17, 23, 0.95);
+    backdrop-filter: blur(20px);
+    padding: 20px;
+    gap: 16px;
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-links.open { display: flex; }
+  .mobile-menu-btn { display: flex; }
+
+  .playground-split {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+  .playground-editor { min-height: 300px; }
+  .playground-canvas { min-height: 350px; }
+
+  .hero-stats { gap: 16px; }
+  .stat-divider { display: none; }
+
+  .features-grid { grid-template-columns: 1fr; }
+  .modes-grid { grid-template-columns: 1fr; }
+  .crate-grid { grid-template-columns: 1fr 1fr; }
+
+  #hero h1 { font-size: 2.2rem; }
+  .hero-sub { font-size: 1rem; }
+}
+
+@media (max-width: 480px) {
+  .crate-grid { grid-template-columns: 1fr; }
+  .section { padding: 60px 16px; }
+  .code-content { font-size: 0.75rem; padding: 16px; }
+}


### PR DESCRIPTION
## Summary

Adds a GitHub Pages landing site for Fast Draft with a **live WASM playground** and automatic deployment.

### New Files

- `site/index.html` — Single-page landing with hero, code preview, live playground, features, benchmarks, architecture, editor support, CTA, and footer
- `site/style.css` — Premium dark-theme design with glassmorphism, gradient accents, scroll animations, responsive layout
- `site/playground.js` — WASM playground controller with 3 pre-loaded examples, theme/sketchy toggles, real-time rendering
- `.github/workflows/pages.yml` — Auto-builds WASM via wasm-pack and deploys to GitHub Pages on push to main

### Site Sections

1. **Hero** — "Design as Code" tagline, stats bar (5×, 6.5×, 331), CTA buttons
2. **Code Preview** — Syntax-highlighted FD code snippet
3. **Live Playground** — Split-pane: textarea editor ↔ WASM canvas, 3 examples, theme/sketchy toggles
4. **Why Fast Draft** — 6 feature cards
5. **Two Modes** — Code Mode vs Canvas Mode comparison
6. **The Numbers** — 11-row benchmark table (FD vs Excalidraw, avg 6.5× smaller)
7. **Architecture** — ASCII diagram + 5 crate cards
8. **Editor Support** — 6-editor comparison table
9. **CTA + Footer**

### Verification

- ✅ WASM builds successfully via `wasm-pack`
- ✅ Playground renders shapes, supports live editing, theme toggle, sketchy mode
- ✅ All sections render correctly on desktop
- ✅ Responsive layout verified at mobile breakpoints
- ✅ Landing page design verified via browser screenshots