### PR TITLE
fix(sync): allow text children to detach from rect/ellipse shape parents

### DIFF
--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -487,12 +487,18 @@ fn handle_child_group_relationship(
 ) -> Option<(fd_core::id::NodeId, fd_core::id::NodeId)> {
     let parent_idx = graph.parent(child_idx)?;
 
-    // Only act on group/frame parents
-    let is_group_parent = matches!(
-        &graph.graph[parent_idx].kind,
-        NodeKind::Group { .. } | NodeKind::Frame { .. }
-    );
-    if !is_group_parent {
+    let parent_kind = &graph.graph[parent_idx].kind;
+    let child_kind = &graph.graph[child_idx].kind;
+
+    // Only act on container parents (Group/Frame) or shape parents (Rect/Ellipse) if the child is Text.
+    let is_container_parent = match parent_kind {
+        NodeKind::Group { .. } | NodeKind::Frame { .. } => true,
+        NodeKind::Rect { .. } | NodeKind::Ellipse { .. } => {
+            matches!(child_kind, NodeKind::Text { .. })
+        }
+        _ => false,
+    };
+    if !is_container_parent {
         return None;
     }
 


### PR DESCRIPTION
Fixes an issue where Text nodes parented to Rect or Ellipse shapes could not be detached via drag-and-drop.

The `handle_child_group_relationship` logic previously only checked if the parent was a `Group` or `Frame`. However, due to the drag-to-consume feature, Text nodes are frequently parented directly to `Rect` and `Ellipse` shapes.

This PR updates the check to explicitly allow `Text` children to detach from `Rect` and `Ellipse` parents as well, resolving the "snap back" behavior observed in browser E2E tests.