### PR TITLE
fix(canvas): revert text-to-child drag reparent feature (R3.38)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.9.1 — Revert Text-to-Child Drag
+
+- **REMOVED (R3.38)**: Reverted drop context menu reparent system — dragging a node onto a container no longer shows "Make child of @target" popup; ~160 lines of JS removed (`detectDropTarget`, `showDropContextMenu`, `closeDropContextMenu`, `reparentNodeIntoContainer`)
+- **REMOVED (R3.44)**: Text tool's shape-reparent on drop removed — dragging Text tool onto a shape now creates a standalone text node at the drop position instead of reparenting inside the shape
+- **KEPT**: Layout solver text-centering for manually-authored text children inside shapes remains functional
+
 ### v0.9.0 — Text Boundary + Inline Editor Fix
 
 - **BUG FIX**: Text node boundaries now tightly wrap content — `measureAndUpdateTextBounds` was calling non-existent `get_node_props(nodeId)` WASM API, silently failing. Added `get_node_props(node_id)` to the WASM API and fixed the function

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -50,13 +50,13 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R3.35** _(planned)_: Detach snap animation — purple glow on near-detach, rubber-band line, scale pop + glow on detach; all animations <200ms → [spec](specs/group-reparent.md)
 - **R3.36** _(done)_: Auto-center text in shapes — single text child inside rect/ellipse/frame auto-expands bounds to parent; renderer's center/middle alignment visually centers the label
 - **R3.37** _(removed)_: ~~Center-snap for text nodes~~ — replaced by R3.38 context menu; center-snap guides removed to reduce visual noise
