### PR TITLE
fix(toolbar): use document-level listeners for drag-to-create

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.10.10 — Fix Drag-to-Create from Toolbar
+
+- **FIX (R3.39)**: Drag-to-create now works in VS Code webview — moved `pointermove`/`pointerup` listeners from button-level to document-level; same root cause as v0.10.8 (toolbar drag handles): `setPointerCapture` silently fails in VS Code webview iframes, so pointer events stopped firing when cursor left the toolbar button
+
 ### v0.10.9 — Remove Onboarding Overlay
 
 - **REMOVED (R3.51)**: Removed the "Start drawing" / "Create something beautiful" onboarding overlay — it obstructed the canvas with a z-index 950 full-screen backdrop that flashed on every file open (even non-empty files like `dark_theme.fd`); the floating scroll toolbar with tooltips and `?` shortcut help already provide sufficient tool discovery

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4808,7 +4808,10 @@ function setupFloatingToolbar() {
     if (dtcGhost) { dtcGhost.remove(); dtcGhost = null; }
   }
 
-  // Attach to each tool button (except select — can't drag-to-create with select)
+  // Track which button initiated the drag for click suppression
+  let dtcBtn = null;
+
+  // Attach pointerdown to each tool button (except select)
   toolbar.querySelectorAll(".ft-tool-btn[data-tool]").forEach((btn) => {
     const tool = btn.getAttribute("data-tool");
     if (tool === "select") return;
@@ -4816,90 +4819,12 @@ function setupFloatingToolbar() {
     btn.addEventListener("pointerdown", (e) => {
       e.stopPropagation(); // Prevent scroll-handle drag from activating
       dtcTool = tool;
+      dtcBtn = btn;
       dtcStartX = e.clientX;
       dtcStartY = e.clientY;
       dtcActive = false;
-      btn.setPointerCapture(e.pointerId);
-    });
-
-    btn.addEventListener("pointermove", (e) => {
-      if (!dtcTool) return;
-      const dx = e.clientX - dtcStartX;
-      const dy = e.clientY - dtcStartY;
-      if (!dtcActive && (dx * dx + dy * dy) >= DRAG_THRESHOLD * DRAG_THRESHOLD) {
-        dtcActive = true;
-        dtcGhost = createGhost(dtcTool);
-      }
-      if (dtcActive && dtcGhost) {
-        moveGhost(dtcGhost, e.clientX, e.clientY);
-      }
-    });
-
-    btn.addEventListener("pointerup", (e) => {
-      btn.releasePointerCapture(e.pointerId);
-      if (!dtcTool) return;
-
-      if (dtcActive) {
-        // Drag-to-create: check if drop is over the canvas
-        removeGhost();
-        const canvasEl = document.getElementById("fd-canvas");
-        if (canvasEl && fdCanvas) {
-          const rect = canvasEl.getBoundingClientRect();
-          const cx = e.clientX;
-          const cy = e.clientY;
-          if (cx >= rect.left && cx <= rect.right
-            && cy >= rect.top && cy <= rect.bottom) {
-            const rawX = ((cx - rect.left) - panX) / zoomLevel;
-            const rawY = ((cy - rect.top) - panY) / zoomLevel;
-
-            // ── Text drop-to-consume: text on shape or edge ──
-            if (dtcTool === "text") {
-              const consumed = dtcTextConsume(rawX, rawY, cx, cy, rect);
-              if (consumed) {
-                dtcActive = false;
-                dtcTool = null;
-                btn._dtcSuppressClick = true;
-                return;
-              }
-            }
-
-            // ── Snap-to-node detection (non-text tools) ──
-            const snap = dtcFindSnapTarget(rawX, rawY, dtcTool);
-            const sceneX = snap ? snap.x : rawX;
-            const sceneY = snap ? snap.y : rawY;
-
-            const created = fdCanvas.create_node_at(dtcTool, sceneX, sceneY);
-            if (created) {
-              lastDrawingTool = dtcTool;
-              applyDefaultsToNewNode(dtcTool);
-              bumpGeneration();
-
-              // ── Auto-create edge if snapped ──
-              if (snap && snap.targetId) {
-                const newNodeId = fdCanvas.get_selected_id();
-                if (newNodeId) {
-                  const edgeId = fdCanvas.create_edge(snap.targetId, newNodeId);
-                  if (edgeId) {
-                    bumpGeneration();
-                    const midSX = (cx + ((snap.targetCx * zoomLevel + panX) + rect.left)) / 2;
-                    const midSY = (cy + ((snap.targetCy * zoomLevel + panY) + rect.top)) / 2;
-                    showEdgeContextMenu(edgeId, midSX, midSY);
-                  }
-                }
-              }
-
-              render();
-              syncTextToExtension();
-              updatePropertiesPanel();
-            }
-          }
-        }
-        dtcActive = false;
-        dtcTool = null;
-        btn._dtcSuppressClick = true;
-      } else {
-        dtcTool = null;
-      }
+      // NOTE: setPointerCapture intentionally omitted —
+      // it silently fails in VS Code webview iframes
     });
 
     // Suppress click after drag-to-create
@@ -4910,12 +4835,97 @@ function setupFloatingToolbar() {
         e.preventDefault();
       }
     }, true);
+  });
 
