### PR TITLE
chore: bump versions for v0.8.94 publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 license = "MIT"
 authors = ["Khang Nghiêm"]


### PR DESCRIPTION
Bump workspace version to 0.1.8 for publishing.