### PR TITLE
fix(canvas): eraser context menu guard + lock icon + undo dismissal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## Completed Requirements
 
+### v0.10.7 — Eraser Context Menu Fix + Lock Icon + Undo Dismissal
+
+- **FIX (R3.48)**: Ctrl+click eraser no longer opens context menu on macOS — `contextmenu` event is now suppressed when eraser tool is active (temp or permanent)
+- **UX (R3.49)**: Floating toolbar tool buttons now show 🔒 lock badge at top-right when tool is locked (double-press) — matches existing top toolbar behavior
+- **FIX (R3.50)**: Undo/redo now dismisses open context menus and annotation cards — prevents stale popups after graph state changes
+
 ### v0.10.6 — Fix Eraser Tool Crash
 
 - **FIX (R3.48)**: Pressing E (eraser tool) no longer crashes/freezes the canvas — `handle_pointer_move` in WASM had `unreachable!()` for eraser when not dragging; replaced with `vec![]` no-op for hover state

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2154,6 +2154,38 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       box-shadow: 0 2px 6px rgba(42, 110, 240, 0.3);
     }
     .dark-theme .ft-tool-btn.active { box-shadow: 0 2px 6px rgba(58, 130, 246, 0.4); }
+    .ft-tool-btn.locked {
+      background: var(--fd-accent);
+      color: #fff;
+      box-shadow: 0 2px 6px rgba(42, 110, 240, 0.3), 0 0 0 1.5px rgba(255,255,255,0.5);
+    }
+    .dark-theme .ft-tool-btn.locked {
+      box-shadow: 0 2px 6px rgba(58, 130, 246, 0.4), 0 0 0 1.5px rgba(255,255,255,0.25);
+    }
+    .ft-tool-btn.locked::after {
+      content: '';
+      position: absolute;
+      top: -2px;
+      right: -2px;
+      width: 10px;
+      height: 10px;
+      background: var(--fd-surface-solid);
+      border-radius: 50%;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+      /* Lock SVG as mask */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .ft-tool-btn.locked::before {
+      content: '🔒';
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      font-size: 8px;
+      line-height: 1;
+      z-index: 1;
+    }
     .ft-tooltip {
       position: absolute;
       bottom: calc(100% + 8px);

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1607,6 +1607,8 @@ document.addEventListener("keydown", (e) => {
   if (result.changed) {
     render();
     syncTextToExtension();
+    closeContextMenu();
+    closeAnnotationCard();
   }
 
   // Handle tool switches from keyboard
@@ -2358,6 +2360,9 @@ function setupContextMenu() {
   canvas.addEventListener("contextmenu", (e) => {
     e.preventDefault();
     if (!fdCanvas) return;
+    // On macOS, Ctrl+click fires contextmenu alongside the eraser pointerdown.
+    // Suppress the context menu when eraser is active (temp or permanent).
+    if (tempEraserMode || fdCanvas.get_tool_name() === "eraser") return;
 
     const rect = canvas.getBoundingClientRect();
     // Adjust for pan offset to get scene-space coords


### PR DESCRIPTION
## Changes

### 1. Fix: Ctrl+click eraser context menu (macOS)
On macOS, Ctrl+click fires a `contextmenu` event simultaneously with the eraser pointerdown. This caused a context menu to open on top of the eraser action. Now suppressed when eraser is active (temp or permanent).

### 2. UX: Lock icon on floating toolbar
Floating toolbar `.ft-tool-btn` now shows a 🔒 badge at top-right when a tool is locked (double-press), with accent border ring. Matches existing top toolbar `.tool-btn.locked` behavior.

### 3. Fix: Undo/redo dismisses popups
Undo/redo now closes any open context menus and annotation cards, preventing stale popups after graph state changes.

## Verification
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace` (all tests pass)
- ✅ `pnpm test` (191 tests pass)
- ✅ WASM build + TypeScript compile