### PR TITLE
chore(release): v0.10.0 — eraser tool, delete button, group-aware deletion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 license = "MIT"
 authors = ["Khang Nghiêm"]

--- a/fd-vscode/CHANGELOG.md
+++ b/fd-vscode/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.10.0] — 2026-03-02
+
+### Added
+
+- **Eraser tool** (`E`): Click to erase single nodes, drag to erase multiple. Red poof fade animation on deletion. Eraser toolbar button with custom circle-X cursor.
+- **Delete button**: Visible ✕ button in floating action bar when nodes are selected. Click to delete selection.
+- **Group-aware deletion**: Erasing a child detaches it from the group first. Empty groups auto-cascade delete up the ancestor chain.
+- **Ctrl+click temporary eraser**: Hold Ctrl from any tool to temporarily switch to eraser; release Ctrl to return.
+- **Duplicate naming**: Duplicated objects get derived names from the original (e.g., `rect_1` → `rect_1_copy`).
+- **Figma-style group selection**: Click selects group, double-click drills into children.
+
 ## [0.6.13] — 2026-02-22
 
 ### Added

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.9.9",
+  "version": "0.10.0",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Release v0.10.0\n\n### Version bumps\n- fd-core/fd-lsp/fd-editor/fd-render/fd-wasm: 0.1.10 → 0.1.11\n- fd-vscode: 0.9.9 → 0.10.0\n\n### Changes since last publish\n- Eraser tool (E key, toolbar, drag-to-erase, red poof animation)\n- Delete button in floating action bar\n- Group-aware deletion with cascade\n- Ctrl+click temporary eraser override\n- Duplicate naming + Figma-style group selection