### PR TITLE
refactor(sync): consolidated syncSelection() + edge sync across Layers↔Code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.29 — Consolidated `syncSelection()` + Edge Sync
+
+- **REFACTOR (R2.5)**: All selection sync logic consolidated into one `syncSelection(id, source)` function in `sync.js` — previously scattered across 4 files (pointer.js, panels.js, shortcuts.js, sync.js); single source of truth for Canvas↔Layers↔Code synchronization; future panels stay in sync automatically
+- **UX (R2.5)**: Edge selection now syncs across Layers and Code panels — clicking an edge `⟶` in Layers highlights the edge's `@id` line in Code; clicking a Code line with `edge @id` highlights it in Layers and scrolls into view; Canvas edge selection is a no-op (gracefully handled, waiting for WASM edge highlight support)
+
 ### v0.10.28 — Cross-Panel Selection Sync
 
 - **UX (R2.5)**: Clicking a node in any panel now syncs selection across all three panels (Code, Canvas, Layers):

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -35,7 +35,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R2.2** _(done)_: Text → Canvas: Source edits re-render the canvas in <16ms
 - **R2.3** _(planned)_: Incremental: Only re-parse/re-emit changed regions, not the entire document
 - **R2.4** _(done)_: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
-- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node block in the text editor selects it on canvas and pans to focus; clicking a node on canvas reveals and highlights its `@id` line in the text editor; all clicks sync the Layers panel highlight with scroll-into-view; Code→Canvas focus is debounced (150ms) to prevent animation jitter
+- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node/edge block in the text editor selects it on canvas and pans to focus; clicking a node on canvas reveals and highlights its `@id` line in the text editor; all clicks sync the Layers panel highlight with scroll-into-view; Code→Canvas focus is debounced (150ms); edge IDs sync across Layers↔Code; all sync logic consolidated in `syncSelection(id, source)`
 
 ### R3: Human Editing (Canvas)
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.28",
+  "version": "0.10.29",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -624,8 +624,7 @@ function setupPointerEvents() {
     if (!inlineEditorActive) {
       const selectedId = fdCanvas.get_selected_id();
       if (selectedId !== lastNotifiedSelectedId) {
-        lastNotifiedSelectedId = selectedId;
-        vscode.postMessage({ type: "nodeSelected", id: selectedId });
+        syncSelection(selectedId, "canvas");
       }
     }
 
@@ -1105,6 +1104,46 @@ function updateLockedIndicator(tool) {
  *  when rapidly arrowing through lines in the text editor. */
 let codeFocusDebounceTimer = null;
 
+/**
+ * Central selection sync — one function, all panels.
+ * Ensures that selecting a node/edge in ANY panel updates all others.
+ *
+ * @param {string} id - Node or edge ID (from @id), or "" to deselect
+ * @param {'canvas'|'layers'|'code'|'keyboard'} source - Origin panel
+ */
+function syncSelection(id, source) {
+  if (!fdCanvas) return;
+
+  // 1. Canvas: select + render (skip if source is canvas — already selected)
+  if (source !== "canvas") {
+    fdCanvas.select_by_id(id || "");
+    // select_by_id returns false for edge IDs — that's OK, edges
+    // don't have canvas selection highlights yet
+    render();
+  }
+
+  // 2. Dedup state — prevents redundant nodeSelected round-trips
+  lastNotifiedSelectedId = id || "";
+
+  // 3. Layers: highlight + scroll into view
+  refreshLayersPanel();
+
+  // 4. Code: notify extension to highlight line (skip if source is code)
+  if (source !== "code") {
+    vscode.postMessage({ type: "nodeSelected", id: id || "" });
+  }
+
+  // 5. Canvas focus: debounced pan/zoom (only for Code→Canvas)
+  if (source === "code" && id) {
+    clearTimeout(codeFocusDebounceTimer);
+    codeFocusDebounceTimer = setTimeout(() => focusOnNode(id), 150);
+  }
+
+  // 6. Side panels
+  updatePropertiesPanel();
+  updateFloatingBar();
+}
+
 window.addEventListener("message", (event) => {
   const message = event.data;
 
@@ -1122,20 +1161,8 @@ window.addEventListener("message", (event) => {
       break;
     }
     case "selectNode": {
-      if (!fdCanvas) return;
-      const nodeId = message.nodeId || "";
-      if (fdCanvas.select_by_id(nodeId)) {
-        // Sync dedup state so next canvas click sends nodeSelected correctly
-        lastNotifiedSelectedId = nodeId;
-        render();
-        // Update Layers panel highlight + scroll into view
-        refreshLayersPanel();
-        // Debounced pan/zoom to the selected node on Canvas (150ms)
-        if (nodeId) {
-          clearTimeout(codeFocusDebounceTimer);
-          codeFocusDebounceTimer = setTimeout(() => focusOnNode(nodeId), 150);
-        }
-      }
+      // Code cursor moved to a node/edge line → sync all panels
+      syncSelection(message.nodeId || "", "code");
       break;
     }
     case "libraryData": {
@@ -1178,6 +1205,7 @@ function syncTextToExtension() {
     text: text,
   });
 }
+
 
 // ─── Keyboard shortcuts (delegated to WASM) ─────────────────────────────
 
@@ -1428,8 +1456,7 @@ document.addEventListener("keydown", (e) => {
   // Notify extension of selection changes from keyboard actions
   if (result.changed || result.action === "deselect") {
     const selectedId = fdCanvas.get_selected_id();
-    vscode.postMessage({ type: "nodeSelected", id: selectedId });
-    updateFloatingBar();
+    syncSelection(selectedId, "keyboard");
   }
 
   // Update cursor when tool changes via shortcut
@@ -3290,22 +3317,18 @@ function refreshLayersPanel() {
       e.stopPropagation();
       const nodeId = item.getAttribute("data-node-id");
       if (nodeId && fdCanvas) {
-        if (fdCanvas.select_by_id(nodeId)) {
-          // Pre-set generation so that scheduleSideEffects() → refreshLayersPanel() skips DOM rebuild.
-          // This keeps our DOM references valid for the highlight update below.
-          lastLayerGeneration = sceneGeneration;
-          lastLayerSelectedId = nodeId;
-          render();
-          // Update selection highlight in layers (DOM still intact because rebuild was skipped)
-          panel.querySelectorAll(".layer-item").forEach((el) => {
-            el.classList.toggle("selected", el.getAttribute("data-node-id") === nodeId);
-          });
-          // Smart focus: pan/zoom to the selected node if needed
-          focusOnNode(nodeId);
-          // Notify extension of selection
-          vscode.postMessage({ type: "nodeSelected", id: nodeId });
-          updatePropertiesPanel();
-        }
+        // Pre-set generation so refreshLayersPanel() inside syncSelection skips DOM rebuild.
+        // This keeps our DOM references valid for the highlight update below.
+        lastLayerGeneration = sceneGeneration;
+        lastLayerSelectedId = nodeId;
+        // Update selection highlight in layers (DOM still intact because rebuild was skipped)
+        panel.querySelectorAll(".layer-item").forEach((el) => {
+          el.classList.toggle("selected", el.getAttribute("data-node-id") === nodeId);
+        });
+        // Smart focus: pan/zoom to the selected node if needed
+        focusOnNode(nodeId);
+        // Central sync: Canvas select + Code highlight + side panels
+        syncSelection(nodeId, "layers");
       }
     });
   });

--- a/fd-vscode/webview/src/panels.js
+++ b/fd-vscode/webview/src/panels.js
@@ -603,22 +603,18 @@ function refreshLayersPanel() {
       e.stopPropagation();
       const nodeId = item.getAttribute("data-node-id");
       if (nodeId && fdCanvas) {
-        if (fdCanvas.select_by_id(nodeId)) {
-          // Pre-set generation so that scheduleSideEffects() → refreshLayersPanel() skips DOM rebuild.
-          // This keeps our DOM references valid for the highlight update below.
-          lastLayerGeneration = sceneGeneration;
-          lastLayerSelectedId = nodeId;
-          render();
-          // Update selection highlight in layers (DOM still intact because rebuild was skipped)
-          panel.querySelectorAll(".layer-item").forEach((el) => {
-            el.classList.toggle("selected", el.getAttribute("data-node-id") === nodeId);
-          });
-          // Smart focus: pan/zoom to the selected node if needed
-          focusOnNode(nodeId);
-          // Notify extension of selection
-          vscode.postMessage({ type: "nodeSelected", id: nodeId });
-          updatePropertiesPanel();
-        }
+        // Pre-set generation so refreshLayersPanel() inside syncSelection skips DOM rebuild.
+        // This keeps our DOM references valid for the highlight update below.
+        lastLayerGeneration = sceneGeneration;
+        lastLayerSelectedId = nodeId;
+        // Update selection highlight in layers (DOM still intact because rebuild was skipped)
+        panel.querySelectorAll(".layer-item").forEach((el) => {
+          el.classList.toggle("selected", el.getAttribute("data-node-id") === nodeId);
+        });
+        // Smart focus: pan/zoom to the selected node if needed
+        focusOnNode(nodeId);
+        // Central sync: Canvas select + Code highlight + side panels
+        syncSelection(nodeId, "layers");
       }
     });
   });

