### PR TITLE
chore(release): bump versions to 0.1.5 / 0.8.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 license = "MIT"
 authors = ["Khang Nghiêm"]

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.87",
+  "version": "0.8.88",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump for v0.1.5 / v0.8.88 release.\n\nPublished:\n- fd-core v0.1.5 → crates.io\n- fd-lsp v0.1.5 → crates.io\n- fd-vscode v0.8.88 → VS Code Marketplace + Open VSX\n- tree-sitter-fd v0.1.1 (unchanged)