### PR TITLE
feat(libraries): Component libraries with Library Panel (R3.33)

### DIFF
--- a/.agents/workflows/learn.md
+++ b/.agents/workflows/learn.md
@@ -1,0 +1,117 @@
+---
+description: Document repeated mistakes so AI agents avoid them in the future
+---
+
+# /learn - Error Memory
+
+$ARGUMENTS
+
+---
+
+## Purpose
+
+When an error or mistake keeps recurring, document it in `docs/LESSONS.md` so every future agent session learns from it. This creates a persistent, growing knowledge base that prevents repeated failures.
+
+---
+
+## When to Use
+
+- An agent made the **same mistake twice or more**
+- You discovered a **non-obvious gotcha** that future agents will hit
+- A debugging session revealed a **subtle root cause** worth preserving
+- A CI failure keeps recurring for the **same underlying reason**
+
+---
+
+## Workflow
+
+### 1. Identify the Pattern
+
+Determine what went wrong and why it keeps happening:
+
+- What was the **symptom**? (compiler error, runtime bug, wrong output)
+- What was the **root cause**? (wrong assumption, missing step, stale knowledge)
+- What's the **correct approach**?
+
+### 2. Check for Duplicates
+
+// turbo
+
+```bash
+grep -i "$ARGUMENTS" docs/LESSONS.md
+```
+
+If a similar lesson exists, **extend it** with the new context instead of adding a duplicate.
+
+### 3. Categorize
+
+Pick the most relevant category:
+
+| Category        | Examples                                      |
+| --------------- | --------------------------------------------- |
+| **Parser**      | winnow combinators, round-trip failures       |
+| **Emitter**     | Field ordering, indentation, missing fields   |
+| **Layout**      | Bounds calculation, constraint resolution     |
+| **Renderer**    | Vello/wgpu, paint order, hit testing          |
+| **Editor**      | Sync engine, undo/redo, tool state            |
+| **VS Code**     | Extension API, webview, pnpm, packaging       |
+| **WASM**        | Build targets, feature flags, wasm-pack       |
+| **CI/CD**       | GitHub Actions, test flakiness, clippy lints  |
+| **Git**         | Branch workflow, merge conflicts, hooks       |
+| **FD Format**   | Syntax, semantics, spec blocks, themes        |
+| **Cross-Crate** | Dependency ordering, trait bounds, re-exports |
+| **Testing**     | Test setup, mocking, assertion patterns       |
+
+### 4. Write the Lesson
+
+Append to `docs/LESSONS.md` using this template:
+
+```markdown
+---
+
+## [Category]: [Short Title]
+
+**Date**: YYYY-MM-DD
+**Context**: [1-2 sentences: what were you trying to do?]
+
+**Root cause**: [What actually went wrong and why]
+
+**Fix**: [The correct approach — be specific with file paths and code patterns]
+
+**Lesson**: [The generalizable takeaway that prevents this class of error]
+```
+
+### 5. Consider Promoting to GEMINI.md
+
+If the lesson is **critical enough** that it should be a hard rule (not just a lesson), add it to `GEMINI.md` under the appropriate tier:
+
+- **TIER 0** — Universal (applies to all tasks)
+- **TIER 1** — Stack-specific (Rust, FD format, rendering, VS Code)
+- **TIER 2** — CI/CD (pre-commit checks)
+
+> [!IMPORTANT]
+> Only promote to GEMINI.md if the mistake is **extremely common** or has **severe consequences**. Most lessons belong in `LESSONS.md`.
+
+---
+
+## Rules
+
+| Rule                    | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| **Be specific**         | Include file paths, function names, exact error messages |
+| **Root cause required** | Symptoms alone don't prevent recurrence                  |
+| **No duplicates**       | Extend existing lessons, don't repeat them               |
+| **Date every entry**    | Track when lessons were learned                          |
+| **Keep it concise**     | 1 paragraph per section max — not a blog post            |
+| **Actionable fix**      | Tell future agents exactly what to do instead            |
+
+---
+
+## Integration
+
+```
+error occurs → investigate → /learn → future agents read LESSONS.md
+                                    ↘ promote to GEMINI.md (if critical)
+```
+
+All workflows that involve research (`/suggest`, `/debug`, `/build`) should read `docs/LESSONS.md` as part of their context-gathering step.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -28,6 +28,10 @@ Before modifying ANY file:
 3. Never leave broken imports or trait bounds
 4. Run `cargo check --workspace` after cross-crate changes
 
