### PR TITLE
refactor: extract LINE_HEIGHT_MULTIPLIER constant

### DIFF
--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -3,6 +3,7 @@
 //! Converts relative constraints (center_in, offset, fill_parent) into
 //! absolute `ResolvedBounds` for each node. Also handles Column/Row/Grid
 //! layout modes for groups.
+pub const LINE_HEIGHT_MULTIPLIER: f32 = 1.4;
 
 use crate::model::*;
 use petgraph::graph::NodeIndex;
@@ -388,7 +389,10 @@ fn intrinsic_size(node: &SceneNode) -> (f32, f32) {
         NodeKind::Text { content } => {
             let font_size = node.style.font.as_ref().map_or(14.0, |f| f.size);
             let char_width = font_size * 0.6;
-            (content.chars().count() as f32 * char_width, font_size * 1.4)
+            (
+                content.chars().count() as f32 * char_width,
+                font_size * LINE_HEIGHT_MULTIPLIER,
+            )
         }
         NodeKind::Group => (0.0, 0.0), // Auto-sized: computed after children resolve
         NodeKind::Frame { width, height, .. } => (*width, *height),
@@ -725,19 +729,19 @@ frame @card {
             amount.y,
             button.y
         );
-        // Heading height should use font size × 1.4 (line-height)
-        let expected_heading_h = 18.0 * 1.4;
+        // Heading height should use font size × LINE_HEIGHT_MULTIPLIER (line-height)
+        let expected_heading_h = 18.0 * LINE_HEIGHT_MULTIPLIER;
         assert!(
             (heading.height - expected_heading_h).abs() < 0.01,
-            "heading height should be {} (font size × 1.4), got {}",
+            "heading height should be {} (font size × LINE_HEIGHT_MULTIPLIER), got {}",
             expected_heading_h,
             heading.height
         );
-        // Amount height should use font size × 1.4 (line-height)
-        let expected_amount_h = 36.0 * 1.4;
+        // Amount height should use font size × LINE_HEIGHT_MULTIPLIER (line-height)
+        let expected_amount_h = 36.0 * LINE_HEIGHT_MULTIPLIER;
         assert!(
             (amount.height - expected_amount_h).abs() < 0.01,
-            "amount height should be {} (font size × 1.4), got {}",
+            "amount height should be {} (font size × LINE_HEIGHT_MULTIPLIER), got {}",
             expected_amount_h,
             amount.height
         );

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -15,6 +15,7 @@
 use fd_core::NodeIndex;
 use fd_core::emitter::emit_document;
 use fd_core::id::NodeId;
+use fd_core::layout::LINE_HEIGHT_MULTIPLIER;
 use fd_core::model::*;
 use fd_core::parser::parse_document;
 use fd_core::{ResolvedBounds, Viewport, resolve_layout};
@@ -481,7 +482,7 @@ impl SyncEngine {
                 .as_ref()
                 .map_or(14.0, |f| f.size);
             let text_w = content.chars().count() as f32 * font_size * 0.6;
-            let text_h = font_size * 1.4;
+            let text_h = font_size * LINE_HEIGHT_MULTIPLIER;
             let cx = child_b.x + child_b.width / 2.0;
             let cy = child_b.y + child_b.height / 2.0;
             child_b.width = text_w;
@@ -655,7 +656,7 @@ fn handle_child_group_relationship(
             .as_ref()
             .map_or(14.0, |f| f.size);
         let text_w = content.chars().count() as f32 * font_size * 0.6;
-        let text_h = font_size * 1.4;
+        let text_h = font_size * LINE_HEIGHT_MULTIPLIER;
 
         // Shrink the overlap test box to the visual text area.
         let cx = child_b.x + child_b.width / 2.0;


### PR DESCRIPTION
Replaced the hardcoded magic number `1.4` used for calculating text line heights across the codebase with a new public constant `LINE_HEIGHT_MULTIPLIER` in `crates/fd-core/src/layout.rs`. The new constant is now imported and utilized in `crates/fd-editor/src/sync.rs`, ensuring a single source of truth for the line height multiplier and adhering to DRY principles. Tests and formatting verified successfully.

---
*PR created automatically by Jules for task [11423594866448970473](https://jules.google.com/task/11423594866448970473) started by @khangnghiem*