### PR TITLE
chore: remove pre-existing duplicate separators from dark_theme.fd

### DIFF
--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -25,9 +25,6 @@ theme dark_text {
 
 # ─── Layout ───
 
-# ─── Layout ───
-# ─── Layout ───
-# ─── Layout ───
 # ─── Settings panel ───────────────────────────────────────────────────────
 group @settings {
   group @header {


### PR DESCRIPTION
Cleanup: removes the 3 duplicate `# ─── Layout ───` lines that were baked into the file before the parser fix in #325.