### PR TITLE
refactor: replace _anon_N with type-prefixed _kind_N anonymous IDs

### DIFF
--- a/crates/fd-core/src/id.rs
+++ b/crates/fd-core/src/id.rs
@@ -23,8 +23,9 @@ impl NodeId {
     }
 
     /// Generate a unique anonymous ID (for nodes without explicit @id).
-    pub fn anonymous() -> Self {
-        Self::with_prefix("_anon")
+    /// Uses the node kind as prefix: `_rect_0`, `_text_1`, `_group_2`, etc.
+    pub fn anonymous(kind: &str) -> Self {
+        Self::with_prefix(&format!("_{kind}"))
     }
 
     /// Generate a unique ID with a type prefix (e.g. `rect_1`, `ellipse_2`).
@@ -75,8 +76,8 @@ mod tests {
 
     #[test]
     fn anonymous_ids_are_unique() {
-        let a = NodeId::anonymous();
-        let b = NodeId::anonymous();
+        let a = NodeId::anonymous("rect");
+        let b = NodeId::anonymous("rect");
         assert_ne!(a, b);
     }
 }

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -435,6 +435,22 @@ pub enum NodeKind {
     Text { content: String },
 }
 
+impl NodeKind {
+    /// Return the FD format keyword for this node kind.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Root => "root",
+            Self::Generic => "generic",
+            Self::Group { .. } => "group",
+            Self::Frame { .. } => "frame",
+            Self::Rect { .. } => "rect",
+            Self::Ellipse { .. } => "ellipse",
+            Self::Path { .. } => "path",
+            Self::Text { .. } => "text",
+        }
+    }
+}
+
 /// A single node in the scene graph.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SceneNode {

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -488,7 +488,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let id = if input.starts_with('@') {
         parse_node_id.parse_next(input)?
     } else {
-        NodeId::anonymous()
+        NodeId::anonymous(kind_str)
     };
 
     skip_space(input);
