### PR TITLE
fix(canvas): remove setPointerCapture — fix drag-to-create from toolbar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.30 — Fix Drag-to-Create from Toolbar (Remove setPointerCapture)
+
+- **FIX (R3.42)**: Drag-to-create from floating toolbar now works reliably — removed all `canvas.setPointerCapture` calls from `pointer.js` which stole pointer events from the toolbar's document-level `pointermove`/`pointerup` listeners, preventing ghost preview from appearing and shapes from being created on drop
+- **REFACTOR (R3.39)**: Canvas pointer event handling now uses document-level listeners with `canvasPointerId` tracking — same pattern already proven by toolbar drag and drag-to-create handlers; eliminates entire class of "pointer capture steals events from sibling overlays" bugs
+- **FIX (R3.39)**: Toolbar guard in canvas `pointerdown` replaced from fragile `getBoundingClientRect()` comparison to robust `e.target.closest('#floating-toolbar')` DOM ancestry check — works regardless of toolbar orientation, transforms, or rolled-up state
+- **REFACTOR**: `dtcTool` and `dtcActive` hoisted from `setupFloatingToolbar()` closure to module scope in `navigation.js` — enables cross-module coordination with canvas pointer handlers
+
 ### v0.10.29 — Consolidated `syncSelection()` + Edge Sync
 
 - **REFACTOR (R2.5)**: All selection sync logic consolidated into one `syncSelection(id, source)` function in `sync.js` — previously scattered across 4 files (pointer.js, panels.js, shortcuts.js, sync.js); single source of truth for Canvas↔Layers↔Code synchronization; future panels stay in sync automatically

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -298,16 +298,18 @@ Engineering lessons discovered through building FD.
 
 ---
 
-## setPointerCapture Fails Silently in VS Code Webview — Use Document-Level Listeners
+## setPointerCapture Fails AND Steals Events in VS Code Webview — Never Use It
 
-**Date**: 2026-03-03
-**Context**: Drag-to-create from floating toolbar buttons didn't work — ghost preview never appeared, shapes never created on canvas drop. Same root cause as toolbar drag handles (PR #333, v0.10.8).
+**Date**: 2026-03-03 (updated 2026-03-05)
+**Context**: Drag-to-create from floating toolbar buttons didn't work — ghost preview never appeared, shapes never created on canvas drop. Root cause was `canvas.setPointerCapture(e.pointerId)` in `pointer.js` stealing pointer events from the toolbar's document-level `pointermove`/`pointerup` listeners. Six fix attempts across v0.10.8, v0.10.10, v0.10.16, v0.10.23, and v0.10.27 addressed symptoms (toolbar drag handles, button listeners, CSS stacking, rect guards) but not the core conflict.
 
