### PR TITLE
Refactor: DRY color calculations and center bounding box coordinates

### DIFF
--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -44,6 +44,8 @@ impl Color {
     pub fn from_hex(hex: &str) -> Option<Self> {
         let hex = hex.strip_prefix('#').unwrap_or(hex);
         let bytes = hex.as_bytes();
+        let parse_short = |v| (v * 17) as f32 / 255.0;
+        let parse_long = |v| v as f32 / 255.0;
 
         match bytes.len() {
             3 => {
@@ -51,9 +53,9 @@ impl Color {
                 let g = hex_val(bytes[1])?;
                 let b = hex_val(bytes[2])?;
                 Some(Self::rgba(
-                    (r * 17) as f32 / 255.0,
-                    (g * 17) as f32 / 255.0,
-                    (b * 17) as f32 / 255.0,
+                    parse_short(r),
+                    parse_short(g),
+                    parse_short(b),
                     1.0,
                 ))
             }
@@ -63,22 +65,17 @@ impl Color {
                 let b = hex_val(bytes[2])?;
                 let a = hex_val(bytes[3])?;
                 Some(Self::rgba(
-                    (r * 17) as f32 / 255.0,
-                    (g * 17) as f32 / 255.0,
-                    (b * 17) as f32 / 255.0,
-                    (a * 17) as f32 / 255.0,
+                    parse_short(r),
+                    parse_short(g),
+                    parse_short(b),
+                    parse_short(a),
                 ))
             }
             6 => {
                 let r = hex_val(bytes[0])? << 4 | hex_val(bytes[1])?;
                 let g = hex_val(bytes[2])? << 4 | hex_val(bytes[3])?;
                 let b = hex_val(bytes[4])? << 4 | hex_val(bytes[5])?;
-                Some(Self::rgba(
-                    r as f32 / 255.0,
-                    g as f32 / 255.0,
-                    b as f32 / 255.0,
-                    1.0,
-                ))
+                Some(Self::rgba(parse_long(r), parse_long(g), parse_long(b), 1.0))
             }
             8 => {
                 let r = hex_val(bytes[0])? << 4 | hex_val(bytes[1])?;
@@ -86,10 +83,10 @@ impl Color {
                 let b = hex_val(bytes[4])? << 4 | hex_val(bytes[5])?;
                 let a = hex_val(bytes[6])? << 4 | hex_val(bytes[7])?;
                 Some(Self::rgba(
-                    r as f32 / 255.0,
-                    g as f32 / 255.0,
-                    b as f32 / 255.0,
-                    a as f32 / 255.0,
+                    parse_long(r),
+                    parse_long(g),
+                    parse_long(b),
+                    parse_long(a),
                 ))
             }
             _ => None,

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -8,6 +8,12 @@ use fd_core::{NodeIndex, ResolvedBounds, SceneGraph};
 use std::collections::HashMap;
 use web_sys::CanvasRenderingContext2d;
 
+#[inline]
+fn center_f64(b: &ResolvedBounds) -> (f64, f64) {
+    let (cx, cy) = b.center();
+    (cx as f64, cy as f64)
+}
+
 /// Theme-dependent colors for the canvas renderer.
 pub struct CanvasTheme {
     pub bg: &'static str,
@@ -209,8 +215,7 @@ fn render_node(
 
     let has_scale = (effective_scale - 1.0).abs() > f32::EPSILON;
     if has_scale {
-        let cx = node_bounds.x as f64 + node_bounds.width as f64 / 2.0;
-        let cy = node_bounds.y as f64 + node_bounds.height as f64 / 2.0;
+        let (cx, cy) = center_f64(node_bounds);
         let s = effective_scale as f64;
         ctx.save();
         ctx.translate(cx, cy).unwrap_or(());
@@ -396,8 +401,7 @@ fn draw_ellipse(
     style: &Style,
     is_selected: bool,
 ) {
-    let cx = b.x as f64 + b.width as f64 / 2.0;
-    let cy = b.y as f64 + b.height as f64 / 2.0;
+    let (cx, cy) = center_f64(b);
     let rx = b.width as f64 / 2.0;
     let ry = b.height as f64 / 2.0;
 
@@ -518,7 +522,7 @@ fn draw_text(
     // Calculate x position based on alignment
     let x = match halign {
         TextAlign::Left => b.x as f64,
-        TextAlign::Center => b.x as f64 + b.width as f64 / 2.0,
+        TextAlign::Center => center_f64(b).0,
         TextAlign::Right => b.x as f64 + b.width as f64,
     };
 
@@ -548,7 +552,7 @@ fn draw_text(
         // Single line — use original baseline positioning for backwards compatibility
         let y = match valign {
             TextVAlign::Top => b.y as f64 + 2.0,
-            TextVAlign::Middle => b.y as f64 + b.height as f64 / 2.0,
+            TextVAlign::Middle => center_f64(b).1,
             TextVAlign::Bottom => b.y as f64 + b.height as f64 - 2.0,
         };
         let _ = ctx.fill_text(content, x, y);
@@ -581,8 +585,7 @@ fn draw_shape_label(
     ctx.set_text_align("center");
     ctx.set_text_baseline("middle");
 
-    let cx = b.x as f64 + b.width as f64 / 2.0;
-    let cy = b.y as f64 + b.height as f64 / 2.0;
+    let (cx, cy) = center_f64(b);
     let _ = ctx.fill_text(label, cx, cy);
 
     ctx.restore();
@@ -1305,8 +1308,7 @@ fn draw_ellipse_sketchy(
     style: &Style,
     is_selected: bool,
 ) {
-    let cx = b.x as f64 + b.width as f64 / 2.0;
-    let cy = b.y as f64 + b.height as f64 / 2.0;
+    let (cx, cy) = center_f64(b);
     let rx = b.width as f64 / 2.0;
     let ry = b.height as f64 / 2.0;
     let seed = cx * 0.43 + cy * 0.67;


### PR DESCRIPTION
Abstracted away repeated color parsing equations and bounding box center calculations to adhere to DRY principles. No functional changes.

---
*PR created automatically by Jules for task [9425107167267537237](https://jules.google.com/task/9425107167267537237) started by @khangnghiem*