### PR TITLE
feat(style): transparent defaults + theme-contextual stroke + copy/paste style

### DIFF
--- a/crates/fd-editor/src/shortcuts.rs
+++ b/crates/fd-editor/src/shortcuts.rs
@@ -57,6 +57,12 @@ pub enum ShortcutAction {
     // ── Hierarchy ──
     Group,
     Ungroup,
+
+    // ── Style ──
+    /// Copy selected node's style to clipboard (⌥⌘C).
+    CopyStyle,
+    /// Paste clipboard style onto selected node (⌥⌘V).
+    PasteStyle,
 }
 
 /// Resolves key events into shortcut actions.
@@ -80,10 +86,19 @@ impl ShortcutMap {
         key: &str,
         ctrl: bool,
         shift: bool,
-        _alt: bool,
+        alt: bool,
         meta: bool,
     ) -> Option<ShortcutAction> {
         let cmd = ctrl || meta;
+
+        // ── Alt+Cmd combos (style clipboard) ──
+        if alt && cmd && !shift {
+            return match key {
+                "c" | "C" => Some(ShortcutAction::CopyStyle),
+                "v" | "V" => Some(ShortcutAction::PasteStyle),
+                _ => None,
+            };
+        }
 
         // ── Modifier combos first (most specific) ──
         if cmd && shift {
@@ -326,6 +341,25 @@ mod tests {
         assert_eq!(
             ShortcutMap::resolve("?", false, true, false, false),
             Some(ShortcutAction::ShowHelp)
+        );
+    }
+
+    #[test]
+    fn resolve_copy_paste_style() {
+        // ⌥⌘C → CopyStyle
+        assert_eq!(
+            ShortcutMap::resolve("c", false, false, true, true),
+            Some(ShortcutAction::CopyStyle)
+        );
+        // ⌥⌘V → PasteStyle
+        assert_eq!(
+            ShortcutMap::resolve("v", false, false, true, true),
+            Some(ShortcutAction::PasteStyle)
+        );
+        // ⌘C without Alt → regular Copy
+        assert_eq!(
+            ShortcutMap::resolve("c", false, false, false, true),
+            Some(ShortcutAction::Copy)
         );
     }
 }

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -57,6 +57,8 @@ pub struct FdCanvas {
     hover_start_ms: f64,
     /// Pointer-down scene position — used to detect click vs drag.
     pointer_down_pos: Option<(f32, f32)>,
+    /// Style clipboard for Copy/Paste Style (⌥⌘C / ⌥⌘V).
+    style_clipboard: Option<fd_core::model::Style>,
 }
 
 #[wasm_bindgen]
@@ -95,6 +97,7 @@ impl FdCanvas {
             pressed_id: None,
             hover_start_ms: 0.0,
             pointer_down_pos: None,
+            style_clipboard: None,
         }
     }
 
