### PR TITLE
fix(editor): inline editor zero-jump editing — match canvas text style exactly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## Completed Requirements
 
+### v0.10.14 — Inline Editor Zero-Jump Editing
+
+- **FIX (R3.28)**: Inline text editor now visually matches canvas-rendered text with zero jump — replaced `border` with `outline` (outlines don't affect layout), fixed vertical padding to match Canvas2D `text_baseline` positioning exactly (`top` → scaled 2px offset, `middle` → symmetric padding, `bottom` → bottom-anchored), matched font-family fallback chain to renderer (`"Inter, sans-serif"`)
+
 ### v0.10.13 — Fix Text Rendering Mismatch + Bounding Box Sizing
 
 - **FIX (R3.28)**: Inline text editor now visually matches canvas-rendered text — textarea positioning, padding, and line-height aligned with Canvas2D `draw_text`: line-height reduced from `fontSize*1.4` to `fontSize*1.2`, left padding removed (0px), top padding set to 2px matching renderer's `b.y+2.0` offset, textarea positioned exactly at node bounds

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -2985,9 +2985,9 @@ function openInlineEditor(nodeId, propKey, currentValue) {
     textColor = isDark ? "#E0E0E0" : "#1C1C1E";
   }
 
-  // Get font info from node props
+  // Get font info from node props — match render2d.rs draw_text() exactly
   const fontSize = props.fontSize ? Math.round(props.fontSize * zoomLevel) : Math.round(14 * zoomLevel);
-  const fontFamily = props.fontFamily || "Inter";
+  const fontFamily = props.fontFamily || "Inter, sans-serif";
   const fontWeight = props.fontWeight || 400;
 
   // Get text alignment — WASM API returns effective defaults (left/top for
@@ -2998,18 +2998,41 @@ function openInlineEditor(nodeId, propKey, currentValue) {
   // Store original value for Esc rollback
   const originalValue = currentValue;
 
-  // Calculate vertical padding for alignment
-  // Use 1.2 line-height multiplier matching the renderer's effective line height
+  // Line-height matching the renderer's effective line height
   const lineHeight = Math.round(fontSize * 1.2);
-  const lines = (currentValue.match(/\n/g) || []).length + 1;
-  const textHeight = lineHeight * lines;
-  // Top padding: 2px matches draw_text's b.y + 2.0 offset for top-aligned text
-  let padTop = 2;
-  if (vAlign === "middle") {
-    padTop = Math.max(2, Math.round((sh - textHeight) / 2));
+
+  // Vertical padding: match Canvas2D text_baseline positioning exactly.
+  // draw_text() uses:
+  //   top    → text_baseline="top",    y = b.y + 2.0
+  //   middle → text_baseline="middle", y = b.y + h/2
+  //   bottom → text_baseline="bottom", y = b.y + h - 2.0
+  // Since we use outline (not border), the textarea content area == node bounds.
+  const topOffset = Math.round(2 * zoomLevel);
+  let padTop = 0;
+  let padBottom = 0;
+  if (vAlign === "top") {
+    padTop = topOffset;
+  } else if (vAlign === "middle") {
+  // CSS vertical centering via equal top/bottom padding
+    const lines = (currentValue.match(/\n/g) || []).length + 1;
+    const textHeight = lineHeight * lines;
+    padTop = Math.max(0, Math.round((sh - textHeight) / 2));
+    padBottom = padTop;
   } else if (vAlign === "bottom") {
-    padTop = Math.max(2, sh - textHeight - 2);
+    padBottom = topOffset;
+    const lines = (currentValue.match(/\n/g) || []).length + 1;
+    const textHeight = lineHeight * lines;
+    padTop = Math.max(0, sh - textHeight - padBottom);
   }
+
+  // Horizontal padding: match Canvas2D x-position within the bounds.
+  // draw_text() uses:
+  //   left   → x = b.x
+  //   center → x = b.x + b.width/2  (text-align:center handles this)
+  //   right  → x = b.x + b.width    (text-align:right handles this)
+  // CSS text-align handles the horizontal positioning, so no extra padding needed.
+  const padLeft = 0;
+  const padRight = 0;
 
   // Compute border-radius matching the node's actual shape
   let borderRadius = "8px";
@@ -3030,14 +3053,15 @@ function openInlineEditor(nodeId, propKey, currentValue) {
     `top:${sy}px`,
     `width:${sw}px`,
     `height:${sh}px`,
-    `padding:${padTop}px 0px 2px 0px`,
-    `font:${fontWeight} ${fontSize}px ${fontFamily},system-ui,sans-serif`,
-    `border:2px solid #4FC3F7`,
+    `padding:${padTop}px ${padRight}px ${padBottom}px ${padLeft}px`,
+    `font:${fontWeight} ${fontSize}px ${fontFamily}`,
+    `border:none`,
+    `outline:2px solid #4FC3F7`,
+    `outline-offset:-1px`,
     `border-radius:${borderRadius}`,
     `background:${bgColor}`,
     `color:${textColor}`,
     `resize:none`,
-    `outline:none`,
     `z-index:100`,
     `box-shadow:0 2px 8px rgba(0,0,0,0.12)`,
     `line-height:${lineHeight}px`,


### PR DESCRIPTION
## Fix: Inline Editor Zero-Jump Editing

Makes the inline text editor visually match canvas-rendered text with zero visual "jump" when entering/exiting edit mode.

### Changes
- **`outline` instead of `border`** — outlines don't affect layout, so textarea content stays at exact node position
- **Vertical padding matches Canvas2D `text_baseline`** — scaled 2px offset for top-aligned, symmetric padding for middle-aligned, bottom-anchored for bottom-aligned
- **Font-family fallback chain** — now matches Rust renderer exactly (`"Inter, sans-serif"`)
- **Zoom-aware offset** — top padding scales with zoom level

### Files Changed
- `fd-vscode/webview/main.js` — `openInlineEditor()` function
- `fd-vscode/package.json` — version 0.10.14
- `docs/CHANGELOG.md` — v0.10.14 entry

### Testing
- ✅ cargo clippy --workspace (clean)
- ✅ cargo test --workspace (all pass)
- ✅ pnpm test (191/191 pass)
- ✅ WASM build (clean)