### PR TITLE
fix(ux): accumulate last_detach to prevent truncation on steady-state drag frames

### DIFF
--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -135,8 +135,11 @@ impl SyncEngine {
                     }
                     // Handle group relationship: expand if partially outside,
                     // detach (reparent) if fully outside the parent group.
-                    self.last_detach =
-                        handle_child_group_relationship(&mut self.graph, idx, &mut self.bounds);
+                    if let Some(info) =
+                        handle_child_group_relationship(&mut self.graph, idx, &mut self.bounds)
+                    {
+                        self.last_detach = Some(info);
+                    }
                 }
             }
             GraphMutation::ResizeNode { id, width, height } => {


### PR DESCRIPTION
Fixes a persistent bug where text nodes pulled out of groups didn't detach in the UI.

The `last_detach` structural response from the WASM bridge was correctly triggered on the exact frame the user crossed the bounds, but it was being unconditionally overwritten with `None` on all subsequent continuous drag frames ("steady-state drag frames"). This caused a truncation of the detach state before the user released the mouse (`pointerup`), resulting in the UI incorrectly showing the node as still group-attached.

Now accumulating `last_detach` using `.take()` consumption. All `cargo test` and `pnpm test` pass. Documented in `/learn`.