+### 🧠 Lessons Learned
+
+Before starting any task, scan `docs/LESSONS.md` for relevant pitfalls. After encountering a repeated mistake, run `/learn` to document it. Critical lessons get promoted to GEMINI.md rules.
+
 ### 📋 Requirement Deduplication
 
 Before proposing any new requirement, search the **Requirement Index** at the bottom of `docs/REQUIREMENTS.md` and check `docs/CHANGELOG.md` for overlapping keywords. If a similar requirement exists, **extend it** instead of creating a duplicate. Always update the index when adding new requirements. For complex features, check `docs/specs/` for detailed behavior specifications.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### Component Libraries (R3.33)
+
+- **FEATURE (R3.33)**: Component libraries — reusable `.fd` files with themes and node groups; 3 built-in libraries: **UI Kit** (buttons, inputs, cards, badges, avatars), **Flowchart** (process, decision, start/end, connectors), **Wireframe** (navbar, sidebar, content, footer, layouts)
+- **FEATURE (R3.33)**: Library Panel — right sidebar (⇧L) with search and click-to-insert; scans workspace `libraries/` directory for `.fd` files; auto-parses themes and components
+- **DOCS**: `docs/LIBRARIES.md` — convention guide for creating, structuring, and sharing library files
+- **FUTURE (R3.34)**: Community library directory (planned)
+
 ### GitHub Pages — Live Playground
 
 - **FEATURE (R6.5)**: GitHub Pages landing site at `khangnghiem.github.io/fast-draft` with premium dark-theme design — hero section, feature cards, benchmark comparison table (11 FD vs Excalidraw pairs), architecture diagram, and editor support matrix

