### PR TITLE
chore(release): bump fd-vscode to v0.9.2

### DIFF
--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.8.99",
+  "version": "0.9.2",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
Version bump for v0.9.2 release (eraser shortcut + auto-switch fix).