### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Renamify panel proposals

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - [XSS in Webview Node ID Injection]
+**Vulnerability:** Node IDs parsed from `.fd` files were unsafely injected into Webview HTML via `.innerHTML` in `renderProposals` inside `fd-vscode/src/webview-html.ts` allowing script injection (XSS).
+**Learning:** Even though `.fd` files are just design specifications, their contents (like node IDs) are effectively user inputs when rendered in VS Code Webviews. Using `.innerHTML` to render these fields directly opens up high-priority XSS vectors.
+**Prevention:** When dynamically rendering user-provided or parsed strings into Webview HTML, always use DOM API creation with `.textContent` or explicitly sanitize using an `escapeHtml` utility before embedding into `.innerHTML`.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2729,11 +2729,28 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         items.forEach((p, i) => {
           const row = document.createElement('div');
           row.className = 'renamify-row';
-          row.innerHTML =
-            '<input type="checkbox" checked data-idx="' + i + '">' +
-            '<span class="renamify-old">@' + p.oldId + '</span>' +
-            '<span class="renamify-arrow">→</span>' +
-            '<span class="renamify-new">@' + p.newId + '</span>';
+
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = true;
+          checkbox.dataset.idx = String(i);
+
+          const oldSpan = document.createElement('span');
+          oldSpan.className = 'renamify-old';
+          oldSpan.textContent = '@' + p.oldId;
+
+          const arrowSpan = document.createElement('span');
+          arrowSpan.className = 'renamify-arrow';
+          arrowSpan.textContent = '→';
+
+          const newSpan = document.createElement('span');
+          newSpan.className = 'renamify-new';
+          newSpan.textContent = '@' + p.newId;
+
+          row.appendChild(checkbox);
+          row.appendChild(oldSpan);
+          row.appendChild(arrowSpan);
+          row.appendChild(newSpan);
           body.appendChild(row);
         });
         footer.style.display = 'flex';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Node IDs parsed from `.fd` files were unsafely injected into Webview HTML via `.innerHTML` in `renderProposals` inside `fd-vscode/src/webview-html.ts`, allowing script injection (XSS).
🎯 **Impact:** Maliciously crafted `.fd` files could contain node IDs that execute arbitrary JavaScript within the context of the VS Code Webview, potentially compromising the user's environment or leaking sensitive data.
🔧 **Fix:** Refactored the `renderProposals` function to use DOM API methods (`document.createElement`, `textContent`) instead of directly injecting HTML strings. `textContent` automatically escapes special characters, eliminating the XSS vector.
✅ **Verification:** Ran the `pnpm test` and `pnpm lint` suites inside `fd-vscode` to ensure no regressions. Verified that `escapeHtml` or standard DOM elements are now used for node ID rendering.

---
*PR created automatically by Jules for task [10985510205030358481](https://jules.google.com/task/10985510205030358481) started by @khangnghiem*