--- a/fd-vscode/webview/src/pointer.js
+++ b/fd-vscode/webview/src/pointer.js
@@ -290,8 +290,7 @@ function setupPointerEvents() {
     if (!inlineEditorActive) {
       const selectedId = fdCanvas.get_selected_id();
       if (selectedId !== lastNotifiedSelectedId) {
-        lastNotifiedSelectedId = selectedId;
-        vscode.postMessage({ type: "nodeSelected", id: selectedId });
+        syncSelection(selectedId, "canvas");
       }
     }
 

--- a/fd-vscode/webview/src/shortcuts.js
+++ b/fd-vscode/webview/src/shortcuts.js
@@ -251,8 +251,7 @@ document.addEventListener("keydown", (e) => {
   // Notify extension of selection changes from keyboard actions
   if (result.changed || result.action === "deselect") {
     const selectedId = fdCanvas.get_selected_id();
-    vscode.postMessage({ type: "nodeSelected", id: selectedId });
-    updateFloatingBar();
+    syncSelection(selectedId, "keyboard");
   }
 
   // Update cursor when tool changes via shortcut

--- a/fd-vscode/webview/src/sync.js
+++ b/fd-vscode/webview/src/sync.js
@@ -8,6 +8,46 @@
  *  when rapidly arrowing through lines in the text editor. */
 let codeFocusDebounceTimer = null;
 
+/**
+ * Central selection sync — one function, all panels.
+ * Ensures that selecting a node/edge in ANY panel updates all others.
+ *
+ * @param {string} id - Node or edge ID (from @id), or "" to deselect
+ * @param {'canvas'|'layers'|'code'|'keyboard'} source - Origin panel
+ */
+function syncSelection(id, source) {
+  if (!fdCanvas) return;
+
+  // 1. Canvas: select + render (skip if source is canvas — already selected)
+  if (source !== "canvas") {
+    fdCanvas.select_by_id(id || "");
+    // select_by_id returns false for edge IDs — that's OK, edges
+    // don't have canvas selection highlights yet
+    render();
+  }
+
+  // 2. Dedup state — prevents redundant nodeSelected round-trips
+  lastNotifiedSelectedId = id || "";
+
+  // 3. Layers: highlight + scroll into view
+  refreshLayersPanel();
+
+  // 4. Code: notify extension to highlight line (skip if source is code)
+  if (source !== "code") {
+    vscode.postMessage({ type: "nodeSelected", id: id || "" });
+  }
+
+  // 5. Canvas focus: debounced pan/zoom (only for Code→Canvas)
+  if (source === "code" && id) {
+    clearTimeout(codeFocusDebounceTimer);
+    codeFocusDebounceTimer = setTimeout(() => focusOnNode(id), 150);
+  }
+
+  // 6. Side panels
+  updatePropertiesPanel();
+  updateFloatingBar();
+}
+
 window.addEventListener("message", (event) => {
   const message = event.data;
 
@@ -25,20 +65,8 @@ window.addEventListener("message", (event) => {
       break;
     }
     case "selectNode": {
-      if (!fdCanvas) return;
-      const nodeId = message.nodeId || "";
-      if (fdCanvas.select_by_id(nodeId)) {
-        // Sync dedup state so next canvas click sends nodeSelected correctly
-        lastNotifiedSelectedId = nodeId;
-        render();
-        // Update Layers panel highlight + scroll into view
-        refreshLayersPanel();
-        // Debounced pan/zoom to the selected node on Canvas (150ms)
-        if (nodeId) {
-          clearTimeout(codeFocusDebounceTimer);
-          codeFocusDebounceTimer = setTimeout(() => focusOnNode(nodeId), 150);
-        }
-      }
+      // Code cursor moved to a node/edge line → sync all panels
+      syncSelection(message.nodeId || "", "code");
       break;
     }
     case "libraryData": {
@@ -81,4 +109,5 @@ function syncTextToExtension() {
     text: text,
   });
 }
+
 


### PR DESCRIPTION
## Changes\n\nConsolidated all selection sync logic into a single `syncSelection(id, source)` function + edge selection support:\n\n### Item 6: Consolidated `syncSelection()`\n- **Before**: Selection sync logic scattered across 4 files (pointer.js, panels.js, shortcuts.js, sync.js) with each doing its own subset of canvas select + layers highlight + code highlight + properties update\n- **After**: One `syncSelection(id, source)` function handles all panel updates consistently; each call site delegates to it with a `source` parameter ('canvas', 'layers', 'code', 'keyboard') to skip the originating panel's update\n\n### Item 4: Edge Selection Sync\n- Clicking an edge in Layers panel now highlights the corresponding `edge @id` line in Code\n- Clicking a Code line with `edge @id` now highlights it in Layers and scrolls into view\n- Canvas edge selection is gracefully handled (no-op since WASM doesn't support edge highlights yet)\n\n## Files Changed\n- `sync.js` — Added `syncSelection()` function, simplified `selectNode` handler\n- `pointer.js` — Canvas pointerup now calls `syncSelection(id, 'canvas')`\n- `panels.js` — Layers click now calls `syncSelection(id, 'layers')`\n- `shortcuts.js` — Keyboard handler now calls `syncSelection(id, 'keyboard')`\n- `main.js` — Rebuilt from source modules\n\n## Tests\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace`\n- ✅ `pnpm test` (191 tests pass)