### PR TITLE
feat(wasm): auto bring-forward on fresh click-select

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.74 — Auto Bring Forward on Select
+
+- **UX**: Clicking to select a node automatically brings it forward one z-level — reuses existing `bring_forward` from ⌘]; only triggers on fresh click-select (<5px movement), not on re-click of already-selected nodes or drag operations; prevents z-fighting by skipping if already selected
+
 ### v0.8.73 — Frosted Glass Tooltips
 
 - **UX**: Apple-style frosted glass tooltips on all 7 floating toolbar buttons — `backdrop-filter: blur(12px)`, glassmorphic pill with 400ms hover delay, monospace shortcut key badge; replaces ugly native `title` tooltips; hidden in collapsed mode and during click

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.73",
+  "version": "0.8.74",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Summary

Clicking to select a node on the FD canvas now automatically brings it forward one z-level, making it visually prominent. This reuses the existing `bring_forward` mutation from the ⌘] shortcut.

### How it works
In `handle_pointer_up` (WASM):
1. Snapshots the previous selection before processing pointer-up
2. After all selection logic (including drill-down), checks three conditions:
   - Was a clean click (<5px movement from pointer-down position)
   - Exactly one node is now selected
   - That node was **not** in the previous selection (fresh select)
3. If all conditions met: calls `bring_forward()` and flushes text to sync

### Safeguards
- **No z-fighting**: Re-clicking an already-selected node does NOT bring forward again
- **No drag interference**: Drag operations (≥5px movement) skip bring-forward entirely
- **No multi-select**: Only triggers for single-node click-select

### Test Results
- `cargo clippy` ✅ | `cargo fmt --check` ✅ | `cargo test` ✅ | `pnpm test` 188/188 ✅