-    btn.addEventListener("pointercancel", () => {
+  // Document-level listeners — setPointerCapture fails in VS Code webview iframes
+  document.addEventListener("pointermove", (e) => {
+    if (!dtcTool) return;
+    const dx = e.clientX - dtcStartX;
+    const dy = e.clientY - dtcStartY;
+    if (!dtcActive && (dx * dx + dy * dy) >= DRAG_THRESHOLD * DRAG_THRESHOLD) {
+      dtcActive = true;
+      dtcGhost = createGhost(dtcTool);
+    }
+    if (dtcActive && dtcGhost) {
+      moveGhost(dtcGhost, e.clientX, e.clientY);
+    }
+  });
+
+  document.addEventListener("pointerup", (e) => {
+    if (!dtcTool) return;
+
+    if (dtcActive) {
+      // Drag-to-create: check if drop is over the canvas
       removeGhost();
+      const canvasEl = document.getElementById("fd-canvas");
+      if (canvasEl && fdCanvas) {
+        const rect = canvasEl.getBoundingClientRect();
+        const cx = e.clientX;
+        const cy = e.clientY;
+        if (cx >= rect.left && cx <= rect.right
+          && cy >= rect.top && cy <= rect.bottom) {
+          const rawX = ((cx - rect.left) - panX) / zoomLevel;
+          const rawY = ((cy - rect.top) - panY) / zoomLevel;
+
+          // ── Text drop-to-consume: text on shape or edge ──
+          if (dtcTool === "text") {
+            const consumed = dtcTextConsume(rawX, rawY, cx, cy, rect);
+            if (consumed) {
+              dtcActive = false;
+              dtcTool = null;
+              if (dtcBtn) dtcBtn._dtcSuppressClick = true;
+              dtcBtn = null;
+              return;
+            }
+          }
+
+          // ── Snap-to-node detection (non-text tools) ──
+          const snap = dtcFindSnapTarget(rawX, rawY, dtcTool);
+          const sceneX = snap ? snap.x : rawX;
+          const sceneY = snap ? snap.y : rawY;
+
+          const created = fdCanvas.create_node_at(dtcTool, sceneX, sceneY);
+          if (created) {
+            lastDrawingTool = dtcTool;
+            applyDefaultsToNewNode(dtcTool);
+            bumpGeneration();
+
+            // ── Auto-create edge if snapped ──
+            if (snap && snap.targetId) {
+              const newNodeId = fdCanvas.get_selected_id();
+              if (newNodeId) {
+                const edgeId = fdCanvas.create_edge(snap.targetId, newNodeId);
+                if (edgeId) {
+                  bumpGeneration();
+                  const midSX = (cx + ((snap.targetCx * zoomLevel + panX) + rect.left)) / 2;
+                  const midSY = (cy + ((snap.targetCy * zoomLevel + panY) + rect.top)) / 2;
+                  showEdgeContextMenu(edgeId, midSX, midSY);
+                }
+              }
+            }
+
+            render();
+            syncTextToExtension();
+            updatePropertiesPanel();
+          }
+        }
+      }
       dtcActive = false;
       dtcTool = null;
-    });
+      if (dtcBtn) dtcBtn._dtcSuppressClick = true;
+      dtcBtn = null;
+    } else {
+      dtcTool = null;
+      dtcBtn = null;
+    }
+  });
+
+  document.addEventListener("pointercancel", () => {
+    if (!dtcTool) return;
+    removeGhost();
+    dtcActive = false;
+    dtcTool = null;
+    dtcBtn = null;
   });
   // ── Text drop-to-consume helper ──
   function dtcTextConsume(sceneX, sceneY, screenX, screenY, canvasRect) {


### PR DESCRIPTION
## Fix Drag-to-Create from Floating Toolbar

### Problem
Shapes cannot be dragged from the floating toolbar onto the canvas to create new shapes. The ghost preview never appears and the drop never triggers.

### Root Cause
Same issue as PR #333 (toolbar drag handles): `setPointerCapture` **silently fails** in VS Code webview iframes. The DTC code used `btn.setPointerCapture()` + button-level `pointermove`/`pointerup` listeners, so when the pointer left the small toolbar button, events stopped firing.

### Fix
Moved `pointermove`, `pointerup`, and `pointercancel` listeners from button-level to document-level (same pattern already working for toolbar drag handles since v0.10.8). Removed `setPointerCapture`/`releasePointerCapture` calls. Added `dtcBtn` variable to track the originating button for click suppression.

### Tests
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all`
- ✅ `cargo test --workspace`
- ✅ `pnpm test` — 191 tests pass