### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -6,6 +6,16 @@
 
 use crate::model::*;
 use petgraph::graph::NodeIndex;
+
+const DEFAULT_VIEWPORT_WIDTH: f32 = 800.0;
+const DEFAULT_VIEWPORT_HEIGHT: f32 = 600.0;
+const DEFAULT_FONT_SIZE: f32 = 14.0;
+const DEFAULT_GENERIC_WIDTH: f32 = 120.0;
+const DEFAULT_GENERIC_HEIGHT: f32 = 40.0;
+const DEFAULT_PATH_SIZE: f32 = 100.0;
+const CHAR_WIDTH_RATIO: f32 = 0.6;
+const LINE_HEIGHT_RATIO: f32 = 1.4;
+
 use std::collections::HashMap;
 
 /// The canvas (viewport) dimensions.
@@ -18,8 +28,8 @@ pub struct Viewport {
 impl Default for Viewport {
     fn default() -> Self {
         Self {
-            width: 800.0,
-            height: 600.0,
+            width: DEFAULT_VIEWPORT_WIDTH,
+            height: DEFAULT_VIEWPORT_HEIGHT,
         }
     }
 }
@@ -495,14 +505,21 @@ fn intrinsic_size(node: &SceneNode) -> (f32, f32) {
         NodeKind::Rect { width, height } => (*width, *height),
         NodeKind::Ellipse { rx, ry } => (*rx * 2.0, *ry * 2.0),
         NodeKind::Text { content, .. } => {
-            let font_size = node.style.font.as_ref().map_or(14.0, |f| f.size);
-            let char_width = font_size * 0.6;
-            (content.chars().count() as f32 * char_width, font_size * 1.4)
+            let font_size = node
+                .style
+                .font
+                .as_ref()
+                .map_or(DEFAULT_FONT_SIZE, |f| f.size);
+            let char_width = font_size * CHAR_WIDTH_RATIO;
+            (
+                content.chars().count() as f32 * char_width,
+                font_size * LINE_HEIGHT_RATIO,
+            )
         }
         NodeKind::Group => (0.0, 0.0), // Auto-sized: computed after children resolve
         NodeKind::Frame { width, height, .. } => (*width, *height),
-        NodeKind::Path { .. } => (100.0, 100.0), // Computed from path bounds
-        NodeKind::Generic => (120.0, 40.0),      // Placeholder label box
+        NodeKind::Path { .. } => (DEFAULT_PATH_SIZE, DEFAULT_PATH_SIZE), // Computed from path bounds
+        NodeKind::Generic => (DEFAULT_GENERIC_WIDTH, DEFAULT_GENERIC_HEIGHT), // Placeholder label box
         NodeKind::Root => (0.0, 0.0),
     }
 }

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -9,6 +9,9 @@
 use crate::id::NodeId;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableDiGraph;
+
+const COLOR_MAX: f32 = 255.0;
+
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::collections::HashMap;
@@ -51,9 +54,9 @@ impl Color {
                 let g = hex_val(bytes[1])?;
                 let b = hex_val(bytes[2])?;
                 Some(Self::rgba(
-                    (r * 17) as f32 / 255.0,
-                    (g * 17) as f32 / 255.0,
-                    (b * 17) as f32 / 255.0,
+                    (r * 17) as f32 / COLOR_MAX,
+                    (g * 17) as f32 / COLOR_MAX,
+                    (b * 17) as f32 / COLOR_MAX,
                     1.0,
                 ))
             }
