### PR TITLE
feat(layout): add `place:` property for 9-position child alignment

### DIFF
--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -317,6 +317,23 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
         writeln!(out, "align: {h} {v}").unwrap();
     }
 
+    // Child placement within parent
+    if let Some((h, v)) = node.place {
+        indent(out, depth + 1);
+        let place_str = match (h, v) {
+            (HPlace::Center, VPlace::Middle) => "center".to_string(),
+            (HPlace::Left, VPlace::Top) => "top-left".to_string(),
+            (HPlace::Center, VPlace::Top) => "top".to_string(),
+            (HPlace::Right, VPlace::Top) => "top-right".to_string(),
+            (HPlace::Left, VPlace::Middle) => "left middle".to_string(),
+            (HPlace::Right, VPlace::Middle) => "right middle".to_string(),
+            (HPlace::Left, VPlace::Bottom) => "bottom-left".to_string(),
+            (HPlace::Center, VPlace::Bottom) => "bottom".to_string(),
+            (HPlace::Right, VPlace::Bottom) => "bottom-right".to_string(),
+        };
+        writeln!(out, "place: {place_str}").unwrap();
+    }
+
     // Inline position (x: / y:) — emitted here for token efficiency
     for constraint in &node.constraints {
         if let Constraint::Position { x, y } = constraint {

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -300,22 +300,44 @@ fn resolve_children(
                 );
             }
 
-            // Auto-center: if parent is a shape with a single text child (no
-            // explicit position), center the text within parent bounds using
-            // its intrinsic size (hug-contents). The renderer's center/middle
-            // alignment handles visual centering within the tight bounds.
             let parent_is_shape = matches!(
                 parent_node.kind,
                 NodeKind::Rect { .. } | NodeKind::Ellipse { .. } | NodeKind::Frame { .. }
             );
-            if parent_is_shape && children.len() == 1 {
-                let child_idx = children[0];
+
+            for &child_idx in &children {
                 let child_node = &graph.graph[child_idx];
                 let has_position = child_node
                     .constraints
                     .iter()
                     .any(|c| matches!(c, Constraint::Position { .. }));
-                if matches!(child_node.kind, NodeKind::Text { .. })
+
+                // Priority 1: explicit `place:` property
+                if let Some((h, v)) = child_node.place {
+                    if !has_position && let Some(cb) = bounds.get(&child_idx).copied() {
+                        let x = match h {
+                            HPlace::Left => parent_bounds.x,
+                            HPlace::Center => {
+                                parent_bounds.x + (parent_bounds.width - cb.width) / 2.0
+                            }
+                            HPlace::Right => parent_bounds.x + parent_bounds.width - cb.width,
+                        };
+                        let y = match v {
+                            VPlace::Top => parent_bounds.y,
+                            VPlace::Middle => {
+                                parent_bounds.y + (parent_bounds.height - cb.height) / 2.0
+                            }
+                            VPlace::Bottom => parent_bounds.y + parent_bounds.height - cb.height,
+                        };
+                        bounds.insert(child_idx, ResolvedBounds { x, y, ..cb });
+                    }
+                    continue;
+                }
+
+                // Priority 2: auto-center text children in shape parents
+                // (no explicit place: and no Position constraint)
+                if parent_is_shape
+                    && matches!(child_node.kind, NodeKind::Text { .. })
                     && !has_position
                     && let Some(child_b) = bounds.get(&child_idx).copied()
                 {

--- a/crates/fd-core/src/layout_tests.rs
+++ b/crates/fd-core/src/layout_tests.rs
@@ -581,13 +581,155 @@ font: "Inter" 400 12
 
     let card = bounds[&graph.index_of(NodeId::intern("card")).unwrap()];
     let title = bounds[&graph.index_of(NodeId::intern("title")).unwrap()];
+    let subtitle = bounds[&graph.index_of(NodeId::intern("subtitle")).unwrap()];
 
-    // Multiple children: text should NOT be expanded to parent
+    // Multiple children: text width should remain intrinsic (not expanded)
     assert!(
         title.width < card.width,
         "text width ({}) should be < parent ({}) with multiple children",
         title.width,
         card.width
+    );
+
+    // Both text children should be auto-centered (multi-child lift)
+    let title_cx = title.x + title.width / 2.0;
+    let card_cx = card.x + card.width / 2.0;
+    assert!(
+        (title_cx - card_cx).abs() < 1.0,
+        "title center_x ({title_cx}) should ≈ card center_x ({card_cx})"
+    );
+    let subtitle_cx = subtitle.x + subtitle.width / 2.0;
+    assert!(
+        (subtitle_cx - card_cx).abs() < 1.0,
+        "subtitle center_x ({subtitle_cx}) should ≈ card center_x ({card_cx})"
+    );
+}
+
+#[test]
+fn layout_place_center() {
+    let input = r#"
+rect @btn {
+  w: 200 h: 60
+  text @label "Click" {
+    place: center
+  }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let bounds = resolve_layout(
+        &graph,
+        Viewport {
+            width: 800.0,
+            height: 600.0,
+        },
+    );
+
+    let btn = bounds[&graph.index_of(NodeId::intern("btn")).unwrap()];
+    let label = bounds[&graph.index_of(NodeId::intern("label")).unwrap()];
+
+    let label_cx = label.x + label.width / 2.0;
+    let btn_cx = btn.x + btn.width / 2.0;
+    assert!(
+        (label_cx - btn_cx).abs() < 1.0,
+        "place:center h — label_cx={label_cx}, btn_cx={btn_cx}"
+    );
+    let label_cy = label.y + label.height / 2.0;
+    let btn_cy = btn.y + btn.height / 2.0;
+    assert!(
+        (label_cy - btn_cy).abs() < 1.0,
+        "place:center v — label_cy={label_cy}, btn_cy={btn_cy}"
+    );
+}
+
+#[test]
+fn layout_place_top_left() {
+    let input = r#"
+rect @box {
+  w: 200 h: 100
+  text @corner "X" { place: top-left }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let bounds = resolve_layout(
+        &graph,
+        Viewport {
+            width: 800.0,
+            height: 600.0,
+        },
+    );
+
+    let parent = bounds[&graph.index_of(NodeId::intern("box")).unwrap()];
+    let child = bounds[&graph.index_of(NodeId::intern("corner")).unwrap()];
+
+    assert!((child.x - parent.x).abs() < 0.01, "top-left x mismatch");
+    assert!((child.y - parent.y).abs() < 0.01, "top-left y mismatch");
+}
+
+#[test]
+fn layout_place_bottom_right() {
+    let input = r#"
+rect @box {
+  w: 200 h: 100
+  text @corner "X" { place: bottom-right }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let bounds = resolve_layout(
+        &graph,
+        Viewport {
+            width: 800.0,
+            height: 600.0,
+        },
+    );
+
+    let parent = bounds[&graph.index_of(NodeId::intern("box")).unwrap()];
+    let child = bounds[&graph.index_of(NodeId::intern("corner")).unwrap()];
+
+    let expected_x = parent.x + parent.width - child.width;
+    let expected_y = parent.y + parent.height - child.height;
+    assert!(
+        (child.x - expected_x).abs() < 0.01,
+        "bottom-right x mismatch"
+    );
+    assert!(
+        (child.y - expected_y).abs() < 0.01,
+        "bottom-right y mismatch"
+    );
+}
+
+#[test]
+fn layout_auto_center_multiple_text_children() {
+    let input = r#"
+rect @card {
+  w: 300 h: 200
+  text @heading "Hello" { font: "Inter" 700 24 }
+  text @body "World" { font: "Inter" 400 14 }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let bounds = resolve_layout(
+        &graph,
+        Viewport {
+            width: 800.0,
+            height: 600.0,
+        },
+    );
+
+    let card = bounds[&graph.index_of(NodeId::intern("card")).unwrap()];
+    let heading = bounds[&graph.index_of(NodeId::intern("heading")).unwrap()];
+    let body = bounds[&graph.index_of(NodeId::intern("body")).unwrap()];
+    let card_cx = card.x + card.width / 2.0;
+
+    let heading_cx = heading.x + heading.width / 2.0;
+    assert!(
+        (heading_cx - card_cx).abs() < 1.0,
+        "heading center ({heading_cx}) ≈ card center ({card_cx})"
+    );
+
+    let body_cx = body.x + body.width / 2.0;
+    assert!(
+        (body_cx - card_cx).abs() < 1.0,
+        "body center ({body_cx}) ≈ card center ({card_cx})"
     );
 }
 

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -226,6 +226,24 @@ pub enum TextVAlign {
     Bottom,
 }
 
+/// Horizontal placement of a child within its parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum HPlace {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+/// Vertical placement of a child within its parent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum VPlace {
+    Top,
+    #[default]
+    Middle,
+    Bottom,
+}
+
 /// A reusable theme set that nodes can reference via `use: theme_name`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Style {
@@ -505,6 +523,10 @@ pub struct SceneNode {
     /// Line comments (`# text`) that appeared before this node in the source.
     /// Preserved across parse/emit round-trips so format passes don't delete them.
     pub comments: Vec<String>,
+
+    /// 9-position placement of this child within its parent.
+    /// `None` = default positioning (auto-center for text, origin for others).
+    pub place: Option<(HPlace, VPlace)>,
 }
 
 impl SceneNode {
@@ -518,6 +540,7 @@ impl SceneNode {
             animations: SmallVec::new(),
             annotations: Vec::new(),
             comments: Vec::new(),
+            place: None,
         }
     }
 }

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -86,6 +86,7 @@ pub fn parse_document(input: &str) -> Result<SceneGraph, String> {
                     annotations: Vec::new(),
                     animations: Default::default(),
                     comments: Vec::new(),
+                    place: None,
                 };
                 let idx = graph.graph.add_node(text_node);
                 graph.graph.add_edge(graph.root, idx, ());
@@ -163,6 +164,8 @@ struct ParsedNode {
     /// Comments that appeared before this node's opening `{` in the source.
     comments: Vec<String>,
     children: Vec<ParsedNode>,
+    /// 9-position placement within parent.
+    place: Option<(HPlace, VPlace)>,
 }
 
 fn insert_node_recursive(
@@ -177,6 +180,7 @@ fn insert_node_recursive(
     node.animations.extend(parsed.animations);
     node.annotations = parsed.annotations;
     node.comments = parsed.comments;
+    node.place = parsed.place;
 
     let idx = graph.add_node(parent, node);
 
@@ -551,6 +555,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let mut height: Option<f32> = None;
     let mut layout = LayoutMode::Free;
     let mut clip = false;
+    let mut place: Option<(HPlace, VPlace)> = None;
 
     skip_ws_and_comments(input);
 
@@ -575,6 +580,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
                 &mut height,
                 &mut layout,
                 &mut clip,
+                &mut place,
             )?;
         }
         // Collect comments between items; they'll be attached to the *next* child node
@@ -620,6 +626,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
         annotations,
         comments: Vec::new(),
         children,
+        place,
     })
 }
 
@@ -745,6 +752,7 @@ fn parse_node_property(
     height: &mut Option<f32>,
     layout: &mut LayoutMode,
     clip: &mut bool,
+    place: &mut Option<(HPlace, VPlace)>,
 ) -> ModalResult<()> {
     let prop_name = parse_identifier.parse_next(input)?;
     skip_space(input);
@@ -842,6 +850,9 @@ fn parse_node_property(
         }
         "align" | "text_align" => {
             parse_align_value(input, style)?;
+        }
+        "place" => {
+            *place = Some(parse_place_value(input)?);
         }
         "shadow" => {
             // shadow: (ox,oy,blur,#COLOR)  — colon already consumed by property parser
@@ -951,6 +962,77 @@ fn parse_align_value(input: &mut &str, style: &mut Style) -> ModalResult<()> {
     }
 
     Ok(())
+}
+
+// ─── Place value parser ──────────────────────────────────────────────────
+
+fn parse_place_value(input: &mut &str) -> ModalResult<(HPlace, VPlace)> {
+    use crate::model::{HPlace, VPlace};
+
+    let first = parse_identifier.parse_next(input)?;
+
+    // Check for compound hyphenated form: "top-left", "bottom-right", etc.
+    if input.starts_with('-') {
+        let saved = *input;
+        *input = &input[1..]; // consume '-'
+        if let Ok(second) = parse_identifier.parse_next(input) {
+            match (first, second) {
+                ("top", "left") => return Ok((HPlace::Left, VPlace::Top)),
+                ("top", "right") => return Ok((HPlace::Right, VPlace::Top)),
+                ("bottom", "left") => return Ok((HPlace::Left, VPlace::Bottom)),
+                ("bottom", "right") => return Ok((HPlace::Right, VPlace::Bottom)),
+                _ => *input = saved, // restore if unrecognized
+            }
+        } else {
+            *input = saved;
+        }
+    }
+
+    match first {
+        "center" => {
+            // Check if there's a second word (2-arg form: "center top")
+            skip_space(input);
+            let at_end = input.is_empty()
+                || input.starts_with('\n')
+                || input.starts_with(';')
+                || input.starts_with('}');
+            if !at_end && let Ok(second) = parse_identifier.parse_next(input) {
+                let v = match second {
+                    "top" => VPlace::Top,
+                    "bottom" => VPlace::Bottom,
+                    _ => VPlace::Middle,
+                };
+                return Ok((HPlace::Center, v));
+            }
+            Ok((HPlace::Center, VPlace::Middle))
+        }
+        "top" => Ok((HPlace::Center, VPlace::Top)),
+        "bottom" => Ok((HPlace::Center, VPlace::Bottom)),
+        _ => {
+            // 2-arg form: "left middle", "right top", etc.
+            let h = match first {
+                "left" => HPlace::Left,
+                "right" => HPlace::Right,
+                _ => HPlace::Center,
+            };
+
+            skip_space(input);
+            let at_end = input.is_empty()
+                || input.starts_with('\n')
+                || input.starts_with(';')
+                || input.starts_with('}');
+            if !at_end && let Ok(second) = parse_identifier.parse_next(input) {
+                let v = match second {
+                    "top" => VPlace::Top,
+                    "bottom" => VPlace::Bottom,
+                    _ => VPlace::Middle,
+                };
+                return Ok((h, v));
+            }
+
+            Ok((h, VPlace::Middle))
+        }
+    }
 }
 
 // ─── Animation block parser ─────────────────────────────────────────────

--- a/crates/fd-core/src/parser_tests.rs
+++ b/crates/fd-core/src/parser_tests.rs
@@ -642,3 +642,80 @@ fn roundtrip_text_no_max_width() {
         }
     }
 }
+
+#[test]
+fn parse_place_center() {
+    let src = r#"text @label "Hello" { place: center }"#;
+    let graph = parse_document(src).unwrap();
+    let node = graph.get_by_id(crate::id::NodeId::intern("label")).unwrap();
+    assert_eq!(
+        node.place,
+        Some((crate::model::HPlace::Center, crate::model::VPlace::Middle))
+    );
+}
+
+#[test]
+fn parse_place_top_left() {
+    let src = r#"rect @icon { w: 32 h: 32 place: top-left }"#;
+    let graph = parse_document(src).unwrap();
+    let node = graph.get_by_id(crate::id::NodeId::intern("icon")).unwrap();
+    assert_eq!(
+        node.place,
+        Some((crate::model::HPlace::Left, crate::model::VPlace::Top))
+    );
+}
+
+#[test]
+fn parse_place_two_arg() {
+    let src = r#"text @t "Hello" { place: right bottom }"#;
+    let graph = parse_document(src).unwrap();
+    let node = graph.get_by_id(crate::id::NodeId::intern("t")).unwrap();
+    assert_eq!(
+        node.place,
+        Some((crate::model::HPlace::Right, crate::model::VPlace::Bottom))
+    );
+}
+
+#[test]
+fn roundtrip_place() {
+    let src = r#"
+rect @card {
+  w: 200 h: 100
+  text @title "Hello" {
+    place: top-left
+  }
+  text @sub "World" {
+    place: bottom-right
+  }
+}
+"#;
+    let graph = parse_document(src).unwrap();
+    let title = graph.get_by_id(crate::id::NodeId::intern("title")).unwrap();
+    assert_eq!(
+        title.place,
+        Some((crate::model::HPlace::Left, crate::model::VPlace::Top))
+    );
+
+    let emitted = crate::emitter::emit_document(&graph);
+    assert!(emitted.contains("place: top-left"), "emitted: {emitted}");
+    assert!(
+        emitted.contains("place: bottom-right"),
+        "emitted: {emitted}"
+    );
+
+    let reparsed = parse_document(&emitted).unwrap();
+    let title2 = reparsed
+        .get_by_id(crate::id::NodeId::intern("title"))
+        .unwrap();
+    assert_eq!(
+        title2.place,
+        Some((crate::model::HPlace::Left, crate::model::VPlace::Top))
+    );
+    let sub2 = reparsed
+        .get_by_id(crate::id::NodeId::intern("sub"))
+        .unwrap();
+    assert_eq!(
+        sub2.place,
+        Some((crate::model::HPlace::Right, crate::model::VPlace::Bottom))
+    );
+}


### PR DESCRIPTION
## Summary

Add a `place:` property for 9-position child alignment within parent nodes, and lift the single-child restriction for auto-centering text nodes.

### Changes

**New `place:` property** — positions a child node within its parent using a 3×3 grid:
- Compound: `top-left`, `top`, `top-right`, `center`, `bottom-left`, `bottom`, `bottom-right`
- Two-arg: `left middle`, `right top`, etc.

**Auto-center multi-child lift** — all text children in shape parents (Rect/Ellipse/Frame) without explicit Position constraint are now auto-centered, not just single children.

**Priority**: explicit `Position` constraint > `place:` > auto-center > parent origin

### Files Changed
- `model.rs` — `HPlace`/`VPlace` enums + `place` field on `SceneNode`
- `parser.rs` — `parse_place_value` with hyphenated keyword support
- `emitter.rs` — `place:` emission in canonical form
- `layout.rs` — `place` positioning + auto-center multi-child lift
- `parser_tests.rs` — 4 new tests
- `layout_tests.rs` — 5 new/updated tests

### CI
- [x] `cargo check --workspace`
- [x] `cargo test --workspace` (all pass)
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all -- --check`