### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Renamify panel

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## YYYY-MM-DD - XSS Vulnerability in Renamify
+**Vulnerability:** XSS via node IDs in renamify HTML injection.
+**Learning:** Avoid unsanitized variable injection into `.innerHTML`.
+**Prevention:** Use `document.createElement()` with `.textContent` or escape the string first.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2833,11 +2833,29 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         items.forEach((p, i) => {
           const row = document.createElement('div');
           row.className = 'renamify-row';
-          row.innerHTML =
-            '<input type="checkbox" checked data-idx="' + i + '">' +
-            '<span class="renamify-old">@' + p.oldId + '</span>' +
-            '<span class="renamify-arrow">→</span>' +
-            '<span class="renamify-new">@' + p.newId + '</span>';
+
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = true;
+          cb.dataset.idx = i.toString();
+
+          const oldSpan = document.createElement('span');
+          oldSpan.className = 'renamify-old';
+          oldSpan.textContent = '@' + p.oldId;
+
+          const arrow = document.createElement('span');
+          arrow.className = 'renamify-arrow';
+          arrow.textContent = '→';
+
+          const newSpan = document.createElement('span');
+          newSpan.className = 'renamify-new';
+          newSpan.textContent = '@' + p.newId;
+
+          row.appendChild(cb);
+          row.appendChild(oldSpan);
+          row.appendChild(arrow);
+          row.appendChild(newSpan);
+
           body.appendChild(row);
         });
         footer.style.display = 'flex';


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The Renamify panel used `innerHTML` to directly embed AI-proposed node IDs (`p.oldId` and `p.newId`) into the DOM. This allowed for an XSS vulnerability if a maliciously crafted `.fd` file node ID was processed and suggested by the AI refine process.
🎯 **Impact**: Arbitrary JavaScript execution in the context of the VSCode webview. 
🔧 **Fix**: Replaced the unsafe `row.innerHTML` string construction with `document.createElement()` and securely populated user-facing strings using `textContent`.
✅ **Verification**: Run `pnpm test` and `pnpm compile` in the `fd-vscode` directory to ensure functionality is unbroken and tests pass.

---
*PR created automatically by Jules for task [10459505532033432297](https://jules.google.com/task/10459505532033432297) started by @khangnghiem*