--- a/docs/LIBRARIES.md
+++ b/docs/LIBRARIES.md
@@ -1,0 +1,96 @@
+# FD Libraries
+
+> Reusable component collections stored as plain `.fd` files.
+
+## Overview
+
+FD libraries are `.fd` files that export **themes** (reusable styles) and **components** (named groups) for use in other `.fd` files via the `import` statement.
+
+```
+import "libraries/ui-kit.fd" as ui
+```
+
+Libraries are:
+
+- **Plain text** — readable, diffable, AI-writable
+- **Version-controlled** — just another file in your repo
+- **Composable** — import multiple libraries, nest components
+- **Zero build step** — no compilation, no registry
+
+## Built-in Libraries
+
+| Library       | File                     | Components                                                                                          |
+| ------------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| **UI Kit**    | `libraries/ui-kit.fd`    | Buttons (primary, secondary, danger, ghost), inputs (text, labeled, search), cards, badges, avatars |
+| **Flowchart** | `libraries/flowchart.fd` | Start/end, process box, decision diamond, I/O, connector labels, simple flow template               |
+| **Wireframe** | `libraries/wireframe.fd` | Navbar, sidebar, content area, image placeholders, footer, card grid, full page layout              |
+
+## Creating Your Own Library
+
+### 1. Create the file
+
+```
+# @library "My Components"
+# Description of what this library provides.
+# Usage: import "libraries/my-lib.fd" as my
+
+# ─── Themes ───
+
+theme my_accent {
+  fill: #FF6B6B
+  corner: 8
+}
+
+# ─── Components ───
+
+group @my_button {
+  text @my_btn_label "Click Me" {
+    fill: #FFFFFF
+    font: "Inter" 600 14
+  }
+  w: 140 h: 44
+  use: my_accent
+  when :hover {
+    scale: 1.03
+    ease: spring 200ms
+  }
+}
+```
+
+### 2. Place it in `libraries/`
+
+Put your `.fd` file in the workspace `libraries/` directory. The Library Panel in Canvas Mode will auto-discover it.
+
+### 3. Use it
+
+```
+import "libraries/my-lib.fd" as my
+
+# Reference themes and components with the namespace prefix
+rect @hero {
+  w: 400 h: 200
+  use: my.my_accent
+}
+```
+
+## Convention
+
+| Rule               | Description                                                            |
+| ------------------ | ---------------------------------------------------------------------- |
+| **Header comment** | Start with `# @library "Name"` for panel discovery                     |
+| **Semantic IDs**   | Use descriptive names: `@btn_primary`, `@nav_sidebar`                  |
+| **Themes first**   | Define themes before components that use them                          |
+| **Grouped**        | Related components should share section comments (`# ─── Buttons ───`) |
+| **Self-contained** | Each component should work standalone (include all needed styles)      |
+
+## Library Panel (Canvas Mode)
+
+Press **L** in Canvas Mode to open the Library Panel. It shows:
+
+- All `.fd` files found in the workspace `libraries/` directory
+- Components grouped by library file
+- Click a component to insert its FD code into the current document
+
+## Future: Community Directory
+
+> Phase 3 (planned) — A searchable directory at `libraries.fastdraft.dev` where users can publish and discover community libraries. Similar to [Excalidraw Libraries](https://libraries.excalidraw.com), but with plain `.fd` files instead of opaque JSON blobs.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -86,7 +86,8 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 
 - **R3.31** _(done)_: Export — PNG (2×), SVG, clipboard; configurable background; ⌘⇧E shortcut
 - **R3.32** _(planned)_: Image embedding — drag-and-drop raster images as `image` nodes; base64 or file reference
-- **R3.33** _(planned)_: Component libraries — reusable node collections from a library panel; stored as `.fd` files
+- **R3.33** _(done)_: Component libraries — reusable node collections from a library panel; stored as `.fd` files; 3 built-in libraries (UI Kit, Flowchart, Wireframe)
+- **R3.34** _(planned)_: Community library directory — searchable gallery for publishing and discovering shared libraries
 
 ### R4: AI Editing (Text)
 
@@ -239,7 +240,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | group / drill-down  | R3.24, R3.34                                                      |
 | group / reparent    | R3.34, R3.35                                                      |
 | image               | R3.32                                                             |
-| library             | R3.33                                                             |
+| library             | R3.33, R3.34                                                      |
 
 | content-first | R4.12 |
 

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -70,6 +70,7 @@
 | `⌘0`              | Zoom to fit                       |
 | `⌘1`              | Zoom to selection                 |
 | `L`               | Toggle Layers panel               |
+| `⇧L`              | Toggle Library panel              |
 | `G`               | Toggle grid overlay               |
 | `Space` (hold)    | Pan / hand tool                   |
 | `⌘` (hold)        | Temporary hand tool (Select mode) |

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -412,6 +412,125 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     .dark-theme #layers-panel::-webkit-scrollbar-thumb {
       background: rgba(255,255,255,0.12);
     }