@@ -63,10 +66,10 @@ impl Color {
                 let b = hex_val(bytes[2])?;
                 let a = hex_val(bytes[3])?;
                 Some(Self::rgba(
-                    (r * 17) as f32 / 255.0,
-                    (g * 17) as f32 / 255.0,
-                    (b * 17) as f32 / 255.0,
-                    (a * 17) as f32 / 255.0,
+                    (r * 17) as f32 / COLOR_MAX,
+                    (g * 17) as f32 / COLOR_MAX,
+                    (b * 17) as f32 / COLOR_MAX,
+                    (a * 17) as f32 / COLOR_MAX,
                 ))
             }
             6 => {
@@ -74,9 +77,9 @@ impl Color {
                 let g = hex_val(bytes[2])? << 4 | hex_val(bytes[3])?;
                 let b = hex_val(bytes[4])? << 4 | hex_val(bytes[5])?;
                 Some(Self::rgba(
-                    r as f32 / 255.0,
-                    g as f32 / 255.0,
-                    b as f32 / 255.0,
+                    r as f32 / COLOR_MAX,
+                    g as f32 / COLOR_MAX,
+                    b as f32 / COLOR_MAX,
                     1.0,
                 ))
             }
@@ -86,10 +89,10 @@ impl Color {
                 let b = hex_val(bytes[4])? << 4 | hex_val(bytes[5])?;
                 let a = hex_val(bytes[6])? << 4 | hex_val(bytes[7])?;
                 Some(Self::rgba(
-                    r as f32 / 255.0,
-                    g as f32 / 255.0,
-                    b as f32 / 255.0,
-                    a as f32 / 255.0,
+                    r as f32 / COLOR_MAX,
+                    g as f32 / COLOR_MAX,
+                    b as f32 / COLOR_MAX,
+                    a as f32 / COLOR_MAX,
                 ))
             }
             _ => None,
@@ -98,10 +101,10 @@ impl Color {
 
     /// Emit as shortest valid hex string.
     pub fn to_hex(&self) -> String {
-        let r = (self.r * 255.0).round() as u8;
-        let g = (self.g * 255.0).round() as u8;
-        let b = (self.b * 255.0).round() as u8;
-        let a = (self.a * 255.0).round() as u8;
+        let r = (self.r * COLOR_MAX).round() as u8;
+        let g = (self.g * COLOR_MAX).round() as u8;
+        let b = (self.b * COLOR_MAX).round() as u8;
+        let a = (self.a * COLOR_MAX).round() as u8;
         if a == 255 {
             format!("#{r:02X}{g:02X}{b:02X}")
         } else {
@@ -1011,7 +1014,7 @@ mod tests {
         assert_eq!(c.to_hex(), "#6C5CE7");
 
         let c2 = Color::from_hex("#FF000080").unwrap();
-        assert!((c2.a - 128.0 / 255.0).abs() < 0.01);
+        assert!((c2.a - 128.0 / COLOR_MAX).abs() < 0.01);
         assert!(c2.to_hex().len() == 9); // #RRGGBBAA
     }
 

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -5,6 +5,10 @@
 //! (group, rect, ellipse, path, text), inline properties, animations,
 //! and top-level constraints.
 
+const DEFAULT_FRAME_SIZE: f32 = 200.0;
+const DEFAULT_RECT_SIZE: f32 = 100.0;
+const DEFAULT_ELLIPSE_RADIUS: f32 = 50.0;
+
 use crate::id::NodeId;
 use crate::model::*;
 use winnow::ascii::space1;
@@ -592,18 +596,18 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let kind = match kind_str {
         "group" => NodeKind::Group, // Group is purely organizational — layout ignored
         "frame" => NodeKind::Frame {
-            width: width.unwrap_or(200.0),
-            height: height.unwrap_or(200.0),
+            width: width.unwrap_or(DEFAULT_FRAME_SIZE),
+            height: height.unwrap_or(DEFAULT_FRAME_SIZE),
             clip,
             layout,
         },
         "rect" => NodeKind::Rect {
-            width: width.unwrap_or(100.0),
-            height: height.unwrap_or(100.0),
+            width: width.unwrap_or(DEFAULT_RECT_SIZE),
+            height: height.unwrap_or(DEFAULT_RECT_SIZE),
         },
         "ellipse" => NodeKind::Ellipse {
-            rx: width.unwrap_or(50.0),
-            ry: height.unwrap_or(50.0),
+            rx: width.unwrap_or(DEFAULT_ELLIPSE_RADIUS),
+            ry: height.unwrap_or(DEFAULT_ELLIPSE_RADIUS),
         },
         "text" => NodeKind::Text {
             content: inline_text.unwrap_or_default(),

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -17,6 +17,15 @@ use fd_core::emitter::emit_document;
 use fd_core::id::NodeId;
 use fd_core::model::*;
 use fd_core::parser::parse_document;
+
+const ROUNDING_FACTOR: f32 = 100.0;
+const DUPLICATE_OFFSET: f32 = 20.0;
+const DEFAULT_TEXT_WIDTH: f32 = 80.0;
+const DEFAULT_TEXT_HEIGHT: f32 = 24.0;
+const DEFAULT_FONT_SIZE: f32 = 14.0;
+const CHAR_WIDTH_RATIO: f32 = 0.6;
+const LINE_HEIGHT_RATIO: f32 = 1.4;
+
 use fd_core::{ResolvedBounds, Viewport, resolve_layout};
 use std::collections::HashMap;
 
@@ -134,15 +143,15 @@ impl SyncEngine {
                                     | Constraint::FillParent { .. }
                             )
                         });
-                        let rx = (rel_x * 100.0).round() / 100.0;
-                        let ry = (rel_y * 100.0).round() / 100.0;
+                        let rx = (rel_x * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
+                        let ry = (rel_y * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
                         node.constraints.push(Constraint::Position { x: rx, y: ry });
                     }
                 }
             }
             GraphMutation::ResizeNode { id, width, height } => {
-                let rw = (width * 100.0).round() / 100.0;
-                let rh = (height * 100.0).round() / 100.0;
+                let rw = (width * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
+                let rh = (height * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
                 if let Some(node) = self.graph.get_by_id_mut(id) {
                     match &mut node.kind {
                         NodeKind::Rect {
@@ -200,7 +209,7 @@ impl SyncEngine {
                     NodeKind::Rect { width, height } => (*width, *height),
                     NodeKind::Ellipse { rx, ry } => (rx * 2.0, ry * 2.0),
                     NodeKind::Frame { width, height, .. } => (*width, *height),
-                    NodeKind::Text { .. } => (80.0, 24.0),
+                    NodeKind::Text { .. } => (DEFAULT_TEXT_WIDTH, DEFAULT_TEXT_HEIGHT),
                     _ => (0.0, 0.0),
                 };
                 let idx = self.graph.add_node(parent_idx, *node);
@@ -258,8 +267,8 @@ impl SyncEngine {
                     // Offset via constraint
                     cloned.constraints.push(Constraint::Offset {
                         from: id,
-                        dx: 20.0,
-                        dy: 20.0,
+                        dx: DUPLICATE_OFFSET,
+                        dy: DUPLICATE_OFFSET,
                     });
                     self.graph.add_node(self.graph.root, cloned);
                 }
@@ -500,9 +509,9 @@ impl SyncEngine {
                 .style
                 .font
                 .as_ref()
-                .map_or(14.0, |f| f.size);
-            let text_w = content.chars().count() as f32 * font_size * 0.6;
-            let text_h = font_size * 1.4;
+                .map_or(DEFAULT_FONT_SIZE, |f| f.size);
+            let text_w = content.chars().count() as f32 * font_size * CHAR_WIDTH_RATIO;
+            let text_h = font_size * LINE_HEIGHT_RATIO;
             let cx = child_b.x + child_b.width / 2.0;
             let cy = child_b.y + child_b.height / 2.0;
             child_b.width = text_w;
@@ -674,9 +683,9 @@ fn handle_child_group_relationship(
             .style
             .font
             .as_ref()
-            .map_or(14.0, |f| f.size);
-        let text_w = content.chars().count() as f32 * font_size * 0.6;
-        let text_h = font_size * 1.4;
+            .map_or(DEFAULT_FONT_SIZE, |f| f.size);
+        let text_w = content.chars().count() as f32 * font_size * CHAR_WIDTH_RATIO;
+        let text_h = font_size * LINE_HEIGHT_RATIO;
 
         // Shrink the overlap test box to the visual text area.
         let cx = child_b.x + child_b.width / 2.0;
@@ -791,8 +800,8 @@ pub fn detach_child_from_group(
         .get(&new_parent_idx)
         .map(|b| (b.x, b.y))
         .unwrap_or((0.0, 0.0));
-    let new_rel_x = ((child_b.x - new_parent_offset.0) * 100.0).round() / 100.0;
-    let new_rel_y = ((child_b.y - new_parent_offset.1) * 100.0).round() / 100.0;
+    let new_rel_x = ((child_b.x - new_parent_offset.0) * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
+    let new_rel_y = ((child_b.y - new_parent_offset.1) * ROUNDING_FACTOR).round() / ROUNDING_FACTOR;
 
     let child_id = graph.graph[child_idx].id;
     if let Some(node) = graph.get_by_id_mut(child_id) {

--- a/crates/fd-render/src/paint.rs
+++ b/crates/fd-render/src/paint.rs
@@ -3,6 +3,8 @@
 //! Walks the resolved scene graph and emits Vello paint operations:
 //! fills, strokes, paths, text glyphs, gradients.
 
+const COLOR_MAX: f32 = 255.0;
+
 use fd_core::NodeIndex;
 use fd_core::ResolvedBounds;
 use fd_core::SceneGraph;
@@ -163,19 +165,19 @@ fn paint_to_color(paint: &Paint, opacity: Option<f32>) -> Color {
     let alpha = opacity.unwrap_or(1.0).clamp(0.0, 1.0);
     match paint {
         Paint::Solid(c) => Color::from_rgba8(
-            (c.r * 255.0) as u8,
-            (c.g * 255.0) as u8,
-            (c.b * 255.0) as u8,
-            (c.a * alpha * 255.0) as u8,
+            (c.r * COLOR_MAX) as u8,
+            (c.g * COLOR_MAX) as u8,
+            (c.b * COLOR_MAX) as u8,
+            (c.a * alpha * COLOR_MAX) as u8,
         ),
         Paint::LinearGradient { stops, .. } | Paint::RadialGradient { stops } => stops
             .first()
             .map(|s| {
                 Color::from_rgba8(
-                    (s.color.r * 255.0) as u8,
-                    (s.color.g * 255.0) as u8,
-                    (s.color.b * 255.0) as u8,
-                    (s.color.a * alpha * 255.0) as u8,
+                    (s.color.r * COLOR_MAX) as u8,
+                    (s.color.g * COLOR_MAX) as u8,
+                    (s.color.b * COLOR_MAX) as u8,
+                    (s.color.a * alpha * COLOR_MAX) as u8,
                 )
             })
             .unwrap_or(Color::from_rgb8(0, 0, 0)),


### PR DESCRIPTION
Extract magic numbers in 5 files (crates/fd-core/src/layout.rs, crates/fd-core/src/model.rs, crates/fd-core/src/parser.rs, crates/fd-editor/src/sync.rs, crates/fd-render/src/paint.rs) as part of Gardener's code quality check. This change preserves all existing behavior.

---
*PR created automatically by Jules for task [12789171408270995747](https://jules.google.com/task/12789171408270995747) started by @khangnghiem*