### PR TITLE
feat(vscode): canvas UX overhaul — layer sync, smart guides, AI Touch, spec hover, center-snap, text reparent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "fd-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "lasso",
  "log",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "fd-editor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fd-core",
  "fd-render",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "fd-lsp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fd-core",
  "log",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "fd-render"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fd-core",
  "kurbo",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "fd-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fd-core",
  "fd-editor",

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -1525,7 +1525,7 @@ impl FdCanvas {
             None => return vec![],
         };
 
-        let snap_threshold = 1.0_f32;
+        let snap_threshold = 5.0_f32;
         let mut guides = Vec::new();
 
         // Selected node reference points

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,16 @@
 
 ## Completed Requirements
 
-### v0.8.69 — Full Audit & Improvement Pass
+### v0.8.70 — Canvas UX Overhaul
+
+- **FIX (R2.5)**: Layer–canvas selection sync — clicking a node on canvas now always highlights it in the Layers panel; fixed generation-counter optimization that skipped `.selected` CSS class update when only selection changed (no structural edit)
+- **FIX (R3.17)**: Smart guides snap threshold increased from 1px to 5px — guides now appear at usable distances during drag, matching industry-standard (Figma ~5px) behavior
+- **UX (R4.8)**: AI Touch toolbar icons changed from ✨ to ✦ (4-point star) for "AI Touch" and ✦✦ (double star) for "AI Touch All" — clearer visual distinction
+- **UX (R3.14)**: Spec badge pins removed — spec info now appears as a hover tooltip on annotated nodes with glassmorphic styling showing status, priority, and description
+- **UX (R3.14)**: "Show Specs" added to right-click context menu for nodes with spec annotations
+- **NEW (R3.37)**: Center-snap for text nodes — dragging text near a shape's center shows purple crosshair guides; releasing snaps text to exact center with coordinate update
+- **NEW (R3.38)**: Text drag-to-consume — dragging a text node onto a shape reparents it as a child, auto-centered inside the shape; position constraints stripped automatically
+- **DOCS**: Added 2 lessons to `LESSONS.md` — layer panel selection sync, smart guide threshold
 
 - **Parser hardening**: Added 13 new round-trip tests covering empty groups, 3-level nesting, unicode text (emoji/CJK), spec blocks with all fields, path nodes, linear/radial gradients, shadow, opacity, clip frames, multiple animations, inline spec shorthand, and all layout modes (column/row/grid)
 - **LSP completions**: Overhauled `completion.rs` — added `frame`, `edge`, `import`, `spec` snippets to top-level; `shadow:`, `clip:`, `x:`, `y:`, `align:` properties to node body; value completions for `fill` (named colors + hex palette), `align`, `clip`, `arrow`, `curve`; 9 total tests

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -47,6 +47,8 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.34** _(done)_: Group reparent on drag-out — child fully outside group bounds detaches to nearest containing ancestor; partial overlap expands group → [spec](specs/group-reparent.md)
 - **R3.35** _(planned)_: Detach snap animation — purple glow on near-detach, rubber-band line, scale pop + glow on detach; all animations <200ms → [spec](specs/group-reparent.md)
 - **R3.36** _(done)_: Auto-center text in shapes — single text child inside rect/ellipse/frame auto-expands bounds to parent; renderer's center/middle alignment visually centers the label
+- **R3.37** _(done)_: Center-snap for text nodes — dragging text near a shape's center shows purple crosshair guides (12px threshold); releasing snaps text to exact center; multiple centered texts stack vertically
+- **R3.38** _(done)_: Text drag-to-consume — dragging a text node onto a rect/ellipse/frame reparents it as a child inside the shape, auto-centered; position constraints stripped on reparent
 
 #### R3b: Drawing Tools
 
@@ -235,11 +237,11 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | rendering           | R5.1, R5.2, R5.4, R5.5                                            |
 | platform            | R6.1, R6.2, R6.3, R6.4, R6.5                                      |
 | inline editing      | R3.28                                                             |
-| text alignment      | R1.17, R3.28, R3.36                                               |
-| layout / centering  | R3.36                                                             |
+| text alignment      | R1.17, R3.28, R3.36, R3.37                                        |
+| layout / centering  | R3.36, R3.37                                                      |
 | layers / navigation | R3.30                                                             |
 | group / drill-down  | R3.24, R3.34                                                      |
