### PR TITLE
Remove browser subagent rule (moved to global notes repo)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,11 +123,6 @@ crates/
 > [!CAUTION]
 > **NEVER use npm for VS Code extension. Always use pnpm if possible, npm only as fallback.**
 
-### 🌐 Browser Subagent Rule
-
-> [!IMPORTANT]
-> When using Chrome browser subagents, if a tab with the same or similar URL already exists, **reuse it** instead of spawning a new tab.
-
 ---
 
 ## TIER 2: CI/CD


### PR DESCRIPTION
Remove the browser subagent tab reuse rule from fast-draft's GEMINI.md — it has been moved to the global notes repo as a universal rule.