@@ -1008,7 +1008,7 @@ fn parse_edge_block(input: &mut &str) -> ModalResult<Edge> {
     let id = if input.starts_with('@') {
         parse_node_id.parse_next(input)?
     } else {
-        NodeId::anonymous()
+        NodeId::anonymous("edge")
     };
 
     skip_space(input);

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -221,7 +221,7 @@ impl SyncEngine {
             }
             GraphMutation::DuplicateNode { id } => {
                 if let Some(original) = self.graph.get_by_id(id).cloned() {
-                    let new_id = NodeId::anonymous();
+                    let new_id = NodeId::anonymous(original.kind.kind_name());
                     let mut cloned = original;
                     cloned.id = new_id;
                     // Offset via constraint

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -664,7 +664,7 @@ impl FdCanvas {
             None => return false,
         };
         let mut cloned = original;
-        let new_id = NodeId::anonymous();
+        let new_id = NodeId::anonymous(cloned.kind.kind_name());
         cloned.id = new_id;
         if dx != 0.0 || dy != 0.0 {
             cloned.constraints.push(fd_core::model::Constraint::Offset {
@@ -695,7 +695,7 @@ impl FdCanvas {
             return false;
         }
         let ids: Vec<NodeId> = self.select_tool.selected.clone();
-        let new_group_id = NodeId::anonymous();
+        let new_group_id = NodeId::anonymous("group");
         let mutation = GraphMutation::GroupNodes { ids, new_group_id };
         let changed = self.apply_mutations(vec![mutation]);
         if changed {
@@ -1443,7 +1443,7 @@ impl FdCanvas {
                         }
                     } else {
                         // Create new text child node
-                        let child_id = NodeId::anonymous();
+                        let child_id = NodeId::anonymous("text");
                         let node = SceneNode::new(
                             child_id,
                             NodeKind::Text {
@@ -1495,7 +1495,7 @@ impl FdCanvas {
     /// `kind` is "rect", "ellipse", "text", or "frame".
     /// Returns `true` if the node was created.
     pub fn create_node_at(&mut self, kind: &str, x: f32, y: f32) -> bool {
-        let id = NodeId::anonymous();
+        let id = NodeId::anonymous(kind);
         let node_kind = match kind {
             "rect" => NodeKind::Rect {
                 width: 100.0,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ## Completed Requirements
 
+### v0.8.85 — Type-Prefixed Anonymous IDs
+
+- **REFACTOR**: Replaced `_anon_N` anonymous IDs with type-prefixed `_kind_N` pattern (e.g. `_rect_0`, `_text_1`, `_group_2`) — clearer at a glance which component an auto-generated ID refers to
+- **CORE**: `NodeId::anonymous(kind)` now takes a `&str` kind parameter; added `NodeKind::kind_name()` returning the FD keyword; `is_anonymous_id()` helper checks against all known prefixes
+- **PARSER**: Both node blocks and edge blocks pass their kind string to `anonymous()`
+- **WASM**: All 4 call sites updated — `duplicate_selected_at`, `group_selected`, `create_node_at`, `set_text`
+- **LINT**: `lint_anonymous_ids` uses new `is_anonymous_id()` pattern matcher
+- **LSP**: `compute_symbols` uses `kind_name()` and `is_anonymous_id()` for symbol filtering
+- **TS**: Removed `findAnonNodeIds`, updated `ANONYMOUS_ID_REGEX` and AI refine prompt; 191 TS tests pass
+- **ZED**: All changes mirrored in zed-extensions copy
+
 ### v0.8.84 — Zoom Inside Minimap (Google Maps-style)
 
 - **UX**: Moved zoom controls `[− 100% +]` from defunct bottom-left widget into the minimap as a floating frosted-glass pill overlay — compact, always-visible zoom level with `stopPropagation()` to prevent minimap pan on button click

--- a/examples/benchmarks/wireframe_ecommerce.fd
+++ b/examples/benchmarks/wireframe_ecommerce.fd
@@ -113,11 +113,4 @@ group @ecommerce_page {
   fill: #FAFAFA  # white
 }
 
-ellipse @_anon_14 {
-  w: 50 h: 40
-  stroke: #333333 2.5
-  x: 364.58
-  y: 931.79
-}
-
 @ecommerce_page -> center_in: canvas

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -1,18 +1,18 @@
-# FD v1
-# Onboarding wizard — 4-step flow with animations
+# ─── Themes ───
 
 theme step_desc {
-  fill: #6B7280
-  font: "Inter" 400 16
+  fill: #6B7280  # blue
+  font: "Inter" regular 16
 }
 
 theme step_title {
-  fill: #1A1A2E
-  font: "Inter" 700 28
+  fill: #1A1A2E  # blue
+  font: "Inter" bold 28
 }
 
-# ─── Wizard container ───────────────────────────────────────────────────
+# ─── Layout ───
 
+# ─── Wizard container ───────────────────────────────────────────────────
 group @wizard {
   spec {
     "Onboarding wizard — 4-step flow"
@@ -23,93 +23,115 @@ group @wizard {
     priority: high
     tag: onboarding, ux, retention
   }
-  layout: column gap=0 pad=0
-
   rect @step_card {
-    w: 480 h: 520
-    fill: #FFFFFF
-    corner: 24
-    shadow: (0,8,40,#00000022)
-
     group @card_content {
-      layout: column gap=24 pad=40
-
-      # Illustration area
       rect @illustration {
         spec {
           "Step illustration — animated SVG"
           accept: "subtle loop animation"
         }
-        w: 400 h: 240
-        fill: #F0EDFC
-        corner: 16
-
         ellipse @shape_1 {
           w: 80 h: 80
-          fill: #6C5CE740
-          when :enter { opacity: 1; scale: 1; ease: spring 800ms }
+          fill: #6C5CE740  # blue
+          when :enter {
+            opacity: 1
+            scale: 1
+            ease: spring 800ms
+          }
         }
-
         rect @shape_2 {
           w: 100 h: 60
-          fill: #A29BFE40
+          fill: #A29BFE40  # blue
           corner: 12
-          when :enter { opacity: 1; ease: ease_out 600ms }
+          when :enter {
+            opacity: 1
+            ease: ease_out 600ms
+          }
         }
-
         ellipse @shape_3 {
           w: 60 h: 60
-          fill: #00B89440
-          when :enter { opacity: 1; scale: 1; ease: spring 1000ms }
+          fill: #00B89440  # teal
+          x: 9.04
+          y: -0.2
+          when :enter {
+            opacity: 1
+            scale: 1
+            ease: spring 1000ms
+          }
         }
+        w: 400 h: 240
+        fill: #F0EDFC  # blue
+        corner: 16
       }
-
       text @step_heading "Create your first draft" {
         use: step_title
       }
-
       text @step_body "Start with a blank canvas or choose from our templates to kickstart your design." {
         use: step_desc
       }
-
-      # Progress dots
       group @dots {
+        ellipse @dot_1 {
+          w: 10 h: 10
+          fill: #6C5CE7  # blue
+        }
+        ellipse @dot_2 {
+          w: 10 h: 10
+          fill: #E8E8EC  # white
+        }
+        ellipse @dot_3 {
+          w: 10 h: 10
+          fill: #E8E8EC  # white
+        }
+        ellipse @dot_4 {
+          w: 10 h: 10
+          fill: #E8E8EC  # white
+        }
         layout: row gap=8 pad=0
-        ellipse @dot_1 { w: 10 h: 10; fill: #6C5CE7 }
-        ellipse @dot_2 { w: 10 h: 10; fill: #E8E8EC }
-        ellipse @dot_3 { w: 10 h: 10; fill: #E8E8EC }
-        ellipse @dot_4 { w: 10 h: 10; fill: #E8E8EC }
       }
-
-      # Action buttons
       group @buttons {
-        layout: row gap=12 pad=0
-
         rect @btn_skip {
+          text @skip_label "Skip" {
+            fill: #999999  # gray
+            font: "Inter" medium 15
+          }
           w: 100 h: 48
           corner: 10
-          text @skip_label "Skip" {
-            fill: #999999
-            font: "Inter" 500 15
+          when :hover {
+            fill: #F5F5F7  # white
+            ease: ease_out 150ms
           }
-          when :hover { fill: #F5F5F7; ease: ease_out 150ms }
         }
-
         rect @btn_next {
+          text @next_label "Next" {
+            fill: #FFFFFF  # white
+            font: "Inter" semibold 15
+          }
           w: 280 h: 48
-          fill: #6C5CE7
+          fill: #6C5CE7  # blue
           corner: 10
           shadow: (0,4,16,#6C5CE740)
-          text @next_label "Next" {
-            fill: #FFFFFF
-            font: "Inter" 600 15
+          when :hover {
+            fill: #5A4BD1  # blue
+            scale: 1.03
+            ease: spring 200ms
           }
-          when :hover { fill: #5A4BD1; scale: 1.03; ease: spring 200ms }
-          when :press { scale: 0.96; ease: ease_out 100ms }
+          when :press {
+            scale: 0.96
+            ease: ease_out 100ms
+          }
         }
+        layout: row gap=12 pad=0
       }
+      layout: column gap=24 pad=40
     }
+    w: 480 h: 520
+    fill: #FFFFFF  # white
+    corner: 24
+    shadow: (0,8,40,#00000022)
   }
+  layout: column gap=0 pad=0
 }
+
+# ─── Constraints ───
 
 @wizard -> center_in: canvas

--- a/fd-vscode/src/ai-refine.ts
+++ b/fd-vscode/src/ai-refine.ts
@@ -1,14 +1,14 @@
 /**
  * AI Refine service for FD nodes.
  *
- * Calls an LLM to rename _anon_ IDs with semantic names and
+ * Calls an LLM to rename auto-generated IDs with semantic names and
  * improve visual styling. Supports multiple providers with
  * per-provider API keys and custom model selection.
  */
 
 import * as vscode from "vscode";
 import {
-  findAnonNodeIds as _findAnonNodeIds,
+  findAnonymousNodeIds as _findAnonymousNodeIds,
   stripMarkdownFences as _stripMarkdownFences,
 } from "./fd-parse";
 
@@ -82,7 +82,7 @@ Given the .fd document below, improve the following nodes: ${targetList}
 
 ## Rules
 
-1. **Rename _anon_ IDs**: Replace any \`@_anon_N\` with a short, semantic snake_case name that describes the node's purpose (e.g., \`@hero_card\`, \`@nav_btn\`). Max 15 characters. If a name would collide with an existing ID, append a number suffix (e.g., \`@card_1\`).
+1. **Rename auto-generated IDs**: Replace any \`@_kind_N\` (like \`@_rect_0\`, \`@_text_3\`) with a short, semantic snake_case name that describes the node's purpose (e.g., \`@hero_card\`, \`@nav_btn\`). Max 15 characters. If a name would collide with an existing ID, append a number suffix (e.g., \`@card_1\`).
 
 2. **Restyle for visual polish**: Improve colors (use harmonious hex palettes, not generic red/blue), add rounded corners where missing, adjust spacing/sizing for better proportions. Follow modern design best practices.
 
@@ -258,7 +258,7 @@ async function callOpenRouter(
  * Refine selected nodes using AI.
  *
  * @param fdText  Full .fd document text
- * @param nodeIds Node IDs to refine (e.g., ["_anon_0", "_anon_3"])
+ * @param nodeIds Node IDs to refine (e.g., ["_rect_0", "_text_3"])
  * @returns The complete refined .fd text
  */
 export async function refineSelectedNodes(
@@ -354,11 +354,11 @@ export async function refineSelectedNodes(
 }
 
 /**
- * Find all _anon_ node IDs in an FD document.
+ * Find all auto-generated node IDs in an FD document.
  * Delegates to fd-parse; re-exported for backward-compatible imports.
  */
 export function findAnonNodeIds(fdText: string): string[] {
-  return _findAnonNodeIds(fdText);
+  return _findAnonymousNodeIds(fdText);
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/fd-vscode/src/e2e-ux.test.ts
+++ b/fd-vscode/src/e2e-ux.test.ts
@@ -14,7 +14,7 @@ import {
     parseSpecNodes,
     computeSpecHideLines,
     computeSpecFoldRanges,
-    findAnonNodeIds,
+    findAnonymousNodeIds,
     stripMarkdownFences,
     escapeHtml,
     parseDocumentSymbols,
@@ -459,9 +459,9 @@ describe("Figma: Inline Text Editing — text node handling", () => {
         // When nothing is selected and you double-click, Figma creates a text node
         // This is handled by create_node_at("text", x, y) in the WASM API
         // We verify the parse side: a text node with empty content
-        const source = `${SHAPES.TEXT} @_anon_1 "" {\n  x: 100 y: 200\n}`;
-        const anons = findAnonNodeIds(source);
-        expect(anons).toContain("_anon_1");
+        const source = `${SHAPES.TEXT} @_text_1 "" {\n  x: 100 y: 200\n}`;
+        const anons = findAnonymousNodeIds(source);
+        expect(anons).toContain("_text_1");
     });
 
     it("hex luminance calculation for text contrast", () => {

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -1216,7 +1216,7 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  // Register AI Assist All command (all _anon_ nodes)
+  // Register AI Assist All command (all auto-generated nodes)
   context.subscriptions.push(
     vscode.commands.registerCommand(COMMAND_AI_REFINE_ALL, async () => {
       const editor = vscode.window.activeTextEditor;

--- a/fd-vscode/src/fd-parse.test.ts
+++ b/fd-vscode/src/fd-parse.test.ts
@@ -4,7 +4,6 @@ import {
   parseSpecNodes,
   computeSpecHideLines,
   computeSpecFoldRanges,
-  findAnonNodeIds,
   findAnonymousNodeIds,
   findAllNodeIds,
   sanitizeToFdId,
@@ -350,37 +349,37 @@ describe("computeSpecFoldRanges", () => {
   });
 });
 
-// ─── findAnonNodeIds ─────────────────────────────────────────────────────
+// ─── findAnonymousNodeIds (type-prefixed) ────────────────────────────────
 
-describe("findAnonNodeIds", () => {
-  it("returns empty for no anon IDs", () => {
-    expect(findAnonNodeIds("rect @hero {\n  fill: #FFF\n}")).toEqual([]);
+describe("findAnonymousNodeIds (type-prefixed)", () => {
+  it("returns empty for no anonymous IDs", () => {
+    expect(findAnonymousNodeIds("rect @hero {\n  fill: #FFF\n}")).toEqual([]);
   });
 
-  it("finds a single anon ID", () => {
-    const result = findAnonNodeIds('text @_anon_1 "Hello" {\n}');
-    expect(result).toEqual(["_anon_1"]);
+  it("finds a single type-prefixed ID", () => {
+    const result = findAnonymousNodeIds('text @_text_1 "Hello" {\n}');
+    expect(result).toEqual(["_text_1"]);
   });
 
-  it("finds multiple unique anon IDs", () => {
-    const source = "rect @_anon_1 {\n}\ntext @_anon_2 {\n}\nellipse @_anon_3 {\n}";
-    const result = findAnonNodeIds(source);
+  it("finds multiple type-prefixed IDs", () => {
+    const source = "rect @_rect_1 {\n}\ntext @_text_2 {\n}\nellipse @_ellipse_3 {\n}";
+    const result = findAnonymousNodeIds(source);
     expect(result).toHaveLength(3);
-    expect(result).toContain("_anon_1");
-    expect(result).toContain("_anon_2");
-    expect(result).toContain("_anon_3");
+    expect(result).toContain("_rect_1");
+    expect(result).toContain("_text_2");
+    expect(result).toContain("_ellipse_3");
   });
 
   it("deduplicates repeated IDs", () => {
-    const source = "rect @_anon_1 {\n}\n@_anon_1 -> center_in: canvas";
-    const result = findAnonNodeIds(source);
-    expect(result).toEqual(["_anon_1"]);
+    const source = "rect @_rect_1 {\n}\n@_rect_1 -> center_in: canvas";
+    const result = findAnonymousNodeIds(source);
+    expect(result).toEqual(["_rect_1"]);
   });
 
-  it("ignores non-anon IDs", () => {
-    const source = "rect @hero {\n}\ntext @_anon_5 {\n}\ngroup @cards {\n}";
-    const result = findAnonNodeIds(source);
-    expect(result).toEqual(["_anon_5"]);
+  it("ignores non-anonymous IDs", () => {
+    const source = "rect @hero {\n}\ntext @_text_5 {\n}\ngroup @cards {\n}";
+    const result = findAnonymousNodeIds(source);
+    expect(result).toEqual(["_text_5"]);
   });
 });
 
@@ -753,9 +752,9 @@ describe("findAnonymousNodeIds", () => {
     expect(result).toContain("text_7");
   });
 
-  it("finds @_anon_0 (backward compat)", () => {
-    const result = findAnonymousNodeIds("rect @_anon_0 {\n}");
-    expect(result).toContain("_anon_0");
+  it("finds @_rect_0 underscored pattern", () => {
+    const result = findAnonymousNodeIds("rect @_rect_0 {\n}");
+    expect(result).toContain("_rect_0");
   });
 
   it("finds @group_2 and @frame_4", () => {

--- a/fd-vscode/src/fd-parse.ts
+++ b/fd-vscode/src/fd-parse.ts
@@ -461,26 +461,14 @@ export function computeSpecFoldRanges(
   return ranges;
 }
 
-// ─── Anon Node IDs ───────────────────────────────────────────────────────
+// ─── Anonymous Node Detection ────────────────────────────────────────────
 
-/** Find all `@_anon_N` node IDs in an FD document. */
-export function findAnonNodeIds(fdText: string): string[] {
-  const matches = fdText.matchAll(/@(_anon_\d+)/g);
-  const ids = new Set<string>();
-  for (const m of matches) {
-    ids.add(m[1]);
-  }
-  return [...ids];
-}
-
-// ─── Anonymous Node Detection (Renamify) ─────────────────────────────────
-
-/** Pattern for auto-generated anonymous node IDs: @kind_N or @_anon_N */
-const ANONYMOUS_ID_REGEX = /^(?:rect|ellipse|text|group|path|frame|generic|_anon)_\d+$/;
+/** Pattern for auto-generated anonymous node IDs: @_kind_N (e.g. _rect_0, _text_3) */
+const ANONYMOUS_ID_REGEX = /^(?:_?(?:rect|ellipse|text|group|path|frame|generic|edge))_\d+$/;
 
 /**
  * Find all anonymous node IDs in an FD document.
- * Matches patterns like @rect_1, @ellipse_3, @group_2, @_anon_0, etc.
+ * Matches patterns like @_rect_1, @_text_3, @rect_1, @ellipse_3, etc.
  */
 export function findAnonymousNodeIds(fdText: string): string[] {
   const allIds = findAllNodeIds(fdText);


### PR DESCRIPTION
## Summary

Replace all `_anon_N` anonymous IDs with type-prefixed `_kind_N` pattern for improved clarity.

### Changes

**Rust (main + zed copies):**
- `id.rs` — `NodeId::anonymous(kind: &str)` generates `_rect_0`, `_text_1`, `_group_2` etc.
- `model.rs` — Added `NodeKind::kind_name()` → `"rect"`, `"text"`, `"group"`, etc.
- `parser.rs` — Passes `kind_str` to `anonymous()` for nodes and edges
- `sync.rs` — `DuplicateNode` uses `original.kind.kind_name()`
- `lib.rs` — 4 WASM call sites updated with correct kind strings
- `lint.rs` — `is_anonymous_id()` helper replaces `starts_with("_anon_")`
- `symbols.rs` — Uses `kind_name()` and `is_anonymous_id()`

**TypeScript:**
- `fd-parse.ts` — Removed `findAnonNodeIds`, updated `ANONYMOUS_ID_REGEX`
- `ai-refine.ts` — Updated LLM prompt and import
- `fd-parse.test.ts` + `e2e-ux.test.ts` — Updated test expectations

### Verification
- ✅ `cargo check/test/clippy/fmt` — all pass (17 Rust tests)
- ✅ `pnpm test` — 191 TS tests pass