### PR TITLE
fix(toolbar): make floating toolbar draggable again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.10.16 — Fix Floating Toolbar Drag
+
+- **FIX (R3.39)**: Floating toolbar is now draggable again — three compounding bugs fixed: (1) document-level `pointermove`/`pointerup` handlers now filter by `e.pointerId` to prevent cross-handler interference with drag-to-create; (2) `pointerdown` on scroll handles now normalizes toolbar position to absolute `px` values, eliminating CSS anchor conflicts between hardcoded `left: 244px` and JS-set `vw`/`vh` units; (3) `.scroll-handle` hit area expanded from 6px wood-core to 16px min-width with padding
+- **UX (R3.39)**: Dragging the toolbar now shows visual feedback — lifted shadow (`0 8px 32px`) and slight opacity reduction (0.92) during drag, cleared on release
+
 ### v0.10.15 — Apple Preview-Style Text Editing
 
 - **FIX (R3.28)**: Text nodes now show only 2 horizontal resize handles (MiddleLeft + MiddleRight) instead of 8-point handles — matches Apple Preview / Figma behavior where text height is intrinsic (auto-sized from font content); selection border reduced from 2px to 1px for text nodes

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -1951,7 +1951,11 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       justify-content: center;
       cursor: grab;
       position: relative;
+      min-width: 16px;
+      min-height: 16px;
+      padding: 0 4px;
     }
+    .vertical .scroll-handle { padding: 4px 0; }
     .scroll-handle:active { cursor: grabbing; }
 
     .horizontal .handle-start { flex-direction: row; }

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4734,17 +4734,19 @@ function setupFloatingToolbar() {
 
   // Use document-level listeners — setPointerCapture fails in VS Code webview iframes
   document.addEventListener("pointermove", (e) => {
-    if (!isDragging) return;
+    if (!isDragging || e.pointerId !== activePointerId) return;
     const dx = e.clientX - dragStartX;
     const dy = e.clientY - dragStartY;
 
-    // Temporary drag visual (disable transition)
+    // Drag visual: disable transition, apply translate + lift effect
     toolbar.style.transition = "none";
     toolbar.style.transform = `translate(${dx}px, ${dy}px)`;
+    toolbar.style.boxShadow = "0 8px 32px rgba(0,0,0,0.25)";
+    toolbar.style.opacity = "0.92";
   });
 
   document.addEventListener("pointerup", (e) => {
-    if (!isDragging) return;
+    if (!isDragging || e.pointerId !== activePointerId) return;
     isDragging = false;
     activePointerId = -1;
 
@@ -4755,6 +4757,8 @@ function setupFloatingToolbar() {
 
     toolbar.style.transform = "";
     toolbar.style.transition = "";
+    toolbar.style.boxShadow = "";
+    toolbar.style.opacity = "";
 
     // Handle Click (Roll/Unroll)
     if (dist < 5 && timeElapsed < 300) {
@@ -4819,9 +4823,14 @@ function setupFloatingToolbar() {
       dragStartY = e.clientY;
       dragStartTime = Date.now();
 
+      // Normalize to px position before drag to avoid CSS anchor conflicts
       const rect = toolbar.getBoundingClientRect();
       initialLeft = rect.left;
       initialTop = rect.top;
+      toolbar.style.left = rect.left + "px";
+      toolbar.style.top = rect.top + "px";
+      toolbar.style.right = "auto";
+      toolbar.style.bottom = "auto";
 
       e.preventDefault();
       e.stopPropagation();


### PR DESCRIPTION
## Summary

Three compounding bugs fixed that made the floating toolbar immobile:

1. **PointerId filtering** — document-level `pointermove`/`pointerup` handlers now filter by `e.pointerId` to prevent cross-handler interference with drag-to-create
2. **CSS anchor normalization** — `pointerdown` on scroll handles normalizes toolbar position to absolute `px` values, eliminating position fights between hardcoded `left: 244px` and JS-set `vw`/`vh` units
3. **Expanded scroll-handle hit area** — `.scroll-handle` min-width increased from 6px wood-core to 16px with padding, making handles actually grabbable

Also adds **visual drag feedback** — lifted shadow and slight opacity reduction during drag.

## Changes

- `fd-vscode/webview/main.js` — pointerId filtering, CSS anchor fix, drag visual feedback
- `fd-vscode/src/webview-html.ts` — expanded `.scroll-handle` hit area CSS
- `fd-vscode/package.json` — version bump 0.10.15 → 0.10.16
- `docs/CHANGELOG.md` — v0.10.16 entry

## Testing

- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace`
- ✅ `pnpm test` (191/191 passed)
- ✅ WASM build successful