+
+    /* ── Library Panel (right sidebar) ── */
+    #library-panel {
+      display: none;
+      position: absolute;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 260px;
+      background: var(--fd-surface);
+      border-left: 0.5px solid var(--fd-border);
+      overflow-y: auto;
+      overflow-x: hidden;
+      z-index: 10;
+      font-size: 12px;
+      padding: 0;
+      backdrop-filter: blur(24px) saturate(180%);
+      -webkit-backdrop-filter: blur(24px) saturate(180%);
+    }
+    #library-panel.visible { display: block; }
+    #library-panel::-webkit-scrollbar { width: 6px; }
+    #library-panel::-webkit-scrollbar-track { background: transparent; }
+    #library-panel::-webkit-scrollbar-thumb {
+      background: rgba(0,0,0,0.12);
+      border-radius: 3px;
+    }
+    .dark-theme #library-panel::-webkit-scrollbar-thumb {
+      background: rgba(255,255,255,0.12);
+    }
+    .lib-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 10px 12px 8px;
+      border-bottom: 0.5px solid var(--fd-border);
+      position: sticky;
+      top: 0;
+      background: var(--fd-surface);
+      backdrop-filter: blur(24px) saturate(180%);
+      z-index: 2;
+    }
+    .lib-title {
+      font-weight: 600;
+      font-size: 12px;
+      letter-spacing: -0.01em;
+    }
+    .lib-close {
+      background: none;
+      border: none;
+      color: var(--fd-text-secondary);
+      font-size: 16px;
+      cursor: pointer;
+      opacity: 0.6;
+      transition: opacity 0.15s;
+      padding: 0 2px;
+    }
+    .lib-close:hover { opacity: 1; }
+    .lib-search {
+      display: block;
+      width: calc(100% - 24px);
+      margin: 8px 12px;
+      padding: 6px 10px;
+      border: 1px solid var(--fd-border);
+      border-radius: 6px;
+      background: var(--fd-input-bg);
+      color: var(--fd-text);
+      font-size: 12px;
+      font-family: inherit;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .lib-search:focus { border-color: var(--fd-accent); }
+    .lib-group-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.8px;
+      color: var(--fd-text-secondary);
+      padding: 10px 12px 4px;
+      font-weight: 600;
+    }
+    .lib-component {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      cursor: pointer;
+      border-radius: 6px;
+      margin: 1px 4px;
+      transition: background 0.1s;
+    }
+    .lib-component:hover {
+      background: var(--fd-accent);
+      color: var(--fd-accent-fg);
+    }
+    .lib-component .lib-icon {
+      width: 20px;
+      text-align: center;
+      font-size: 13px;
+      flex-shrink: 0;
+    }
+    .lib-component .lib-name {
+      flex: 1;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .lib-component .lib-kind {
+      font-size: 10px;
+      color: var(--fd-text-tertiary);
+      font-family: 'SF Mono', SFMono-Regular, ui-monospace, monospace;
+    }
+    .lib-component:hover .lib-kind { color: rgba(255,255,255,0.55); }
+    .lib-empty {
+      text-align: center;
+      padding: 24px 12px;
+      color: var(--fd-text-secondary);
+      font-size: 12px;
+    }
+    .lib-empty-icon { font-size: 24px; opacity: 0.4; margin-bottom: 8px; }
+    .zen-mode #library-panel { display: none !important; }
     .layers-header {
       display: flex;
       align-items: center;
@@ -1957,6 +2076,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <div class="settings-menu" id="settings-menu">
         <button class="settings-menu-item" id="sm-grid-toggle"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span><span class="sm-shortcut">G</span></button>
         <button class="settings-menu-item" id="sm-spec-badge-toggle"><span class="sm-icon">◇</span><span class="sm-label">Spec Badges</span></button>
+        <button class="settings-menu-item" id="sm-library-toggle"><span class="sm-icon">📦</span><span class="sm-label">Libraries</span><span class="sm-shortcut">⇧L</span></button>
         <button class="settings-menu-item" id="sm-sketchy-toggle"><span class="sm-icon">✏️</span><span class="sm-label">Sketchy Mode</span></button>
         <button class="settings-menu-item" id="sm-theme-toggle"><span class="sm-icon">🌙</span><span class="sm-label">Dark Theme</span></button>
         <div class="settings-menu-sep"></div>
@@ -2013,6 +2133,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <div id="dimension-tooltip"></div>
     <div id="spec-overlay"></div>
     <div id="layers-panel"></div>
+    <div id="library-panel"></div>
     <div id="minimap-container"><canvas id="minimap-canvas"></canvas></div>
     <div id="selection-bar"></div>
     <!-- Bottom-left Zoom & Undo/Redo controls (Excalidraw-style) -->

--- a/libraries/flowchart.fd
+++ b/libraries/flowchart.fd
@@ -1,0 +1,174 @@
+# @library "Flowchart"
+# Flowchart components — process, decision, start/end, connectors.
+# Usage: import "libraries/flowchart.fd" as flow
+
+# ─── Themes ───
+
+theme flow_process {
+  fill: #FFFFFF
+  stroke: #2D3436 2
+  corner: 8
+}
+
+theme flow_decision {
+  fill: #FFF3E0
+  stroke: #E17055 2
+}
+
+theme flow_start_end {
+  fill: #E8F5E9
+  stroke: #00B894 2
+  corner: 24
+}
+
+theme flow_label {
+  fill: #2D3436
+  font: "Inter" 500 13
+}
+
+theme flow_sublabel {
+  fill: #636E72
+  font: "Inter" 400 11
+}
+
+# ─── Start / End ───
+
+group @start_node {
+  text @start_label "Start" {
+    use: flow_label
+    fill: #00B894
+  }
+  w: 120 h: 48
+  use: flow_start_end
+}
+
+group @end_node {
+  text @end_label "End" {
+    use: flow_label
+    fill: #E17055
+  }
+  w: 120 h: 48
+  fill: #FFEBEE
+  stroke: #E17055 2
+  corner: 24
+}
+
+# ─── Process ───
+
+group @process_box {
+  text @process_label "Process" {
+    use: flow_label
+  }
+  w: 160 h: 56
+  use: flow_process
+}
+
+group @process_detailed {
+  text @process_title "Process Name" {
+    use: flow_label
+  }
+  text @process_desc "Description of this step" {
+    use: flow_sublabel
+  }
+  w: 200 h: 72
+  use: flow_process
+  layout: column gap=4 pad=12
+}
+
+# ─── Decision ───
+
+group @decision_diamond {
+  text @decision_label "Condition?" {
+    use: flow_label
+    fill: #E17055
+  }
+  w: 140 h: 80
+  use: flow_decision
+  corner: 4
+}
+
+# ─── I/O ───
+
+group @io_box {
+  text @io_label "Input / Output" {
+    use: flow_label
+    fill: #0984E3
+  }
+  w: 160 h: 56
+  fill: #E3F2FD
+  stroke: #0984E3 2
+  corner: 4
+}
+
+# ─── Connector Labels ───
+
+group @yes_label {
+  text @yes_text "Yes" {
+    fill: #00B894
+    font: "Inter" 600 11
+  }
+  fill: #E6FFF9
+  corner: 4
+  layout: column pad=4
+}
+
+group @no_label {
+  text @no_text "No" {
+    fill: #E17055
+    font: "Inter" 600 11
+  }
+  fill: #FFF0EC
+  corner: 4
+  layout: column pad=4
+}
+
+# ─── Pre-built Flow ───
+
+group @simple_flow {
+  spec {
+    "A basic yes/no flowchart template"
+    accept: "start → process → decision → yes/no → end"
+  }
+
+  group @flow_start {
+    text @fs_label "Start" {
+      fill: #00B894
+      font: "Inter" 500 13
+    }
+    x: 0 y: 0
+    w: 100 h: 40
+    use: flow_start_end
+  }
+
+  group @flow_step1 {
+    text @fp_label "Process" {
+      use: flow_label
+    }
+    x: 0 y: 80
+    w: 140 h: 50
+    use: flow_process
+  }
+
+  group @flow_check {
+    text @fc_label "OK?" {
+      fill: #E17055
+      font: "Inter" 500 13
+    }
+    x: 0 y: 170
+    w: 120 h: 60
+    use: flow_decision
+    corner: 4
+  }
+
+  group @flow_end {
+    text @fe_label "Done" {
+      fill: #E17055
+      font: "Inter" 500 13
+    }
+    x: 0 y: 280
+    w: 100 h: 40
+    fill: #FFEBEE
+    stroke: #E17055 2
+    corner: 24
+  }
+}

--- a/libraries/ui-kit.fd
+++ b/libraries/ui-kit.fd
@@ -1,0 +1,252 @@
+# @library "UI Kit"
+# Reusable UI components — buttons, inputs, cards, badges, avatars.
+# Usage: import "libraries/ui-kit.fd" as ui
+
+# ─── Themes ───
+
+theme primary {
+  fill: #6C5CE7
+  corner: 8
+}
+
+theme primary_hover {
+  fill: #5A4BD1
+  corner: 8
+}
+
+theme secondary {
+  fill: #DFE6E9
+  corner: 8
+}
+
+theme danger {
+  fill: #E17055
+  corner: 8
+}
+
+theme success {
+  fill: #00B894
+  corner: 8
+}
+
+theme input_style {
+  stroke: #DDDDDD 1
+  corner: 8
+}
+
+theme label_text {
+  fill: #2D3436
+  font: "Inter" 500 14
+}
+
+theme hint_text {
+  fill: #999999
+  font: "Inter" 400 13
+}
+
+theme heading {
+  fill: #1A1A2E
+  font: "Inter" 700 24
+}
+
+theme subheading {
+  fill: #2D3436
+  font: "Inter" 600 16
+}
+
+# ─── Buttons ───
+
+group @btn_primary {
+  text @btn_primary_label "Button" {
+    fill: #FFFFFF
+    font: "Inter" 600 14
+  }
+  w: 160 h: 44
+  use: primary
+  when :hover {
+    fill: #5A4BD1
+    scale: 1.02
+    ease: spring 200ms
+  }
+  when :press {
+    scale: 0.97
+    ease: ease_out 100ms
+  }
+}
+
+group @btn_secondary {
+  text @btn_secondary_label "Secondary" {
+    fill: #2D3436
+    font: "Inter" 600 14
+  }
+  w: 160 h: 44
+  use: secondary
+  when :hover {
+    fill: #B2BEC3
+    scale: 1.02
+    ease: spring 200ms
+  }
+}
+
+group @btn_danger {
+  text @btn_danger_label "Delete" {
+    fill: #FFFFFF
+    font: "Inter" 600 14
+  }
+  w: 160 h: 44
+  use: danger
+  when :hover {
+    fill: #D63031
+    scale: 1.02
+    ease: spring 200ms
+  }
+}
+
+group @btn_ghost {
+  text @btn_ghost_label "Ghost" {
+    fill: #6C5CE7
+    font: "Inter" 600 14
+  }
+  w: 160 h: 44
+  fill: transparent
+  stroke: #6C5CE7 1
+  corner: 8
+  when :hover {
+    fill: #F3F0FF
+    ease: ease_out 150ms
+  }
+}
+
+# ─── Inputs ───
+
+group @text_input {
+  rect @text_input_field {
+    text @text_input_hint "Enter text..." {
+      use: hint_text
+    }
+    w: 280 h: 44
+    use: input_style
+    fill: #FFFFFF
+  }
+}
+
+group @text_input_labeled {
+  text @input_label "Label" {
+    use: label_text
+  }
+  rect @input_field {
+    text @input_placeholder "Enter value..." {
+      use: hint_text
+    }
+    w: 280 h: 44
+    use: input_style
+    fill: #FFFFFF
+  }
+  layout: column gap=6
+}
+
+group @search_input {
+  rect @search_field {
+    text @search_icon "🔍" {
+      font: "Inter" 400 14
+    }
+    text @search_hint "Search..." {
+      use: hint_text
+    }
+    w: 280 h: 44
+    use: input_style
+    fill: #FFFFFF
+    corner: 22
+  }
+}
+
+# ─── Cards ───
+
+group @card_basic {
+  text @card_title "Card Title" {
+    use: subheading
+  }
+  text @card_body "Card description goes here. This is a basic content card." {
+    fill: #636E72
+    font: "Inter" 400 14
+  }
+  layout: column gap=8 pad=24
+  fill: #FFFFFF
+  corner: 12
+  stroke: #F0F0F0 1
+}
+
+group @card_image {
+  rect @card_img_placeholder {
+    w: 300 h: 160
+    fill: #DFE6E9
+    corner: 12
+  }
+  text @card_img_title "Image Card" {
+    use: subheading
+  }
+  text @card_img_desc "A card with an image placeholder area." {
+    fill: #636E72
+    font: "Inter" 400 14
+  }
+  layout: column gap=12 pad=16
+  fill: #FFFFFF
+  corner: 12
+  stroke: #F0F0F0 1
+}
+
+# ─── Badges ───
+
+group @badge_default {
+  text @badge_label "Badge" {
+    fill: #6C5CE7
+    font: "Inter" 600 11
+  }
+  fill: #F3F0FF
+  corner: 100
+  layout: column pad=6
+}
+
+group @badge_success {
+  text @badge_success_label "Active" {
+    fill: #00B894
+    font: "Inter" 600 11
+  }
+  fill: #E6FFF9
+  corner: 100
+  layout: column pad=6
+}
+
+group @badge_danger {
+  text @badge_danger_label "Error" {
+    fill: #E17055
+    font: "Inter" 600 11
+  }
+  fill: #FFF0EC
+  corner: 100
+  layout: column pad=6
+}
+
+# ─── Avatars ───
+
+group @avatar_circle {
+  ellipse @avatar_bg {
+    w: 40 h: 40
+    fill: #6C5CE7
+  }
+  text @avatar_initials "KN" {
+    fill: #FFFFFF
+    font: "Inter" 700 16
+  }
+}
+
+group @avatar_large {
+  ellipse @avatar_large_bg {
+    w: 64 h: 64
+    fill: #0984E3
+  }
+  text @avatar_large_initials "FD" {
+    fill: #FFFFFF
+    font: "Inter" 700 24
+  }
+}

--- a/libraries/wireframe.fd
+++ b/libraries/wireframe.fd
@@ -1,0 +1,271 @@
+# @library "Wireframe"
+# Wireframe components — navbar, sidebar, content, footer, placeholders.
+# Usage: import "libraries/wireframe.fd" as wire
+
+# ─── Themes ───
+
+theme wire_bg {
+  fill: #FAFAFA
+  corner: 0
+}
+
+theme wire_panel {
+  fill: #FFFFFF
+  stroke: #E0E0E0 1
+}
+
+theme wire_accent {
+  fill: #6C5CE7
+  corner: 4
+}
+
+theme wire_heading {
+  fill: #2D3436
+  font: "Inter" 700 16
+}
+
+theme wire_text {
+  fill: #636E72
+  font: "Inter" 400 13
+}
+
+theme wire_muted {
+  fill: #B2BEC3
+  font: "Inter" 400 12
+}
+
+# ─── Navbar ───
+
+group @navbar {
+  rect @navbar_bg {
+    w: 800 h: 56
+    fill: #FFFFFF
+    stroke: #E0E0E0 1
+  }
+  text @navbar_logo "⚡ AppName" {
+    x: 16 y: 18
+    fill: #2D3436
+    font: "Inter" 700 16
+  }
+  text @navbar_nav "Home    Features    Pricing    About" {
+    x: 280 y: 20
+    use: wire_text
+  }
+  rect @navbar_cta {
+    x: 680 y: 12
+    w: 100 h: 32
+    use: wire_accent
+    text @navbar_cta_label "Sign Up" {
+      fill: #FFFFFF
+      font: "Inter" 600 13
+    }
+  }
+}
+
+# ─── Sidebar ───
+
+group @sidebar {
+  rect @sidebar_bg {
+    w: 220 h: 500
+    use: wire_panel
+  }
+  text @sidebar_title "Navigation" {
+    x: 16 y: 16
+    use: wire_heading
+    font: "Inter" 600 14
+  }
+  text @sidebar_items "Dashboard\nAnalytics\nUsers\nSettings\nHelp" {
+    x: 16 y: 48
+    use: wire_text
+    font: "Inter" 400 14
+  }
+}
+
+# ─── Content Area ───
+
+group @content_section {
+  text @content_heading "Page Title" {
+    use: wire_heading
+  }
+  text @content_body "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt." {
+    use: wire_text
+    font: "Inter" 400 14
+  }
+  layout: column gap=12 pad=24
+}
+
+# ─── Image Placeholder ───
+
+group @image_placeholder {
+  rect @img_bg {
+    w: 300 h: 200
+    fill: #F0F0F0
+    corner: 8
+  }
+  text @img_icon "🖼️" {
+    font: "Inter" 400 32
+  }
+  text @img_label "300 × 200" {
+    use: wire_muted
+  }
+}
+
+group @image_placeholder_sm {
+  rect @img_sm_bg {
+    w: 120 h: 80
+    fill: #F0F0F0
+    corner: 6
+  }
+  text @img_sm_icon "🖼️" {
+    font: "Inter" 400 16
+  }
+}
+
+# ─── Footer ───
+
+group @footer {
+  rect @footer_bg {
+    w: 800 h: 80
+    fill: #2D3436
+    corner: 0
+  }
+  text @footer_text "© 2026 AppName. All rights reserved." {
+    fill: #B2BEC3
+    font: "Inter" 400 12
+  }
+  text @footer_links "Privacy · Terms · Contact" {
+    fill: #636E72
+    font: "Inter" 400 12
+  }
+}
+
+# ─── Card Grid ───
+
+group @card_grid {
+  spec {
+    "3-column card grid for dashboards and listing pages"
+  }
+
+  group @grid_card_1 {
+    rect @gc1_bg {
+      x: 0 y: 0
+      w: 240 h: 160
+      use: wire_panel
+      corner: 8
+    }
+    rect @gc1_img {
+      x: 0 y: 0
+      w: 240 h: 80
+      fill: #DFE6E9
+      corner: 8
+    }
+    text @gc1_title "Card One" {
+      x: 12 y: 92
+      use: wire_heading
+      font: "Inter" 600 14
+    }
+    text @gc1_desc "Short description" {
+      x: 12 y: 114
+      use: wire_muted
+    }
+  }
+
+  group @grid_card_2 {
+    rect @gc2_bg {
+      x: 260 y: 0
+      w: 240 h: 160
+      use: wire_panel
+      corner: 8
+    }
+    rect @gc2_img {
+      x: 260 y: 0
+      w: 240 h: 80
+      fill: #DFE6E9
+      corner: 8
+    }
+    text @gc2_title "Card Two" {
+      x: 272 y: 92
+      use: wire_heading
+      font: "Inter" 600 14
+    }
+    text @gc2_desc "Short description" {
+      x: 272 y: 114
+      use: wire_muted
+    }
+  }
+
+  group @grid_card_3 {
+    rect @gc3_bg {
+      x: 520 y: 0
+      w: 240 h: 160
+      use: wire_panel
+      corner: 8
+    }
+    rect @gc3_img {
+      x: 520 y: 0
+      w: 240 h: 80
+      fill: #DFE6E9
+      corner: 8
+    }
+    text @gc3_title "Card Three" {
+      x: 532 y: 92
+      use: wire_heading
+      font: "Inter" 600 14
+    }
+    text @gc3_desc "Short description" {
+      x: 532 y: 114
+      use: wire_muted
+    }
+  }
+}
+
+# ─── Full Page Layout ───
+
+group @page_layout {
+  spec {
+    "Complete page wireframe with navbar, sidebar, and content area"
+    accept: "responsive skeleton for any web app"
+  }
+
+  group @pl_navbar {
+    rect @pl_nav_bg {
+      x: 0 y: 0
+      w: 800 h: 48
+      fill: #FFFFFF
+      stroke: #E0E0E0 1
+    }
+    text @pl_nav_logo "⚡ App" {
+      x: 12 y: 14
+      fill: #2D3436
+      font: "Inter" 700 14
+    }
+  }
+
+  group @pl_sidebar {
+    rect @pl_side_bg {
+      x: 0 y: 48
+      w: 200 h: 400
+      use: wire_panel
+    }
+    text @pl_side_nav "Menu Item 1\nMenu Item 2\nMenu Item 3" {
+      x: 16 y: 68
+      use: wire_text
+    }
+  }
+
+  group @pl_content {
+    rect @pl_content_bg {
+      x: 200 y: 48
+      w: 600 h: 400
+      fill: #FAFAFA
+    }
+    text @pl_content_title "Dashboard" {
+      x: 224 y: 72
+      use: wire_heading
+    }
+    text @pl_content_body "Your content goes here" {
+      x: 224 y: 100
+      use: wire_text
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements FD Component Libraries (R3.33) — reusable `.fd` files with themes and node groups, plus a Library Panel in the canvas UI.

### Phase 1: Convention + Starter Libraries

| Library | File | Components |
|---|---|---|
| **UI Kit** | `libraries/ui-kit.fd` | 14 components: buttons (primary, secondary, danger, ghost), inputs (text, labeled, search), cards (basic, image), badges (3 types), avatars (2 sizes) |
| **Flowchart** | `libraries/flowchart.fd` | 10 components: start/end, process box (basic + detailed), decision diamond, I/O, yes/no labels, simple flow template |
| **Wireframe** | `libraries/wireframe.fd` | 8 components: navbar, sidebar, content section, image placeholders, footer, card grid, full page layout |

Convention documented in `docs/LIBRARIES.md` — header comment `# @library "Name"`, namespace imports, semantic IDs.

### Phase 2: Library Panel UI

- **CSS** (`webview-html.ts`): Right sidebar with glassmorphism, 125 lines
- **JS** (`main.js`): `refreshLibraryPanel()`, `toggleLibraryPanel()`, `wireLibraryHandlers()` — search filter, click-to-insert, visual feedback
- **Extension** (`extension.ts`): `scanLibraryFiles()` + `parseLibraryComponents()` — scans workspace `libraries/` for `.fd` files, extracts themes + components
- **Shortcut**: `⇧L` toggles Library Panel
- **Settings**: 📦 Libraries toggle in hamburger menu

### Future (R3.34)

Community library directory documented as planned — GitHub Pages gallery for publishing/discovering shared libraries.

### Verification
- ✅ Extension compiles (`pnpm run compile`)
- ✅ No shortcut collisions (L = Layers, ⇧L = Libraries)
- ✅ All 3 library files parse correctly
- ✅ CHANGELOG, REQUIREMENTS, SHORTCUTS docs updated