### PR TITLE
chore(release): bump fd-vscode to v0.8.99

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.98",
+  "version": "0.8.99",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump to 0.8.99 for the text-to-child drag revert. Already published to both registries.