### PR TITLE
feat(eraser): Ctrl+click temporary eraser override — split Ctrl/Cmd modifier handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.9.8 — Ctrl → Temporary Eraser Override
+
+- **UX (R3.48)**: Hold Ctrl + click/drag from any tool to temporarily switch to eraser; release Ctrl or pointer-up restores original tool
+- **FIX**: Split `e.ctrlKey` from `e.metaKey` in pointerdown — Cmd=temp-select (Screenbrush), Ctrl=temp-eraser (new). Previously both triggered temp-select.
+- **Keyup**: Control keyup now restores from temp eraser; Meta keyup handles Cmd-hold separately
+
 ### v0.9.7 — Eraser Poof Animation
 
 - **UX (R3.48)**: Erasing a node now shows a brief red "poof" animation — a fading red rounded rect (150ms, 30% alpha → 0, slight scale-up) at the deleted node's position

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -94,6 +94,9 @@ let cmdTempSelectActive = false;
 let cmdTempSelectOriginalTool = null;
 /** Alt+drag clone-and-drag active */
 let altCloneActive = false;
+/** Ctrl+click on any tool → temporary eraser mode */
+let tempEraserMode = false;
+let tempEraserPrevTool = null;
 
 // ─── Eraser Poof Animation ───────────────────────────────────────────────
 /** Entries: { x, y, width, height, startTime } — brief red fade on erase */
@@ -612,10 +615,18 @@ function setupPointerEvents() {
     const currentTool = fdCanvas.get_tool_name();
     const drawingTools = ["rect", "ellipse", "pen", "arrow", "text", "frame"];
     const isDrawingTool = drawingTools.includes(currentTool);
-    if (isDrawingTool && (e.metaKey || e.ctrlKey)) {
+    if (isDrawingTool && e.metaKey && !e.ctrlKey) {
       cmdTempSelectActive = true;
       cmdTempSelectOriginalTool = currentTool;
       fdCanvas.set_tool("select");
+    }
+
+    // ── Ctrl+click = temporary Eraser (from any non-eraser tool) ──
+    if (e.ctrlKey && !e.metaKey && currentTool !== "eraser") {
+      tempEraserMode = true;
+      tempEraserPrevTool = currentTool;
+      fdCanvas.set_tool("eraser");
+      updateToolbarActive("eraser");
     }
 
     // ── Alt+drag = clone and drag ──
@@ -925,6 +936,15 @@ function setupPointerEvents() {
     cmdTempSelectActive = false;
     cmdTempSelectOriginalTool = null;
     altCloneActive = false;
+
+    // ── Restore tool after Ctrl temp Eraser ──
+    if (tempEraserMode && tempEraserPrevTool && fdCanvas) {
+      fdCanvas.set_tool(tempEraserPrevTool);
+      updateToolbarActive(lockedTool || tempEraserPrevTool);
+      updateCanvasCursor(tempEraserPrevTool);
+    }
+    tempEraserMode = false;
+    tempEraserPrevTool = null;
   });
 
   // ── Wheel / Trackpad → Pan or Zoom ──
@@ -1632,7 +1652,7 @@ document.addEventListener("keyup", (e) => {
     canvas.style.cursor = "";
   }
   // Screenbrush: Release ⌘ → restore previous tool
-  if ((e.key === "Meta" || e.key === "Control") && isCmdHold && fdCanvas) {
+  if (e.key === "Meta" && isCmdHold && fdCanvas) {
     isCmdHold = false;
     canvas.style.cursor = "";
     if (toolBeforeCmdHold) {
@@ -1640,6 +1660,16 @@ document.addEventListener("keyup", (e) => {
       updateToolbarActive(toolBeforeCmdHold);
       toolBeforeCmdHold = null;
     }
+  }
+  // Release Ctrl → restore from temporary eraser mode
+  if (e.key === "Control" && tempEraserMode && fdCanvas) {
+    if (tempEraserPrevTool) {
+      fdCanvas.set_tool(tempEraserPrevTool);
+      updateToolbarActive(lockedTool || tempEraserPrevTool);
+      updateCanvasCursor(tempEraserPrevTool);
+    }
+    tempEraserMode = false;
+    tempEraserPrevTool = null;
   }
 });
 


### PR DESCRIPTION
## Summary\n\nAdds Ctrl modifier → temporary eraser override from any tool. Hold Ctrl + click/drag to erase, release Ctrl (or pointer-up) to restore the previous tool.\n\n### Changes\n\n**JS (`main.js`)**:\n- `tempEraserMode` + `tempEraserPrevTool` state vars\n- Pointerdown: Ctrl+click (without Cmd) enters temp eraser from any non-eraser tool\n- Pointerup: restores previous tool on release\n- Keyup `Control`: restores previous tool if Ctrl released mid-hold\n- **FIX**: Split `e.ctrlKey` from `e.metaKey` — Cmd=temp-select (Screenbrush), Ctrl=temp-eraser\n\n### What's NOT changed (verify only)\n- Cmd+drag = pan (already works)\n- Alt+click = clone (already works)