@@ -1701,7 +1704,12 @@ impl FdCanvas {
         let mut node = SceneNode::new(id, node_kind);
         node.constraints.push(Constraint::Position { x, y });
 
-        // ScreenBrush-style defaults: transparent fill + bezeled stroke
+        // Transparent fill + contextual stroke (adapts to canvas theme)
+        let stroke_color = if self.dark_mode {
+            Color::rgba(0.63, 0.63, 0.69, 1.0) // #A0A0B0 — visible on dark bg
+        } else {
+            Color::rgba(0.2, 0.2, 0.2, 1.0) // #333333 — visible on light bg
+        };
         if kind == "frame" {
             node.style.fill = Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0)));
             node.style.stroke = Some(Stroke {
@@ -1711,18 +1719,16 @@ impl FdCanvas {
                 join: StrokeJoin::Miter,
             });
         } else if kind == "rect" {
-            node.style.fill = Some(Paint::Solid(Color::rgba(1.0, 1.0, 1.0, 1.0)));
             node.style.stroke = Some(Stroke {
-                paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
+                paint: Paint::Solid(stroke_color),
                 width: 2.5,
                 cap: StrokeCap::Round,
                 join: StrokeJoin::Round,
             });
             node.style.corner_radius = Some(8.0);
         } else if kind == "ellipse" {
-            node.style.fill = Some(Paint::Solid(Color::rgba(1.0, 1.0, 1.0, 1.0)));
             node.style.stroke = Some(Stroke {
-                paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
+                paint: Paint::Solid(stroke_color),
                 width: 2.5,
                 cap: StrokeCap::Round,
                 join: StrokeJoin::Round,
@@ -2187,6 +2193,32 @@ impl FdCanvas {
             | ShortcutAction::PanStart
             | ShortcutAction::PanEnd
             | ShortcutAction::ShowHelp => (false, false),
+
+            // Style clipboard
+            ShortcutAction::CopyStyle => {
+                if let Some(id) = self.select_tool.first_selected()
+                    && let Some(node) = self.engine.graph.get_by_id(id)
+                {
+                    self.style_clipboard = Some(node.style.clone());
+                }
+                (false, false)
+            }
+            ShortcutAction::PasteStyle => {
+                if let Some(ref clipboard) = self.style_clipboard.clone()
+                    && let Some(id) = self.select_tool.first_selected()
+                {
+                    let mutation = GraphMutation::SetStyle {
+                        id,
+                        style: clipboard.clone(),
+                    };
+                    let changed = self.apply_mutations(vec![mutation]);
+                    if changed {
+                        self.engine.flush_to_text();
+                    }
+                    return (changed, false);
+                }
+                (false, false)
+            }
         }
     }
 }
@@ -2237,6 +2269,8 @@ fn action_to_name(action: ShortcutAction) -> &'static str {
         ShortcutAction::BringToFront => "bringToFront",
         ShortcutAction::Deselect => "deselect",
         ShortcutAction::ShowHelp => "showHelp",
+        ShortcutAction::CopyStyle => "copyStyle",
+        ShortcutAction::PasteStyle => "pasteStyle",
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## Completed Requirements
 
+### v0.10.12 — Transparent Defaults + Copy/Paste Style
+
+- **UX (R3.52)**: Newly created rect/ellipse shapes now default to transparent fill with visible stroke — removes the opaque white rectangle that previously obscured content underneath; consistent with Excalidraw/ScreenBrush behavior
+- **UX (R3.52)**: Stroke color is now theme-contextual — dark stroke (`#333`) on light canvas, light stroke (`#A0A0B0`) on dark canvas; adapts via `self.dark_mode` flag in WASM `create_node_at`
+- **NEW (R3.53)**: Copy Style (⌥⌘C) / Paste Style (⌥⌘V) — copies the selected node's full `Style` (fill, stroke, corner radius, opacity, font, shadow) to a clipboard, then applies it to another selected node; toast feedback "Style copied" / "Style pasted"
+- **CORE**: `style_clipboard: Option<Style>` field on `FdCanvas` for cross-node style transfer via `CopyStyle` / `PasteStyle` `ShortcutAction` dispatch
+- **TESTING**: New `resolve_copy_paste_style` test — verifies ⌥⌘C → CopyStyle, ⌥⌘V → PasteStyle, ⌘C → Copy (no alt regression)
+
 ### v0.10.11 — Fix Nested Group Drill-Down
 
 - **FIX (R3.24)**: Clicking a node nested inside multiple groups (e.g., `OuterGroup > InnerGroup > Rect`) now correctly drills down through the hierarchy — first click selects outer group, second click selects inner group, third click selects the leaf node; previously clicks oscillated between the two groups forever because `effective_target` required cumulative selection `[outer, inner]` but `SelectTool` replaced selection to `[inner]`; fixed by using `rposition` (deepest match) instead of linear scan

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -141,6 +141,28 @@ function captureDefault(prop, value) {
 /** Store the last drawing tool used for default capturing from Select mode */
 let lastDrawingTool = "rect";
 
+/** Show a brief toast notification at the bottom of the canvas */
+function showToast(message, durationMs = 1200) {
+  const existing = document.getElementById("fd-toast");
+  if (existing) existing.remove();
+  const el = document.createElement("div");
+  el.id = "fd-toast";
+  el.textContent = message;
+  el.style.cssText = `
+    position: fixed; bottom: 80px; left: 50%; transform: translateX(-50%);
+    padding: 6px 16px; border-radius: 8px; font-size: 12px; font-weight: 500;
+    color: #fff; background: rgba(30,30,46,0.85); backdrop-filter: blur(8px);
+    pointer-events: none; z-index: 9999; opacity: 0;
+    transition: opacity 150ms ease;
+  `;
+  (canvas ? canvas.parentElement : document.body).appendChild(el);
+  requestAnimationFrame(() => { el.style.opacity = "1"; });
+  setTimeout(() => {
+    el.style.opacity = "0";
+    setTimeout(() => el.remove(), 200);
+  }, durationMs);
+}
+
 /** Apply stored defaults to the currently selected (newly created) node */
 function applyDefaultsToNewNode(toolName) {
   if (!fdCanvas) return;
@@ -1646,6 +1668,16 @@ document.addEventListener("keydown", (e) => {
     case "showHelp":
       toggleShortcutHelp();
       break;
+    case "copyStyle":
+      showToast("Style copied");
+      break;
+    case "pasteStyle":
+      if (result.changed) {
+        render();
+        syncTextToExtension();
+        showToast("Style pasted");
+      }
+      break;
   }
 
   // Notify extension of selection changes from keyboard actions
@@ -1826,6 +1858,8 @@ function buildShortcutHelpHtml() {
         [`${cmd}C`, "Copy"],
         [`${cmd}X`, "Cut"],
         [`${cmd}V`, "Paste"],
+        [`⌥${cmd}C`, "Copy Style"],
+        [`⌥${cmd}V`, "Paste Style"],
       ],
     },
     {


### PR DESCRIPTION
## Changes

- **Transparent fill defaults** — rect/ellipse shapes now create with `fill: None` instead of opaque white
- **Theme-contextual stroke** — stroke adapts to canvas theme: `#333` on light, `#A0A0B0` on dark
- **Copy/Paste Style** (⌥⌘C / ⌥⌘V) — new shortcuts to copy a node's style and paste it onto another node
- **Style clipboard** — `style_clipboard: Option<Style>` on `FdCanvas` for cross-node style transfer
- **Toast notifications** — `showToast()` function for brief glassmorphism feedback
- **Help dialog** — updated with Copy Style / Paste Style entries

## Files Changed

- `crates/fd-editor/src/shortcuts.rs` — `CopyStyle` + `PasteStyle` variants + test
- `crates/fd-wasm/src/lib.rs` — transparent defaults, contextual stroke, style_clipboard, dispatch handlers
- `fd-vscode/webview/main.js` — showToast, help entries, action handlers
- `fd-vscode/package.json` — version 0.10.12
- `docs/CHANGELOG.md` — v0.10.12 entry

## CI

- ✅ `cargo check --workspace`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace` (17/17 pass)