### PR TITLE
feat(ui): add visible delete button to floating action bar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.9.9 — Visible Delete Button
+
+- **UX (R3.48)**: Added visible delete button (✕ icon) to the floating action bar — appears when a node is selected, red hover feedback (#FF3B30), calls `delete_selected()` on click
+- **Tests**: All eraser/shortcut/sync tests confirmed passing (eraser_tool_lifecycle, erase_child_preserves_group, erase_nested_cascade, etc.)
+
 ### v0.9.8 — Ctrl → Temporary Eraser Override
 
 - **UX (R3.48)**: Hold Ctrl + click/drag from any tool to temporarily switch to eraser; release Ctrl or pointer-up restores original tool

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -269,6 +269,23 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       background: var(--fd-accent);
       cursor: pointer;
     }
+    .fab-delete-btn {
+      background: none;
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 6px;
+      color: #aaa;
+      cursor: pointer;
+      padding: 3px 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: all 0.15s ease;
+    }
+    .fab-delete-btn:hover {
+      background: rgba(255,59,48,0.15);
+      border-color: rgba(255,59,48,0.3);
+      color: #FF3B30;
+    }
 
 
     /* ── Onboarding Overlay ── */
@@ -2502,6 +2519,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <label class="fab-label fab-text-only" for="fab-font-size">Size</label>
       <input type="number" id="fab-font-size" class="fab-input fab-text-only" min="8" max="200" step="1" value="16" title="Font size">
       <div class="fab-sep"></div>
+      <button class="fab-delete-btn" id="deleteSelectedBtn" title="Delete (⌫)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
       <button class="fab-btn" id="fab-more-btn" aria-label="More actions" title="More actions">⋯</button>
       <div id="fab-overflow-menu">
         <button class="fab-menu-item" data-action="group">⌘G Group</button>

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1974,6 +1974,17 @@ function hideFloatingBar() {
   if (menu) menu.classList.remove("visible");
 }
 
+// ─── Delete Button (Floating Action Bar) ───────────────────────────────────
+document.getElementById("deleteSelectedBtn")?.addEventListener("click", () => {
+  if (!fdCanvas) return;
+  const changed = fdCanvas.delete_selected();
+  if (changed) {
+    render();
+    syncTextToExtension();
+    updateFloatingBar();
+  }
+});
+
 // ─── Onboarding Overlay ────────────────────────────────────────────────────
 
 /** Show onboarding overlay if the canvas is empty (no nodes) */


### PR DESCRIPTION
## Changes\n\n- Added visible delete button (✕ icon) directly in the floating action bar\n- `.fab-delete-btn` CSS with red hover feedback (#FF3B30)\n- Click handler calls `delete_selected()` → render + sync\n- Version bump to 0.9.9\n\n## Tests\n\nAll existing Rust tests confirmed passing:\n- tools.rs: eraser_tool_lifecycle, eraser_tool_clear_resets_state, eraser_tool_pointerdown_clears_previous_ids\n- shortcuts.rs: resolve_tool_shortcuts (includes 'e' → ToolEraser)\n- sync.rs: erase_child_preserves_group, erase_last_child_leaves_empty_group, erase_nested_cascade\n\n✅ cargo check, test, clippy, fmt all pass"