-**Root cause**: `btn.setPointerCapture(e.pointerId)` silently fails inside VS Code webview iframes. When `pointermove`/`pointerup` listeners are attached to the button element, they stop firing as soon as the pointer leaves the button's bounding box (because the capture never took effect). This means: no ghost preview, no drop detection, no new shapes.
+**Root cause**: `setPointerCapture` has a dual failure mode in VS Code webview iframes: (1) it **silently fails** — capture never takes effect, so events stop when the pointer leaves the originating element. (2) When it **does work** (desktop Electron, some VS Code versions), it **steals ALL pointer events** for that pointerId and redirects them to the capturing element, bypassing ALL other listeners including document-level ones. This inconsistency means: Codespace E2E tests pass (failure mode 1 — capture doesn't work, document handlers fire fine) but local desktop testing fails (success mode — capture steals events from toolbar handlers).
 
-**Fix**: Removed `setPointerCapture` call. Moved `pointermove`, `pointerup`, and `pointercancel` from per-button listeners to `document`-level listeners. Added `dtcBtn` variable to track the originating button for click suppression after drag.
+**The geometry-based guard was also fragile**: `getBoundingClientRect()` comparison fails when toolbar is rolled-up (rect shrinks), has CSS transforms during drag, or buttons extend beyond padding.
 
-**Lesson**: **Never use `setPointerCapture` in VS Code webview code.** It silently fails in iframe contexts. Always use document-level `pointermove`/`pointerup` listeners for any drag interaction that needs to track the pointer after it leaves the originating element. Pattern: attach `pointerdown` on the element (for state init), attach `pointermove`/`pointerup` on `document` (for tracking).
+**Fix**: (v0.10.30) Removed ALL `setPointerCapture`/`releasePointerCapture` calls from canvas. Moved canvas `pointermove`/`pointerup` from `canvas` element to `document`-level listeners. Track ownership via `canvasPointerId` flag (set in pointerdown, cleared in pointerup). Gate idle hover to `e.target === canvas` check. Gate active drag to `e.pointerId === canvasPointerId`. Replaced toolbar rect guard with `e.target.closest('#floating-toolbar')` DOM ancestry check.
+
+**Lesson**: **Never use `setPointerCapture` anywhere in VS Code webview code — not just toolbar handlers, not just canvas.** It has inconsistent behavior across VS Code environments. Always use document-level `pointermove`/`pointerup` listeners with a pointer ownership flag. For toolbar/overlay guards, use `e.target.closest()` DOM ancestry — never `getBoundingClientRect()` geometry comparison.
 
 ---
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.29",
+  "version": "0.10.30",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -341,18 +341,16 @@ function playDetachAnimation(nodeId) {
 function setupPointerEvents() {
   const dpr = window.devicePixelRatio || 1;
 
+  // Track canvas pointer ownership — replaces setPointerCapture
+  // (setPointerCapture silently fails in VS Code webview iframes and
+  //  steals events from toolbar's document-level drag-to-create listeners)
+  let canvasPointerId = -1;
+
   canvas.addEventListener("pointerdown", (e) => {
     if (!fdCanvas) return;
 
-    // Skip if pointer is over the floating toolbar (sibling overlay)
-    const ft = document.getElementById("floating-toolbar");
-    if (ft) {
-      const tbRect = ft.getBoundingClientRect();
-      if (e.clientX >= tbRect.left && e.clientX <= tbRect.right
-        && e.clientY >= tbRect.top && e.clientY <= tbRect.bottom) {
-        return;
-      }
-    }
+    // Skip if pointer originated inside the floating toolbar (DOM ancestry)
+    if (e.target.closest && e.target.closest('#floating-toolbar')) return;
 
     clearModifierCursors(); // Modifier preview ends when interaction starts
     const rect = canvas.getBoundingClientRect();
@@ -365,7 +363,7 @@ function setupPointerEvents() {
       panStartX = e.clientX - panX;
       panStartY = e.clientY - panY;
       canvas.style.cursor = "grabbing";
-      canvas.setPointerCapture(e.pointerId);
+      canvasPointerId = e.pointerId;
       e.preventDefault();
       return;
     }
@@ -438,7 +436,7 @@ function setupPointerEvents() {
       e.metaKey
     );
     if (changed) render();
-    canvas.setPointerCapture(e.pointerId);
+    canvasPointerId = e.pointerId;
 
     // Track interaction start for dimension tooltip
     pointerIsDown = true;
@@ -457,8 +455,14 @@ function setupPointerEvents() {
     }
   });
 
-  canvas.addEventListener("pointermove", (e) => {
+  document.addEventListener("pointermove", (e) => {
     if (!fdCanvas) return;
+    // During active drag, only process our owned pointer
+    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
+    // Skip if a toolbar drag-to-create or toolbar drag is in progress
+    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // During hover (no active drag), only process events over the canvas
+    if (canvasPointerId === -1 && e.target !== canvas) return;
 
     // Pan drag in progress
     if (panDragging) {
@@ -555,17 +559,18 @@ function setupPointerEvents() {
     }
   });
 
-  canvas.addEventListener("pointerup", (e) => {
+  document.addEventListener("pointerup", (e) => {
     if (!fdCanvas) return;
-    // Always release pointer capture — prevents stale captures
-    // from blocking toolbar and other overlay pointer events
-    try { canvas.releasePointerCapture(e.pointerId); } catch (_) { }
+    // Only handle events owned by the canvas
+    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
+    // Skip if a toolbar drag-to-create is in progress
+    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    canvasPointerId = -1;
 
     // End pan drag
     if (panDragging) {
       panDragging = false;
       canvas.style.cursor = isPanning ? "grab" : "";
-      canvas.releasePointerCapture(e.pointerId);
       return;
     }
 
@@ -615,7 +620,7 @@ function setupPointerEvents() {
       }
     }
 
-    canvas.releasePointerCapture(e.pointerId);
+    // (setPointerCapture removed — using canvasPointerId tracking instead)
     // Update properties panel after interaction ends
     updatePropertiesPanel();
     updateFloatingBar();
@@ -4064,6 +4069,10 @@ function openInlineEditor(nodeId, propKey, currentValue) {
 
 // ─── Dimension Tooltip (R3.18) ────────────────────────────────────────────────
 
+/** Module-level drag-to-create state (shared with pointer.js document listeners) */
+let dtcTool = null;
+let dtcActive = false;
+
 /** Show a floating dimension tooltip near the cursor. */
 function showDimensionTooltip(clientX, clientY, text) {
   const el = document.getElementById("dimension-tooltip");
@@ -4579,8 +4588,8 @@ function setupFloatingToolbar() {
 
   // ── Drag-to-Create: drag a tool button onto the canvas ──
   const DRAG_THRESHOLD = 5;
-  let dtcActive = false;
-  let dtcTool = null;
+  // dtcTool and dtcActive are declared at module scope (above) so
+  // pointer.js document-level listeners can check for active toolbar drags
   let dtcStartX = 0;
   let dtcStartY = 0;
   let dtcGhost = null;

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -4,6 +4,10 @@
 
 // ─── Dimension Tooltip (R3.18) ────────────────────────────────────────────────
 
+/** Module-level drag-to-create state (shared with pointer.js document listeners) */
+let dtcTool = null;
+let dtcActive = false;
+
 /** Show a floating dimension tooltip near the cursor. */
 function showDimensionTooltip(clientX, clientY, text) {
   const el = document.getElementById("dimension-tooltip");
@@ -519,8 +523,8 @@ function setupFloatingToolbar() {
 
   // ── Drag-to-Create: drag a tool button onto the canvas ──
   const DRAG_THRESHOLD = 5;
-  let dtcActive = false;
-  let dtcTool = null;
+  // dtcTool and dtcActive are declared at module scope (above) so
+  // pointer.js document-level listeners can check for active toolbar drags
   let dtcStartX = 0;
   let dtcStartY = 0;
   let dtcGhost = null;

--- a/fd-vscode/webview/src/pointer.js
+++ b/fd-vscode/webview/src/pointer.js
@@ -7,18 +7,16 @@
 function setupPointerEvents() {
   const dpr = window.devicePixelRatio || 1;
 
+  // Track canvas pointer ownership — replaces setPointerCapture
+  // (setPointerCapture silently fails in VS Code webview iframes and
+  //  steals events from toolbar's document-level drag-to-create listeners)
+  let canvasPointerId = -1;
+
   canvas.addEventListener("pointerdown", (e) => {
     if (!fdCanvas) return;
 
-    // Skip if pointer is over the floating toolbar (sibling overlay)
-    const ft = document.getElementById("floating-toolbar");
-    if (ft) {
-      const tbRect = ft.getBoundingClientRect();
-      if (e.clientX >= tbRect.left && e.clientX <= tbRect.right
-        && e.clientY >= tbRect.top && e.clientY <= tbRect.bottom) {
-        return;
-      }
-    }
+    // Skip if pointer originated inside the floating toolbar (DOM ancestry)
+    if (e.target.closest && e.target.closest('#floating-toolbar')) return;
 
     clearModifierCursors(); // Modifier preview ends when interaction starts
     const rect = canvas.getBoundingClientRect();
@@ -31,7 +29,7 @@ function setupPointerEvents() {
       panStartX = e.clientX - panX;
       panStartY = e.clientY - panY;
       canvas.style.cursor = "grabbing";
-      canvas.setPointerCapture(e.pointerId);
+      canvasPointerId = e.pointerId;
       e.preventDefault();
       return;
     }
@@ -104,7 +102,7 @@ function setupPointerEvents() {
       e.metaKey
     );
     if (changed) render();
-    canvas.setPointerCapture(e.pointerId);
+    canvasPointerId = e.pointerId;
 
     // Track interaction start for dimension tooltip
     pointerIsDown = true;
@@ -123,8 +121,14 @@ function setupPointerEvents() {
     }
   });
 
-  canvas.addEventListener("pointermove", (e) => {
+  document.addEventListener("pointermove", (e) => {
     if (!fdCanvas) return;
+    // During active drag, only process our owned pointer
+    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
+    // Skip if a toolbar drag-to-create or toolbar drag is in progress
+    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // During hover (no active drag), only process events over the canvas
+    if (canvasPointerId === -1 && e.target !== canvas) return;
 
     // Pan drag in progress
     if (panDragging) {
@@ -221,17 +225,18 @@ function setupPointerEvents() {
     }
   });
 
-  canvas.addEventListener("pointerup", (e) => {
+  document.addEventListener("pointerup", (e) => {
     if (!fdCanvas) return;
-    // Always release pointer capture — prevents stale captures
-    // from blocking toolbar and other overlay pointer events
-    try { canvas.releasePointerCapture(e.pointerId); } catch (_) { }
+    // Only handle events owned by the canvas
+    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
+    // Skip if a toolbar drag-to-create is in progress
+    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    canvasPointerId = -1;
 
     // End pan drag
     if (panDragging) {
       panDragging = false;
       canvas.style.cursor = isPanning ? "grab" : "";
-      canvas.releasePointerCapture(e.pointerId);
       return;
     }
 
@@ -281,7 +286,7 @@ function setupPointerEvents() {
       }
     }
 
-    canvas.releasePointerCapture(e.pointerId);
+    // (setPointerCapture removed — using canvasPointerId tracking instead)
     // Update properties panel after interaction ends
     updatePropertiesPanel();
     updateFloatingBar();


### PR DESCRIPTION
## Fix Drag-to-Create from Floating Toolbar

### Problem
Dragging a shape from the floating toolbar onto the canvas did not create a new shape. This was a regression that persisted through 6 prior fix attempts (v0.10.8, v0.10.10, v0.10.16, v0.10.23, v0.10.27).

### Root Cause
`canvas.setPointerCapture(e.pointerId)` in `pointer.js` stole ALL pointer events from the toolbar's document-level `pointermove`/`pointerup` listeners. The geometry-based toolbar guard (`getBoundingClientRect`) was also fragile under toolbar transforms/rolling.

### Fix
- **Removed** all `canvas.setPointerCapture`/`releasePointerCapture` calls
- **Moved** canvas `pointermove`/`pointerup` to document-level listeners with `canvasPointerId` tracking
- **Replaced** toolbar rect guard with `e.target.closest('#floating-toolbar')` DOM ancestry check
- **Hoisted** `dtcTool`/`dtcActive` to module scope for cross-module coordination

### Test Results
- ✅ `cargo clippy --workspace -- -D warnings` — clean
- ✅ `cargo fmt --all -- --check` — clean
- ✅ `cargo test --workspace` — all 287 Rust tests pass
- ✅ `pnpm test` — all 191 TS tests pass
- ✅ `pnpm run build:webview` — 6503 lines built