### PR TITLE
fix(toolbar): prevent select-all on drag + enable body-wide drag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ## Completed Requirements
 
+### v0.10.23 — Fix Toolbar Drag "Select All" + Unmovable Toolbar
+
+- **FIX (R3.39)**: Dragging the floating toolbar no longer triggers browser text selection ("select all") — added `user-select: none` and `touch-action: none` to `#floating-toolbar` CSS
+- **FIX (R3.39)**: Toolbar is now draggable from anywhere on its body — replaced scroll-handle-only `pointerdown` with a toolbar-wide handler that initiates drag from the toolbar background, paper body, and scroll handles (tool buttons excluded to preserve click-to-select and drag-to-create)
+
 ### v0.10.22 — Fix Canvas Resize + Text Editing Shape Preservation
 
 - **FIX (R3.2, R3.28)**: Resizing a parent shape (rect/ellipse/frame) no longer fights with JS-measured child bounds — `resolve_children` in `layout.rs` now uses `or_insert` instead of `insert` for Free-layout children, preserving existing cached bounds (e.g. text sizes from JS `measureAndUpdateTextBounds`) during `resolve_subtree` calls; previously each resize frame would overwrite child bounds with the `intrinsic_size` heuristic, creating a "resize fight"

--- a/examples/constraints.fd
+++ b/examples/constraints.fd
@@ -19,15 +19,15 @@ frame @hero {
   }
   layout: column gap=16 pad=40
   w: 326.07 h: 147.34
-  x: 133.91
-  y: 673.86
+  x: 229.52
+  y: 663.05
 }
 
 text @_text_0 "Try It Now" {
   fill: #FFFFFF  # white
   font: "Inter" semibold 16
-  x: 249.51
-  y: 785.35
+  x: 388.51
+  y: 611.44
 }
 
 text @hero_title "Welcome to " {
@@ -41,14 +41,17 @@ text @hero_title "Welcome to " {
 # ─── Offset-positioned tooltip ───────────────────────────────────────────
 rect @tooltip_target {
   spec "Anchor element for tooltip"
-  text @_text_1 "Hover me" {
-    fill: #333333  # gray
-    font: "Inter" medium 14
-  }
   w: 160 h: 48
   fill: #F5F5F7  # white
   stroke: #E8E8EC 1
   corner: 8
+}
+
+text @_text_1 "Hover me" {
+  fill: #333333  # gray
+  font: "Inter" medium 14
+  x: 174.32
+  y: 819.94
 }
 
 rect @tooltip {
@@ -88,32 +91,33 @@ text @_text_3 "This panel uses fill_parent with 24px inset" {
   y: 326.51
 }
 
-# ─── Floating action button ─────────────────────────────────────────────
-rect @fab {
-  spec {
-    "Floating action button — fixed bottom-right"
-    accept: "persists across scroll"
+group @_group_0 {
+  rect @fab {
+    spec {
+      "Floating action button — fixed bottom-right"
+      accept: "persists across scroll"
+    }
+    text @_text_4 "+" {
+      fill: #FFFFFF  # white
+      font: "Inter" bold 24
+      x: 19.63
+      y: 11.92
+    }
+    w: 56 h: 56
+    fill: #6C5CE7  # blue
+    corner: 28
+    shadow: (0,4,16,#6C5CE760)
+    when :hover {
+      scale: 1.5
+      ease: spring 1300ms
+    }
+    when :press {
+      scale: 0.5
+      ease: spring 2150ms
+    }
   }
-  text @_text_4 "+" {
-    fill: #FFFFFF  # white
-    font: "Inter" bold 24
-    x: 19.63
-    y: 11.92
-  }
-  w: 56 h: 56
-  fill: #6C5CE7  # blue
-  corner: 28
-  shadow: (0,4,16,#6C5CE760)
   x: 81.82
   y: 1077.34
-  when :hover {
-    scale: 1.5
-    ease: spring 1300ms
-  }
-  when :press {
-    scale: 0.5
-    ease: spring 2150ms
-  }
 }
 
 @tooltip_target -> offset: @hero 0, 180

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.22",
+  "version": "0.10.23",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -1945,6 +1945,9 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       align-items: stretch;
       --left-roll-width: 12px;
       --right-roll-width: 12px;
+      user-select: none;
+      -webkit-user-select: none;
+      touch-action: none;
     }
     #floating-toolbar.horizontal { flex-direction: row; }
     #floating-toolbar.vertical { flex-direction: column; }

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4764,7 +4764,6 @@ function updateSettingsToggleStates() {
 function setupFloatingToolbar() {
   const toolbar = document.getElementById("floating-toolbar");
   if (!toolbar) return;
-  const handles = toolbar.querySelectorAll(".scroll-handle");
 
   // Restore persisted state
   const savedState = vscode.getState() || {};
@@ -4915,26 +4914,29 @@ function setupFloatingToolbar() {
     }
   });
 
-  handles.forEach(handle => {
-    handle.addEventListener("pointerdown", (e) => {
-      isDragging = true;
-      activePointerId = e.pointerId;
-      dragStartX = e.clientX;
-      dragStartY = e.clientY;
-      dragStartTime = Date.now();
+  // Allow drag from anywhere on the toolbar except tool buttons
+  // (tool buttons have their own pointerdown for drag-to-create)
+  toolbar.addEventListener("pointerdown", (e) => {
+    // Skip if target is a tool button or inside one (handled by drag-to-create)
+    if (e.target.closest(".ft-tool-btn")) return;
 
-      // Normalize to px position before drag to avoid CSS anchor conflicts
-      const rect = toolbar.getBoundingClientRect();
-      initialLeft = rect.left;
-      initialTop = rect.top;
-      toolbar.style.left = rect.left + "px";
-      toolbar.style.top = rect.top + "px";
-      toolbar.style.right = "auto";
-      toolbar.style.bottom = "auto";
+    isDragging = true;
+    activePointerId = e.pointerId;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    dragStartTime = Date.now();
 
-      e.preventDefault();
-      e.stopPropagation();
-    });
+    // Normalize to px position before drag to avoid CSS anchor conflicts
+    const rect = toolbar.getBoundingClientRect();
+    initialLeft = rect.left;
+    initialTop = rect.top;
+    toolbar.style.left = rect.left + "px";
+    toolbar.style.top = rect.top + "px";
+    toolbar.style.right = "auto";
+    toolbar.style.bottom = "auto";
+
+    e.preventDefault();
+    e.stopPropagation();
   });
 
   // ── Drag-to-Create: drag a tool button onto the canvas ──


### PR DESCRIPTION
## Fix Toolbar Drag "Select All" + Unmovable Toolbar

### Root Cause
1. **"Select All" on drag**: `#floating-toolbar` CSS had no `user-select: none`, causing native browser text selection when dragging the toolbar body.
2. **Unable to move toolbar**: Only `.scroll-handle` elements (the wooden scroll ends) initiated toolbar drag. The toolbar body/paper area was not draggable.

### Changes
- **CSS** (`webview-html.ts`): Added `user-select: none`, `-webkit-user-select: none`, and `touch-action: none` to `#floating-toolbar`
- **JS** (`main.js`): Replaced scroll-handle-only `pointerdown` with a toolbar-wide handler — any click on the toolbar (excluding tool buttons) now initiates drag. Tool buttons still have their own click and drag-to-create handlers.

### Test Results
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace` (all tests pass)
- ✅ `pnpm test` (191 tests pass)
- ✅ WASM build successful