### PR TITLE
refactor(vscode): remove onboarding overlay

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.10.9 — Remove Onboarding Overlay
+
+- **REMOVED (R3.51)**: Removed the "Start drawing" / "Create something beautiful" onboarding overlay — it obstructed the canvas with a z-index 950 full-screen backdrop that flashed on every file open (even non-empty files like `dark_theme.fd`); the floating scroll toolbar with tooltips and `?` shortcut help already provide sufficient tool discovery
+- **CLEANUP**: ~85 lines CSS, 22 lines HTML, ~57 lines JS removed from `webview-html.ts` and `main.js`
+
 ### v0.10.8 — Fix Floating Toolbar Drag Handles
 
 - **FIX (R3.39)**: Floating toolbar drag handles now work reliably in VS Code webview — moved `pointermove`/`pointerup` listeners from handle elements to document level; `setPointerCapture` silently fails in VS Code webview iframes, causing drag events to stop when pointer leaves the small handle element

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -288,91 +288,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     }
 
 
-    /* ── Onboarding Overlay ── */
-    #onboarding-overlay {
-      position: absolute;
-      inset: 0;
-      z-index: 950;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      background: radial-gradient(ellipse at center, rgba(20,20,30,0.92) 0%, rgba(10,10,18,0.97) 100%);
-      backdrop-filter: blur(8px);
-      pointer-events: auto;
-      opacity: 1;
-      transition: opacity 0.4s ease;
-    }
-    #onboarding-overlay.hidden { opacity: 0; pointer-events: none; }
-    .onboard-heading {
-      font-size: 28px;
-      font-weight: 300;
-      color: #eee;
-      letter-spacing: 1px;
-      margin-bottom: 8px;
-      animation: onboardFloat 3s ease-in-out infinite;
-    }
-    .onboard-sub {
-      font-size: 13px;
-      color: rgba(255,255,255,0.4);
-      margin-bottom: 32px;
-    }
-    @keyframes onboardFloat {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-6px); }
-    }
-    .onboard-cards {
-      display: flex;
-      gap: 16px;
-      margin-bottom: 40px;
-    }
-    .onboard-card {
-      width: 140px;
-      padding: 20px 16px;
-      background: rgba(255,255,255,0.06);
-      border: 1px solid rgba(255,255,255,0.1);
-      border-radius: 14px;
-      text-align: center;
-      cursor: pointer;
-      transition: all 0.2s ease;
-      font-family: inherit;
-      font-size: inherit;
-      color: inherit;
-    }
-    .onboard-card:focus-visible {
-      outline: 2px solid var(--fd-accent);
-      outline-offset: 2px;
-    }
-    .onboard-card:hover {
-      background: rgba(255,255,255,0.12);
-      border-color: var(--fd-accent);
-      transform: translateY(-4px);
-      box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-    }
-    .onboard-card-icon { font-size: 28px; display: block; margin-bottom: 10px; }
-    .onboard-card-title {
-      font-size: 13px;
-      font-weight: 500;
-      color: #ddd;
-    }
-    .onboard-card-desc {
-      font-size: 10px;
-      color: rgba(255,255,255,0.35);
-      margin-top: 4px;
-    }
-    .onboard-hint {
-      font-size: 11px;
-      color: rgba(255,255,255,0.25);
-      letter-spacing: 0.5px;
-    }
-    .onboard-hint kbd {
-      background: rgba(255,255,255,0.1);
-      border: 1px solid rgba(255,255,255,0.15);
-      border-radius: 3px;
-      padding: 1px 5px;
-      font-family: inherit;
-      font-size: 11px;
-    }
+
     .tool-icon { font-size: 13px; }
     .tool-key {
       font-size: 9px;
@@ -2515,28 +2431,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   </div>
   <div id="canvas-container">
 
-    <div id="onboarding-overlay">
-      <div class="onboard-heading">Start drawing</div>
-      <div class="onboard-sub">Create something beautiful</div>
-      <div class="onboard-cards">
-        <button class="onboard-card" data-tool="rect" type="button">
-          <span class="onboard-card-icon">📐</span>
-          <div class="onboard-card-title">Draw shapes</div>
-          <div class="onboard-card-desc">Rectangles, ellipses, frames</div>
-        </button>
-        <button class="onboard-card" data-tool="pen" type="button">
-          <span class="onboard-card-icon">✏️</span>
-          <div class="onboard-card-title">Sketch freely</div>
-          <div class="onboard-card-desc">Freehand pen drawings</div>
-        </button>
-        <button class="onboard-card" data-tool="text" type="button">
-          <span class="onboard-card-icon">📝</span>
-          <div class="onboard-card-title">Type text</div>
-          <div class="onboard-card-desc">Labels, headings, notes</div>
-        </button>
-      </div>
-      <div class="onboard-hint">Press <kbd>?</kbd> for all shortcuts</div>
-    </div>
+
     <div id="floating-action-bar">
       <label class="fab-label" for="fab-fill">Fill</label>
       <input type="color" id="fab-fill" class="fab-color" value="#4A90D9" title="Fill color">

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -367,8 +367,7 @@ async function main() {
     setupAnimPicker();
     setupHelpButton();
     setupFloatingBar();
-    setupOnboarding();
-    checkOnboarding();
+
     setupApplePencilPro();
     setupThemeToggle();
     setupSketchyToggle();
@@ -2006,63 +2005,7 @@ document.getElementById("deleteSelectedBtn")?.addEventListener("click", () => {
   }
 });
 
-// ─── Onboarding Overlay ────────────────────────────────────────────────────
 
-/** Show onboarding overlay if the canvas is empty (no nodes) */
-function checkOnboarding() {
-  const overlay = document.getElementById("onboarding-overlay");
-  if (!overlay || !fdCanvas) return;
-  const text = fdCanvas.get_text().trim();
-  // Show overlay if canvas text is empty or only whitespace/comments
-  const hasNodes = /\b(rect|ellipse|text|group|frame|pen|arrow|path)\s+@/.test(text);
-  if (!hasNodes) {
-    overlay.classList.remove("hidden");
-  } else {
-    overlay.classList.add("hidden");
-  }
-}
-
-/** Dismiss onboarding overlay with fade-out */
-function dismissOnboarding() {
-  const overlay = document.getElementById("onboarding-overlay");
-  if (!overlay) return;
-  if (!overlay.classList.contains("hidden")) {
-    overlay.classList.add("hidden");
-    // Remove from DOM after transition to free up resources
-    setTimeout(() => { overlay.remove(); }, 500);
-  }
-}
-
-/** Wire onboarding card clicks + auto-dismiss */
-function setupOnboarding() {
-  const overlay = document.getElementById("onboarding-overlay");
-  if (!overlay) return;
-
-  // Card clicks → activate tool + dismiss
-  overlay.querySelectorAll(".onboard-card").forEach(card => {
-    card.addEventListener("click", (e) => {
-      e.stopPropagation();
-      const tool = card.dataset.tool;
-      if (tool && fdCanvas) {
-        fdCanvas.set_tool(tool);
-        updateToolbarActive(tool);
-        updateCanvasCursor(tool);
-      }
-      dismissOnboarding();
-    });
-  });
-
-  // Dismiss on any canvas interaction
-  const canvas = document.getElementById("fd-canvas");
-  if (canvas) {
-    canvas.addEventListener("pointerdown", dismissOnboarding, { once: true });
-  }
-  document.addEventListener("keydown", (e) => {
-    // Don't dismiss on modifier-only keys
-    if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return;
-    dismissOnboarding();
-  }, { once: true });
-}
 
 function setupFloatingBar() {
   const fab = document.getElementById("floating-action-bar");


### PR DESCRIPTION
## Remove Onboarding Overlay

The "Start drawing" / "Create something beautiful" onboarding overlay obstructed the canvas with a z-index 950 full-screen backdrop that flashed on every file open, even for non-empty files like `dark_theme.fd`.

The floating scroll toolbar with tooltips and `?` shortcut help already provide sufficient tool discovery.

### Changes
- Removed ~85 lines CSS (onboarding overlay styles, animations, card layout)
- Removed 22 lines HTML (overlay container, cards, hint)
- Removed ~57 lines JS (checkOnboarding, dismissOnboarding, setupOnboarding functions + setup calls)
- Bumped version to 0.10.9

### CI Results
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace`
- ✅ `pnpm run compile` (TypeScript)
- ✅ `pnpm test` (191 tests pass)