### PR TITLE
refactor: Group is now a unit variant — purely organizational (Figma Group alignment)

### DIFF
--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -412,8 +412,9 @@ pub enum NodeKind {
     /// Used for spec-only nodes: `@login_btn { spec "CTA" }`
     Generic,
 
-    /// Group / frame — contains children.
-    Group { layout: LayoutMode },
+    /// Organizational container (like Figma Group).
+    /// Auto-sizes to children, no own styles or layout modes.
+    Group,
 
     /// Frame — visible container with explicit size and optional clipping.
     /// Like a Figma frame: has fill/stroke, declared dimensions, clips overflow.
@@ -443,7 +444,7 @@ impl NodeKind {
         match self {
             Self::Root => "root",
             Self::Generic => "generic",
-            Self::Group { .. } => "group",
+            Self::Group => "group",
             Self::Frame { .. } => "frame",
             Self::Rect { .. } => "rect",
             Self::Ellipse { .. } => "ellipse",
@@ -810,7 +811,7 @@ impl SceneGraph {
             if matches!(parent.kind, NodeKind::Root) {
                 break;
             }
-            if matches!(parent.kind, NodeKind::Group { .. }) {
+            if matches!(parent.kind, NodeKind::Group) {
                 // If this group is already selected, stop bubbling — let inner target through
                 if selected.contains(&parent.id) {
                     break;
@@ -1018,12 +1019,7 @@ mod tests {
         let group_id = NodeId::intern("my_group");
         let rect_id = NodeId::intern("my_rect");
 
-        let group = SceneNode::new(
-            group_id,
-            NodeKind::Group {
-                layout: LayoutMode::Free,
-            },
-        );
+        let group = SceneNode::new(group_id, NodeKind::Group);
         let rect = SceneNode::new(
             rect_id,
             NodeKind::Rect {
@@ -1055,18 +1051,8 @@ mod tests {
         let inner_id = NodeId::intern("group_inner");
         let leaf_id = NodeId::intern("rect_leaf");
 
-        let outer = SceneNode::new(
-            outer_id,
-            NodeKind::Group {
-                layout: LayoutMode::Free,
-            },
-        );
-        let inner = SceneNode::new(
-            inner_id,
-            NodeKind::Group {
-                layout: LayoutMode::Free,
-            },
-        );
+        let outer = SceneNode::new(outer_id, NodeKind::Group);
+        let inner = SceneNode::new(inner_id, NodeKind::Group);
         let leaf = SceneNode::new(
             leaf_id,
             NodeKind::Rect {
@@ -1118,12 +1104,7 @@ mod tests {
         let rect_id = NodeId::intern("r1");
         let other_id = NodeId::intern("other");
 
-        let group = SceneNode::new(
-            group_id,
-            NodeKind::Group {
-                layout: LayoutMode::Free,
-            },
-        );
+        let group = SceneNode::new(group_id, NodeKind::Group);
         let rect = SceneNode::new(
             rect_id,
             NodeKind::Rect {

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -549,7 +549,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let _ = '}'.parse_next(input)?;
 
     let kind = match kind_str {
-        "group" => NodeKind::Group { layout },
+        "group" => NodeKind::Group, // Group is purely organizational — layout ignored
         "frame" => NodeKind::Frame {
             width: width.unwrap_or(200.0),
             height: height.unwrap_or(200.0),

--- a/crates/fd-core/src/transform.rs
+++ b/crates/fd-core/src/transform.rs
@@ -154,7 +154,7 @@ fn is_style_empty(style: &Style) -> bool {
 fn kind_priority(kind: &NodeKind) -> u8 {
     match kind {
         NodeKind::Root => 0,
-        NodeKind::Group { .. } | NodeKind::Frame { .. } => 1,
+        NodeKind::Group | NodeKind::Frame { .. } => 1,
         NodeKind::Rect { .. } => 2,
         NodeKind::Ellipse { .. } => 3,
         NodeKind::Text { .. } => 4,

--- a/crates/fd-core/tests/fixtures/nested_layout.fd
+++ b/crates/fd-core/tests/fixtures/nested_layout.fd
@@ -1,6 +1,7 @@
 # Nested layout — exercises the layout solver with groups, columns, and constraints
 
-group @sidebar {
+frame @sidebar {
+  w: 232 h: 200
   layout: column gap=8 pad=16
 
   rect @nav_item_1 {
@@ -22,7 +23,8 @@ group @sidebar {
   }
 }
 
-group @main_content {
+frame @main_content {
+  w: 448 h: 400
   layout: column gap=12 pad=24
 
   text @heading "Dashboard" {

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -283,12 +283,7 @@ impl SyncEngine {
                 let rel_group_y = min_y - parent_offset.1;
 
                 // Create the new group node
-                let mut group_node = SceneNode::new(
-                    new_group_id,
-                    NodeKind::Group {
-                        layout: LayoutMode::Free,
-                    },
-                );
+                let mut group_node = SceneNode::new(new_group_id, NodeKind::Group);
                 group_node.constraints.push(Constraint::Position {
                     x: rel_group_x,
                     y: rel_group_y,
@@ -464,7 +459,7 @@ impl SyncEngine {
         let child_kind = &self.graph.graph[child_idx].kind;
 
         let is_container_parent = match parent_kind {
-            NodeKind::Group { .. } | NodeKind::Frame { .. } => true,
+            NodeKind::Group | NodeKind::Frame { .. } => true,
             NodeKind::Rect { .. } | NodeKind::Ellipse { .. } => {
                 matches!(child_kind, NodeKind::Text { .. })
             }
@@ -586,7 +581,7 @@ impl SyncEngine {
         while let Some((idx, visited)) = stack.pop() {
             if visited {
                 let kind = &graph.graph[idx].kind;
-                let is_container = matches!(kind, NodeKind::Group { .. } | NodeKind::Frame { .. });
+                let is_container = matches!(kind, NodeKind::Group | NodeKind::Frame { .. });
                 if is_container && idx != graph.root {
                     result.push(idx);
                 }
@@ -629,7 +624,7 @@ fn handle_child_group_relationship(
 
     // Only act on container parents (Group/Frame) or shape parents (Rect/Ellipse) if the child is Text.
     let is_container_parent = match parent_kind {
-        NodeKind::Group { .. } | NodeKind::Frame { .. } => true,
+        NodeKind::Group | NodeKind::Frame { .. } => true,
         NodeKind::Rect { .. } | NodeKind::Ellipse { .. } => {
             matches!(child_kind, NodeKind::Text { .. })
         }
@@ -674,20 +669,10 @@ fn handle_child_group_relationship(
 }
 
 /// Extract padding from a group's layout mode.
+/// Groups are purely organizational — always 0 padding.
 fn group_padding(graph: &SceneGraph, group_idx: NodeIndex) -> f32 {
     match &graph.graph[group_idx].kind {
-        NodeKind::Group {
-            layout: LayoutMode::Column { pad, .. },
-        }
-        | NodeKind::Group {
-            layout: LayoutMode::Row { pad, .. },
-        }
-        | NodeKind::Group {
-            layout: LayoutMode::Grid { pad, .. },
-        } => *pad,
-        NodeKind::Group {
-            layout: LayoutMode::Free,
-        } => 0.0,
+        NodeKind::Group => 0.0,
         _ => 0.0,
     }
 }

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -58,7 +58,7 @@ fn hover_node_id(id: &str, graph: Option<&SceneGraph>) -> Option<Hover> {
     let kind_str = match &node.kind {
         fd_core::NodeKind::Root => "Root",
         fd_core::NodeKind::Generic => "Generic (placeholder)",
-        fd_core::NodeKind::Group { .. } => "Group",
+        fd_core::NodeKind::Group => "Group",
         fd_core::NodeKind::Frame { width, height, .. } => {
             let desc = format!("**Frame** — {}×{}", width, height);
             return Some(make_hover(&desc));
@@ -89,7 +89,7 @@ fn hover_keyword(word: &str) -> Option<Hover> {
     let info = match word {
         // Node types
         "group" => {
-            "**group** — Logical container for child elements.\n\nInvisible on canvas. Supports `layout:` for automatic arrangement of children."
+            "**group** — Organizational container (like Figma Group).\n\nInvisible on canvas. Auto-sizes to children. No own styles or layout modes."
         }
         "frame" => {
             "**frame** — Visible container with explicit size.\n\nLike a Figma frame: has fill/stroke, declared `w:` `h:`, optional `clip: true`.\nSupports `layout:` for automatic arrangement of children."

--- a/crates/fd-render/src/paint.rs
+++ b/crates/fd-render/src/paint.rs
@@ -42,7 +42,7 @@ fn paint_node(
     let style = graph.resolve_style(node, &[]);
 
     match &node.kind {
-        NodeKind::Root | NodeKind::Generic => {}
+        NodeKind::Root | NodeKind::Generic | NodeKind::Group => {}
 
         NodeKind::Rect { .. } => paint_rect(scene, nb, &style),
 
@@ -60,12 +60,6 @@ fn paint_node(
         }
 
         NodeKind::Path { commands } => paint_path(scene, commands, nb, &style),
-
-        NodeKind::Group { .. } => {
-            if style.fill.is_some() {
-                paint_rect(scene, nb, &style);
-            }
-        }
 
         NodeKind::Frame { .. } => {
             // Frames always render their background (like a visible container)

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -431,7 +431,7 @@ impl FdCanvas {
                 // Skip bring_forward for groups — they should stay behind children
                 let is_group = matches!(
                     self.engine.graph.graph[idx].kind,
-                    fd_core::model::NodeKind::Group { .. }
+                    fd_core::model::NodeKind::Group
                 );
                 if is_group {
                     false
@@ -737,7 +737,7 @@ impl FdCanvas {
                 self.engine
                     .graph
                     .get_by_id(*id)
-                    .is_some_and(|n| matches!(n.kind, fd_core::model::NodeKind::Group { .. }))
+                    .is_some_and(|n| matches!(n.kind, fd_core::model::NodeKind::Group))
             })
             .collect();
 
@@ -1245,7 +1245,7 @@ impl FdCanvas {
                 props.insert("kind".into(), "text".into());
                 props.insert("content".into(), serde_json::Value::String(content.clone()));
             }
-            NodeKind::Group { .. } => {
+            NodeKind::Group => {
                 props.insert("kind".into(), "group".into());
             }
             NodeKind::Frame { width, height, .. } => {
@@ -2045,7 +2045,7 @@ fn collect_node_tree(graph: &fd_core::SceneGraph, idx: fd_core::NodeIndex) -> se
     let kind_str = match &node.kind {
         fd_core::NodeKind::Root => "root",
         fd_core::NodeKind::Generic => "generic",
-        fd_core::NodeKind::Group { .. } => "group",
+        fd_core::NodeKind::Group => "group",
         fd_core::NodeKind::Frame { .. } => "frame",
         fd_core::NodeKind::Rect { .. } => "rect",
         fd_core::NodeKind::Ellipse { .. } => "ellipse",

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -251,8 +251,8 @@ fn render_node(
             });
             draw_text(ctx, node_bounds, content, &style, parent_is_shape);
         }
-        NodeKind::Group { .. } => {
-            draw_group_bg(ctx, node_bounds, &style);
+        NodeKind::Group => {
+            // Group is purely organizational — no background fill
 
             // Draw hover/selection borders for groups
             if is_selected || Some(node.id.as_str()) == hovered_id {
@@ -530,35 +530,6 @@ fn pick_label_color(style: &Style) -> String {
         }
         _ => "#1C1C1E".to_string(),
     }
-}
-
-fn draw_group_bg(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, style: &Style) {
-    if style.fill.is_none() && style.stroke.is_none() {
-        return;
-    }
-
-    let (x, y, w, h) = (b.x as f64, b.y as f64, b.width as f64, b.height as f64);
-    let radius = style.corner_radius.unwrap_or(0.0) as f64;
-
-    ctx.save();
-    apply_opacity(ctx, style);
-
-    if style.fill.is_some() {
-        let fill_color = resolve_fill_color(style);
-        ctx.set_fill_style_str(&fill_color);
-        rounded_rect_path(ctx, x, y, w, h, radius);
-        ctx.fill();
-    }
-
-    if let Some(ref stroke) = style.stroke {
-        let stroke_color = resolve_paint_color(&stroke.paint);
-        ctx.set_stroke_style_str(&stroke_color);
-        ctx.set_line_width(stroke.width as f64);
-        rounded_rect_path(ctx, x, y, w, h, radius);
-        ctx.stroke();
-    }
-
-    ctx.restore();
 }
 
 /// Draw a freehand path from its PathCmd commands.

--- a/crates/fd-wasm/src/svg.rs
+++ b/crates/fd-wasm/src/svg.rs
@@ -290,15 +290,8 @@ fn render_node_svg(
                 d, fill, stroke, stroke_width
             ));
         }
-        NodeKind::Group { .. } | NodeKind::Root | NodeKind::Generic => {
-            // Groups might have a background optionally (if style has fill)
-            if fill != "none" {
-                let r = style.corner_radius.unwrap_or(0.0);
-                out.push_str(&format!(
-                    "  <rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" rx=\"{}\" ry=\"{}\" fill=\"{}\" stroke=\"{}\" stroke-width=\"{}\" />\n",
-                    b.x, b.y, b.width, b.height, r, r, fill, stroke, stroke_width
-                ));
-            }
+        NodeKind::Group | NodeKind::Root | NodeKind::Generic => {
+            // Groups are purely organizational — no visual output
         }
     }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 ## Completed Requirements
 
+### v0.8.92 — Group vs Frame Refactoring (Figma Alignment)
+
+- **REFACTOR**: `NodeKind::Group` is now a unit variant — purely organizational container (like Figma Group); no own styles, layout modes, or visual rendering; auto-sizes to children bounding box
+- **REFACTOR**: `layout:` directives inside `group {}` blocks are parsed but silently ignored (backward compat); layout modes only apply to `frame` nodes
+- **CLEANUP**: Removed `draw_group_bg()` dead code from Canvas2D renderer
+- **LSP**: Updated group/frame hover descriptions to clarify semantic distinction
+- **EXAMPLES**: Migrated `checkout_flow.fd`, `constraints.fd`, and `nested_layout.fd` test fixture from `group + layout:` to `frame + layout:`
+- **TESTING**: 10 tests migrated from group+layout to frame+layout; all 142 Rust tests pass
+
 ### v0.8.91 — Canvas Interaction Fixes
 
 - **FIX**: Resize handles now work in all 8 directions — `ResizeNode` handler in `sync.rs` now updates cached bounds so `resize_origin` stays accurate across frames

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -257,6 +257,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | group / reparent    | R3.34, R3.35, R3.38                                               |
 | image               | R3.32                                                             |
 | library             | R3.33, R3.34                                                      |
+| group / frame       | R3.24, R3.34, R1.1                                                |
 
 | content-first | R4.12 |
 | mermaid | R1.18 |

--- a/examples/checkout_flow.fd
+++ b/examples/checkout_flow.fd
@@ -8,7 +8,8 @@ theme muted { font: "Inter" 12; fill: #999 }
 
 # ─── Checkout page ───────────────────────────────────────────────────────
 
-group @checkout_page {
+frame @checkout_page {
+  w: 500 h: 800
   layout: column gap=20 pad=32
 
   spec {
@@ -23,7 +24,8 @@ group @checkout_page {
 
   # ─── Progress bar ────────────────────────────────────────────────
 
-  group @progress {
+  frame @progress {
+    w: 420 h: 4
     layout: row gap=0 pad=0
 
     spec {
@@ -59,7 +61,8 @@ group @checkout_page {
 
   # ─── Form fields ─────────────────────────────────────────────────
 
-  group @form {
+  frame @form {
+    w: 412 h: 400
     layout: column gap=12 pad=0
 
     spec {
@@ -71,7 +74,8 @@ group @checkout_page {
       tag: form, ux
     }
 
-    group @name_row {
+    frame @name_row {
+      w: 412 h: 48
       layout: row gap=12 pad=0
 
       rect @first_name {
@@ -121,7 +125,8 @@ group @checkout_page {
       text "Apt, suite, etc. (optional)" { use: muted }
     }
 
-    group @city_state {
+    frame @city_state {
+      w: 412 h: 48
       layout: row gap=12 pad=0
 
       rect @city {
@@ -174,7 +179,9 @@ group @checkout_page {
       tag: checkout
     }
 
-    group { layout: column gap=8 pad=20
+    frame @_summary_layout {
+      w: 372 h: 160
+      layout: column gap=8 pad=20
       text "Order Summary" { font: "Inter" 600 16; fill: #1A1A2E }
       text "Widget Pro × 2" { use: label }
       text "Cable Pack × 1" { use: label }
@@ -187,7 +194,8 @@ group @checkout_page {
 
   # ─── Action buttons ────────────────────────────────────────────
 
-  group @actions {
+  frame @actions {
+    w: 412 h: 48
     layout: row gap=12 pad=0
 
     rect @btn_back {

--- a/examples/constraints.fd
+++ b/examples/constraints.fd
@@ -3,7 +3,8 @@
 
 # ─── Canvas-centered hero ────────────────────────────────────────────────
 
-group @hero {
+frame @hero {
+  w: 400 h: 200
   layout: column gap=16 pad=40
 
   spec "Hero section — demonstrates center_in constraint"
@@ -55,7 +56,9 @@ rect @full_width_bg {
   corner: 0
   spec "Background that fills parent width with 24px padding"
 
-  group { layout: row gap=16 pad=24
+  frame @_panel_layout {
+    w: 752 h: 72
+    layout: row gap=16 pad=24
     text "This panel uses fill_parent with 24px inset" {
       font: "Inter" 14; fill: #6B7280
     }


### PR DESCRIPTION
## Summary

Aligns FD's `Group` and `Frame` nodes with Figma's model:

- **Group** = purely organizational container (auto-sizes to children, no own styles/layout/rendering)
- **Frame** = styled container with explicit dimensions, clipping, and layout modes

## Changes

### Core Model (`fd-core`)
- `NodeKind::Group { layout }` → `NodeKind::Group` (unit variant)
- Parser silently ignores `layout:` inside `group {}` (backward compatible)
- Emitter no longer outputs `layout:` for groups
- Layout solver treats Group as always Free with 0 padding
- Group auto-sizing simplified (no padding calculation)

### Rendering (`fd-render`, `fd-wasm`)
- Group paint: no-op (no fill/stroke rendering)
- Canvas2D: removed `draw_group_bg()` dead code
- SVG: Group produces no visual output

### Editor (`fd-editor`)
- Sync engine creates Group unit variant
- `group_padding()` always returns 0
- Container checks updated

### LSP (`fd-lsp`)
- Hover descriptions updated for group/frame distinction

### Examples & Tests
- Migrated `checkout_flow.fd`, `constraints.fd`, `nested_layout.fd`
- 10 tests converted from group+layout to frame+layout
- All 142 Rust tests pass ✅

## Verification
- `cargo check --workspace` ✅
- `cargo test --workspace` ✅ (142 tests)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