### PR TITLE
fix(editor): fix group detach on drag out — chasing envelope bug

### DIFF
--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -796,6 +796,24 @@ impl FdCanvas {
         String::new()
     }
 
+    // ─── Detach Info API ─────────────────────────────────────────────────
+
+    /// Get last detach event info. Returns JSON:
+    /// `{"detached":true,"nodeId":"...","fromGroupId":"..."}` or `""` if none.
+    /// Clears the event after reading (one-shot).
+    pub fn get_last_detach_info(&mut self) -> String {
+        match self.engine.last_detach.take() {
+            Some((child_id, parent_id)) => {
+                format!(
+                    r#"{{"detached":true,"nodeId":"{}","fromGroupId":"{}"}}"#,
+                    child_id.as_str(),
+                    parent_id.as_str()
+                )
+            }
+            None => String::new(),
+        }
+    }
+
     // ─── Animation APIs ──────────────────────────────────────────────────
 
     /// Add an animation to a node by ID.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 ## Completed Requirements
 
+### v0.8.72 — Fix Group Detach on Drag Out
+
+- **BUG FIX (R3.34)**: Fixed "chasing envelope" bug — dragging a child incrementally outside a group now correctly detaches it. Previously, `expand_group_to_children` grew the parent to contain the moving child on every drag frame, making escape impossible. Fix: skip group expansion during continuous drag; only detach or keep in-place
+- **UX**: Snappy detach animation — teal glow ring (250ms pop) appears on the detached node when it leaves a group, giving visual feedback that reparenting occurred
+- **WASM**: New `get_last_detach_info()` API — returns `{detached, nodeId, fromGroupId}` one-shot event for JS animation trigger
+- **TESTING**: New `sync_incremental_drag_detaches_child` regression test — simulates 30 small moves proving detach works with real drag gestures; renamed `sync_move_partial_overlap_expands_group` → `sync_move_partial_overlap_keeps_child` (group no longer expands during drag)
+
 ### v0.8.71 — ✦ Renamify (Batch AI Rename)
 
 - **NEW (R4.20)**: ✦ Renamify — batch AI rename for anonymous node IDs (`@rect_1`, `@ellipse_3`, etc.) → semantic names (`@login_button`, `@hero_card`); toolbar button + command palette


### PR DESCRIPTION
## Fix: Group Detach on Drag Out — "Chasing Envelope" Bug

### Problem
Dragging a child node incrementally outside its parent group never detaches it. The group keeps expanding to contain the child on every drag frame, making it impossible for the child to escape.

### Root Cause
`expand_group_to_children()` was called on every `MoveNode` frame when there was partial overlap. This grew the parent bounds to include the dragged child, so on the next frame, the child was always inside the expanded group.

### Fix
Skip group expansion during continuous drag. Check child overlap against the parent's *current stored bounds* without expanding. When the child fully leaves the parent, it detaches. The group bounds remain stable — only the child moves.

### Changes
- **`sync.rs`**: `handle_child_group_relationship` no longer calls `expand_group_to_children` during drag
- **`sync.rs`**: Added `last_detach` event tracking for WASM API
- **`lib.rs`**: New `get_last_detach_info()` one-shot WASM API
- **`main.js`**: `playDetachAnimation()` — teal glow ring (250ms) on detach
- **`CHANGELOG.md`**: v0.8.72 entry

### Tests
- **New**: `sync_incremental_drag_detaches_child` — 30 small moves proving detach works
- **Updated**: `sync_move_partial_overlap_keeps_child` (was `_expands_group`)
- **All 264 workspace tests pass** ✅