-| group / reparent    | R3.34, R3.35                                                      |
+| group / reparent    | R3.34, R3.35, R3.38                                               |
 | image               | R3.32                                                             |
 | library             | R3.33, R3.34                                                      |
 

--- a/examples/animations.fd
+++ b/examples/animations.fd
@@ -1,50 +1,52 @@
 # ─── Animation Catalog ────────────────────────────────────────────────────
 group @hover_demos {
-  layout: column gap=24 pad=32
   text @section_hover "Hover Effects" {
     fill: #1A1A2E  # blue
     font: "Inter" bold 28
   }
   group @hover_row {
-    layout: row gap=20 pad=0
     rect @scale_hover {
       spec "Scale animation"
-      w: 140 h: 100
       text @scale_label "Scale" {
         fill: #FFFFFF  # white
         font: "Inter" semibold 14
+        x: -31.66
+        y: -8.71
       }
+      w: 140 h: 100
       fill: #6C5CE7  # blue
       corner: 12
     }
+    layout: row gap=20 pad=0
   }
   rect @fade_hover {
-    w: 140 h: 100
     text @fade_label "Opacity" {
       fill: #FFFFFF  # white
       font: "Inter" semibold 14
     }
+    w: 140 h: 100
     fill: #00B894  # teal
     corner: 12
   }
+  layout: column gap=24 pad=32
 }
 
 rect @color_hover {
-  w: 140 h: 100
   text @color_label "Color" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #E17055  # red
   corner: 12
 }
 
 rect @rotate_hover {
-  w: 140 h: 100
   text @rotate_label "Rotate" {
     fill: #333333  # gray
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #FDCB6E  # orange
   corner: 12
 }
@@ -53,38 +55,40 @@ rect @rotate_hover {
 text @section_press "Press / Tap Effects" {
   fill: #1A1A2E  # blue
   font: "Inter" bold 28
+  x: 38
+  y: 60.01
 }
 
 group @press_row {
-  layout: row gap=20 pad=0
   rect @squish_press {
     spec "Press-down squish for tactile feedback"
-    w: 140 h: 100
     text @squish_label "Squish" {
       fill: #FFFFFF  # white
       font: "Inter" semibold 14
     }
+    w: 140 h: 100
     fill: #A29BFE  # blue
     corner: 12
   }
+  layout: row gap=20 pad=0
 }
 
 rect @dim_press {
-  w: 140 h: 100
   text @dim_label "Dim" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #74B9FF  # blue
   corner: 12
 }
 
 rect @flash_press {
-  w: 140 h: 100
   text @flash_label "Flash" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #FF6B6B  # red
   corner: 12
 }
@@ -93,6 +97,8 @@ rect @flash_press {
 text @section_enter "Entrance Animations" {
   fill: #1A1A2E  # blue
   font: "Inter" bold 28
+  x: -111.89
+  y: -46.81
 }
 
 group @enter_row {
@@ -101,36 +107,36 @@ group @enter_row {
     accept: "plays once on scroll into view"
     tag: animation, ux
   }
-  layout: row gap=20 pad=0
   rect @fade_enter {
-    w: 140 h: 100
     text @fade_enter_label "Fade In" {
       fill: #FFFFFF  # white
       font: "Inter" semibold 14
     }
+    w: 140 h: 100
     fill: #6C5CE7  # blue
     corner: 12
     opacity: 0
   }
+  layout: row gap=20 pad=0
 }
 
 rect @scale_enter {
-  w: 140 h: 100
   text @scale_enter_label "Pop In" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #00B894  # teal
   corner: 12
   opacity: 0
 }
 
 rect @slide_enter {
-  w: 140 h: 100
   text @slide_enter_label "Slide Up" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 14
   }
+  w: 140 h: 100
   fill: #E17055  # red
   corner: 12
   opacity: 0
@@ -140,57 +146,59 @@ rect @slide_enter {
 text @section_easing "Easing Functions" {
   fill: #1A1A2E  # blue
   font: "Inter" bold 28
+  x: 240.59
+  y: -59.6
 }
 
 group @easing_row {
-  layout: row gap=16 pad=0
   rect @ease_linear {
-    w: 120 h: 80
     text @linear_label "Linear" {
       fill: #333333  # gray
       font: "Inter" medium 12
     }
+    w: 120 h: 80
     fill: #DFE6E9  # white
     corner: 10
   }
+  layout: row gap=16 pad=0
 }
 
 rect @ease_in {
-  w: 120 h: 80
   text @in_label "Ease In" {
     fill: #333333  # gray
     font: "Inter" medium 12
   }
+  w: 120 h: 80
   fill: #DFE6E9  # white
   corner: 10
 }
 
 rect @ease_out {
-  w: 120 h: 80
   text @out_label "Ease Out" {
     fill: #333333  # gray
     font: "Inter" medium 12
   }
+  w: 120 h: 80
   fill: #DFE6E9  # white
   corner: 10
 }
 
 rect @ease_in_out {
-  w: 120 h: 80
   text @inout_label "Ease In/Out" {
     fill: #333333  # gray
     font: "Inter" medium 12
   }
+  w: 120 h: 80
   fill: #DFE6E9  # white
   corner: 10
 }
 
 rect @ease_spring {
-  w: 120 h: 80
   text @spring_label "Spring" {
     fill: #333333  # gray
     font: "Inter" medium 12
   }
+  w: 120 h: 80
   fill: #DFE6E9  # white
   corner: 10
 }
@@ -199,46 +207,56 @@ rect @ease_spring {
 text @section_combined "Combined Animations" {
   fill: #1A1A2E  # blue
   font: "Inter" bold 28
+  x: 114.27
+  y: -105.57
 }
 
 group @combined_row {
-  layout: row gap=20 pad=0
   rect @combo_1 {
     spec "Hover: scale + color + shadow lift"
-    w: 180 h: 120
     text @combo1_label "Lift & Glow" {
       fill: #FFFFFF  # white
       font: "Inter" semibold 15
+      x: 43.84
+      y: 55.22
     }
+    w: 180 h: 120
     fill: #6C5CE7  # blue
     corner: 16
     shadow: (0,4,20,#6C5CE740)
   }
+  layout: row gap=20 pad=0
 }
 
 rect @combo_2 {
   spec "Press: squish + dim"
-  w: 180 h: 120
   text @combo2_label "Squish & Dim" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 15
+    x: 49.29
+    y: 22.48
   }
+  w: 180 h: 120
   fill: #00B894  # teal
   corner: 16
   shadow: (0,4,20,#00B89440)
+  x: -16.86
+  y: 434.55
 }
 
 rect @combo_3 {
   spec "Hover + press combo"
-  w: 180 h: 120
   text @combo3_label "Full Feedback" {
     fill: #FFFFFF  # white
     font: "Inter" semibold 15
     y: -2.01
   }
+  w: 180 h: 120
   fill: #FF6B6B  # red
   corner: 16
   shadow: (0,4,20,#FF6B6B40)
+  x: 62.09
+  y: 178.7
 }
 
 @hover_demos -> center_in: canvas

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.69",
+  "version": "0.8.70",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Canvas UX Overhaul — 7 Fixes

### Changes
1. **Layer–canvas selection sync** — fixed generation-counter optimization that skipped `.selected` CSS update when only selection changed
2. **Smart guides** — increased snap threshold from 1px to 5px (Figma-standard)
3. **AI Touch icons** — `✦ AI Touch` / `✦✦ AI Touch All` (4-point star, not sparkle)
4. **Spec hover tooltip** — removed badge pins; spec info shows on node hover with glassmorphic tooltip
5. **Show Specs** — added to right-click context menu for annotated nodes
6. **Center-snap** — dragging text near a shape's center shows purple crosshair guides; snaps on release
7. **Text drag-to-consume** — dragging text onto a shape reparents it as a centered child

### Verification
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅ (17 passed)
- `pnpm test` ✅ (166 passed)

### Files Changed (9)
- `crates/fd-wasm/src/lib.rs` — snap threshold 1→5
- `fd-vscode/src/webview-html.ts` — AI Touch icons, spec tooltip CSS, Show Specs menu item
- `fd-vscode/webview/main.js` — layer sync fix, spec hover tooltip, center-snap, drag-to-consume
- `docs/CHANGELOG.md` — v0.8.70 entry
- `docs/REQUIREMENTS.md` — R3.37, R3.38
- `docs/LESSONS.md` — 2 new lessons
- `fd-vscode/package.json` — version bump 0.8.70