-- **R3.38** _(done)_: Context-menu reparent on drop — dropping a node onto a rect/ellipse/frame/group shows a "Make child of @target" context menu; clicking executes reparent + auto-center; click-outside or Escape cancels. Replaces old auto-reparent-on-drag behavior
+- **R3.38** _(removed)_: ~~Context-menu reparent on drop~~ — reverted; dragging a node onto a container no longer offers reparent
 - **R3.39** _(done)_: Floating toolbar — draggable bottom toolbar with 7 tool buttons (SVG icons); drag handle toggles top/bottom position (80px threshold); double-click collapses to circle; state persists via VS Code webview state → [spec](specs/floating-toolbar.md)
 - **R3.40** _(done)_: Toolbar tooltips — Apple-style frosted glass tooltips on hover (400ms delay); pill shape with backdrop-filter blur; shows tool name + shortcut; replaces native title attributes → [spec](specs/floating-toolbar.md)
 - **R3.41** _(done)_: Click-to-raise — selecting a node via fresh click automatically brings it forward one z-level (reuses ⌘] bring_forward); no-op on already-selected or drag interactions (5px threshold)
 - **R3.42** _(done)_: Drag-to-create — drag a tool button from floating toolbar onto canvas creates shape at drop position; ghost preview (dashed outline matching shape type) follows cursor; ScreenBrush-style defaults (transparent fill, #333 stroke 2.5); smart defaults cascade applied → [spec](specs/floating-toolbar.md)
 - **R3.43** _(done)_: Snap-to-node — dropping near existing node (40px threshold) snaps to adjacent position (20px gap, 4 cardinal dirs); auto-creates edge from existing→new node (arrow:end, curve:smooth); shows frosted-glass edge context menu with arrow/curve/stroke/flow controls → [spec](specs/floating-toolbar.md)
-- **R3.44** _(done)_: Text consume on drag — Text tool dropped on shape triggers context menu for reparent (R3.38 reuse); dropped near edge (≤30px) inserts child text node in edge block; hit priority: shape > edge > empty canvas → [spec](specs/floating-toolbar.md)
+- **R3.44** _(partial)_: Text consume on drag — Text tool dropped near edge (≤30px) inserts child text node in edge block; shape reparent on drop removed; hit priority: edge > empty canvas → [spec](specs/floating-toolbar.md)
 - **R3.45** _(done)_: Auto-expand parent on release — `finalize_child_bounds()` expands parent groups/frames to contain overflowing children after resize or text growth; processes bottom-up for recursive cascade; skips `clip: true` frames; only on pointer-up (avoids chasing-envelope bug)
 - **R3.46** _(done)_: Text intrinsic sizing — text node bounds auto-fit to content via Canvas2D `measureText()` bridge; JS measures → WASM `update_text_metrics()` → parent expansion via `finalize_bounds()`; wired into inline editor commit flow
 - **R3.47** _(done)_: Child containment constraint — child nodes cannot be fully outside their parent; dragging a child completely outside detaches it and reparents to nearest ancestor (enforced by `handle_child_group_relationship` in Rust)
@@ -269,7 +269,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | z-order / raise | R3.41 |
 | drag-to-create | R3.42, R3.44 |
 | snap / auto-edge | R3.43 |
-| text consume | R3.38, R3.44 |
+| text consume | R3.44 |
 | default styles | R3.42 |
 | auto-expand | R3.45 |
 | text sizing | R3.46, R3.36 |

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -1,3 +1,5 @@
+# ─── Themes ───
+
 theme dark_accent {
   fill: #A29BFE  # blue
 }
@@ -20,6 +22,8 @@ theme dark_text {
   fill: #E0E0E0  # white
   font: "Inter" regular 14
 }
+
+# ─── Layout ───
 
 # ─── Layout ───
 # ─── Layout ───
@@ -132,8 +136,8 @@ rect @toggle_notif {
   }
   w: 344 h: 56
   use: dark_card
-  x: 335.1
-  y: -13.28
+  x: 358.85
+  y: 28.77
   when :hover {
     fill: #353550  # blue
     ease: ease_out 150ms
@@ -249,3 +253,73 @@ text @delete_label "Delete Account" {
   y: 300.99
 }
 
+rect @_rect_0 {
+  w: 344 h: 56
+  use: dark_card
+  x: 257.61
+  y: -65.07
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+rect @_rect_1 {
+  w: 344 h: 56
+  use: dark_card
+  x: 358.85
+  y: 28.77
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+rect @_rect_2 {
+  w: 344 h: 56
+  use: dark_card
+  x: 582.41
+  y: -122.29
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+rect @_rect_3 {
+  w: 344 h: 56
+  use: dark_card
+  x: 257.61
+  y: -65.07
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+rect @_rect_4 {
+  w: 328.18 h: 95.49
+  use: dark_card
+  x: 234.11
+  y: 101.1
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+rect @_rect_5 {
+  w: 328.18 h: 95.49
+  use: dark_card
+  x: 531.48
+  y: 146.46
+  when :hover {
+    fill: #353550  # blue
+    ease: ease_out 150ms
+  }
+}
+
+# ─── Constraints ───
+
+@_rect_1 -> offset: @_rect_0 20, 20
+@_rect_3 -> offset: @_rect_2 20, 20


### PR DESCRIPTION
## Summary

Reverts the text-to-child drag reparent feature (R3.38, R3.44 partial).

### Removed
- **Drop context menu**: `detectDropTarget`, `showDropContextMenu`, `closeDropContextMenu`, `reparentNodeIntoContainer` — ~140 lines of JS removed
- **Pointerup trigger**: Drop target detection on pointer release
- **Text tool shape reparent**: PRIORITY 1 in `dtcTextConsume` that auto-reparented text into shapes — now creates standalone text at drop position

### Kept
- Layout solver text-centering for manually-authored text children inside shapes (core behavior)
- Text tool's edge consume (PRIORITY 2 — drop near edge inserts child text)
- `parent_of` WASM API (general purpose)

### Verification
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all` ✅
- `cargo test --workspace` — all tests pass ✅
- CHANGELOG and REQUIREMENTS updated