### PR TITLE
feat(wasm,webview): ScreenBrush-style defaults for new shapes

### DIFF
--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -1463,7 +1463,7 @@ impl FdCanvas {
         let mut node = SceneNode::new(id, node_kind);
         node.constraints.push(Constraint::Position { x, y });
 
-        // Set a default fill for shapes
+        // ScreenBrush-style defaults: transparent fill + bezeled stroke
         if kind == "frame" {
             node.style.fill = Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0)));
             node.style.stroke = Some(Stroke {
@@ -1472,8 +1472,21 @@ impl FdCanvas {
                 cap: StrokeCap::Butt,
                 join: StrokeJoin::Miter,
             });
-        } else if kind != "text" {
-            node.style.fill = Some(Paint::Solid(Color::rgba(0.8, 0.8, 0.85, 1.0)));
+        } else if kind == "rect" {
+            node.style.stroke = Some(Stroke {
+                paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
+                width: 2.5,
+                cap: StrokeCap::Round,
+                join: StrokeJoin::Round,
+            });
+            node.style.corner_radius = Some(8.0);
+        } else if kind == "ellipse" {
+            node.style.stroke = Some(Stroke {
+                paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
+                width: 2.5,
+                cap: StrokeCap::Round,
+                join: StrokeJoin::Round,
+            });
         }
 
         let mutation = GraphMutation::AddNode {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.8.76 — ScreenBrush Default Styles
+
+- **UX**: New shapes default to ScreenBrush-style transparent fill + thick bezeled stroke (#333333, width 2.5, round caps/joins); rects also get 8px corner radius. Cascade: sticky defaults (per-tool) take priority → WASM fallbacks only when no sticky style exists. Hit-testing unaffected — uses bounding-box containment
+
 ### v0.8.75 — SVG Toolbar Icons
 
 - **UX**: Replaced all 7 Unicode glyph icons in floating toolbar with clean inline SVGs (18×18 viewBox, stroke-based, `currentColor`) — cursor arrow (Select), rounded rect (Rectangle), circle (Ellipse), pencil (Pen), diagonal arrow (Arrow), T-bar (Text), nested rects (Frame); fixes cross-platform rendering issues (⊞ displayed incorrectly on some systems)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.75",
+  "version": "0.8.76",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -98,8 +98,8 @@ let altCloneActive = false;
 // ─── Smart Defaults (Sticky Styles Per Tool) ─────────────────────────────
 /** Session-only style defaults per tool type (Excalidraw-style) */
 const toolDefaults = {
-  rect: { fill: "#4A90D9", stroke: "#333333", strokeWidth: 1, opacity: 1 },
-  ellipse: { fill: "#4A90D9", stroke: "#333333", strokeWidth: 1, opacity: 1 },
+  rect: { fill: "none", stroke: "#333333", strokeWidth: 2.5, opacity: 1 },
+  ellipse: { fill: "none", stroke: "#333333", strokeWidth: 2.5, opacity: 1 },
   pen: { stroke: "#333333", strokeWidth: 2, opacity: 1 },
   arrow: { stroke: "#333333", strokeWidth: 2, opacity: 1 },
   text: { fill: "#333333", fontSize: 16, opacity: 1 },


### PR DESCRIPTION
## Summary

Changes default style for newly created rect and ellipse shapes from solid gray fill to ScreenBrush-style transparent background with thick bezeled borders.

### Defaults cascade
1. **Sticky defaults** (JS `toolDefaults` per-tool): Override if user has previously edited a style
2. **WASM fallback** (`create_node_at`): Used when no sticky style exists

### New defaults
| Shape | Fill | Stroke | Corner |
|---|---|---|---|
| Rect | transparent | #333333 w:2.5, round | 8px |
| Ellipse | transparent | #333333 w:2.5, round | — |
| Frame | unchanged | unchanged | — |

### Hit-testing
Transparent shapes remain selectable — hit-test uses bounding-box containment (`b.contains(px, py)`), not fill detection.

### Test Results
`cargo clippy` ✅ | `cargo fmt` ✅ | `cargo test` ✅ | `pnpm test` 188/188 ✅