### PR TITLE
fix(canvas): fix pointer event regressions from v0.10.30

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.31 — Fix Pointer Event Regressions (from v0.10.30)
+
+- **FIX (R3.42)**: Drag-to-create from toolbar no longer triggers context menu — canvas `pointerup` handler now skips entirely when `canvasPointerId === -1` (no canvas `pointerdown` started the interaction); previously, drag-to-create's `pointerup` handler cleared `dtcTool` before the canvas handler ran, allowing fallthrough
+- **FIX (R3.39)**: Floating toolbar is now draggable again — canvas `pointermove` handler now checks `ftDragging` (hoisted from closure to module scope) to skip processing during toolbar drag; prevents cursor interference and WASM hover calls during toolbar repositioning
+
 ### v0.10.30 — Fix Drag-to-Create from Toolbar (Remove setPointerCapture)
 
 - **FIX (R3.42)**: Drag-to-create from floating toolbar now works reliably — removed all `canvas.setPointerCapture` calls from `pointer.js` which stole pointer events from the toolbar's document-level `pointermove`/`pointerup` listeners, preventing ghost preview from appearing and shapes from being created on drop

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.30",
+  "version": "0.10.31",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -459,8 +459,8 @@ function setupPointerEvents() {
     if (!fdCanvas) return;
     // During active drag, only process our owned pointer
     if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
-    // Skip if a toolbar drag-to-create or toolbar drag is in progress
-    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // Skip if toolbar drag or drag-to-create is in progress
+    if (ftDragging || dtcTool) return;
     // During hover (no active drag), only process events over the canvas
     if (canvasPointerId === -1 && e.target !== canvas) return;
 
@@ -561,10 +561,10 @@ function setupPointerEvents() {
 
   document.addEventListener("pointerup", (e) => {
     if (!fdCanvas) return;
-    // Only handle events owned by the canvas
-    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
-    // Skip if a toolbar drag-to-create is in progress
-    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // Skip entirely if no canvas pointerdown started this interaction
+    if (canvasPointerId === -1) return;
+    // Only handle events from our owned pointer
+    if (e.pointerId !== canvasPointerId) return;
     canvasPointerId = -1;
 
     // End pan drag
@@ -4069,9 +4069,10 @@ function openInlineEditor(nodeId, propKey, currentValue) {
 
 // ─── Dimension Tooltip (R3.18) ────────────────────────────────────────────────
 
-/** Module-level drag-to-create state (shared with pointer.js document listeners) */
+/** Module-level drag state (shared with pointer.js document listeners) */
 let dtcTool = null;
 let dtcActive = false;
+let ftDragging = false;   // true while toolbar is being dragged
 
 /** Show a floating dimension tooltip near the cursor. */
 function showDimensionTooltip(clientX, clientY, text) {
@@ -4470,7 +4471,8 @@ function setupFloatingToolbar() {
     observer.observe(btn, { attributes: true, attributeFilter: ["class"] });
   });
 
-  let isDragging = false;
+  // ftDragging is declared at module scope (above) so
+  // pointer.js document-level listeners can check for active toolbar drags
   let dragStartX = 0;
   let dragStartY = 0;
   let dragStartTime = 0;
@@ -4480,7 +4482,7 @@ function setupFloatingToolbar() {
 
   // Use document-level listeners — setPointerCapture fails in VS Code webview iframes
   document.addEventListener("pointermove", (e) => {
-    if (!isDragging || e.pointerId !== activePointerId) return;
+    if (!ftDragging || e.pointerId !== activePointerId) return;
     const dx = e.clientX - dragStartX;
     const dy = e.clientY - dragStartY;
 
@@ -4492,8 +4494,8 @@ function setupFloatingToolbar() {
   });
 
   document.addEventListener("pointerup", (e) => {
-    if (!isDragging || e.pointerId !== activePointerId) return;
-    isDragging = false;
+    if (!ftDragging || e.pointerId !== activePointerId) return;
+    ftDragging = false;
     activePointerId = -1;
 
     const dx = e.clientX - dragStartX;
@@ -4567,7 +4569,7 @@ function setupFloatingToolbar() {
     // Skip if target is a tool button or inside one (handled by drag-to-create)
     if (e.target.closest(".ft-tool-btn")) return;
 
-    isDragging = true;
+    ftDragging = true;
     activePointerId = e.pointerId;
     dragStartX = e.clientX;
     dragStartY = e.clientY;

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -4,9 +4,10 @@
 
 // ─── Dimension Tooltip (R3.18) ────────────────────────────────────────────────
 
-/** Module-level drag-to-create state (shared with pointer.js document listeners) */
+/** Module-level drag state (shared with pointer.js document listeners) */
 let dtcTool = null;
 let dtcActive = false;
+let ftDragging = false;   // true while toolbar is being dragged
 
 /** Show a floating dimension tooltip near the cursor. */
 function showDimensionTooltip(clientX, clientY, text) {
@@ -405,7 +406,8 @@ function setupFloatingToolbar() {
     observer.observe(btn, { attributes: true, attributeFilter: ["class"] });
   });
 
-  let isDragging = false;
+  // ftDragging is declared at module scope (above) so
+  // pointer.js document-level listeners can check for active toolbar drags
   let dragStartX = 0;
   let dragStartY = 0;
   let dragStartTime = 0;
@@ -415,7 +417,7 @@ function setupFloatingToolbar() {
 
   // Use document-level listeners — setPointerCapture fails in VS Code webview iframes
   document.addEventListener("pointermove", (e) => {
-    if (!isDragging || e.pointerId !== activePointerId) return;
+    if (!ftDragging || e.pointerId !== activePointerId) return;
     const dx = e.clientX - dragStartX;
     const dy = e.clientY - dragStartY;
 
@@ -427,8 +429,8 @@ function setupFloatingToolbar() {
   });
 
   document.addEventListener("pointerup", (e) => {
-    if (!isDragging || e.pointerId !== activePointerId) return;
-    isDragging = false;
+    if (!ftDragging || e.pointerId !== activePointerId) return;
+    ftDragging = false;
     activePointerId = -1;
 
     const dx = e.clientX - dragStartX;
@@ -502,7 +504,7 @@ function setupFloatingToolbar() {
     // Skip if target is a tool button or inside one (handled by drag-to-create)
     if (e.target.closest(".ft-tool-btn")) return;
 
-    isDragging = true;
+    ftDragging = true;
     activePointerId = e.pointerId;
     dragStartX = e.clientX;
     dragStartY = e.clientY;

--- a/fd-vscode/webview/src/pointer.js
+++ b/fd-vscode/webview/src/pointer.js
@@ -125,8 +125,8 @@ function setupPointerEvents() {
     if (!fdCanvas) return;
     // During active drag, only process our owned pointer
     if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
-    // Skip if a toolbar drag-to-create or toolbar drag is in progress
-    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // Skip if toolbar drag or drag-to-create is in progress
+    if (ftDragging || dtcTool) return;
     // During hover (no active drag), only process events over the canvas
     if (canvasPointerId === -1 && e.target !== canvas) return;
 
@@ -227,10 +227,10 @@ function setupPointerEvents() {
 
   document.addEventListener("pointerup", (e) => {
     if (!fdCanvas) return;
-    // Only handle events owned by the canvas
-    if (canvasPointerId !== -1 && e.pointerId !== canvasPointerId) return;
-    // Skip if a toolbar drag-to-create is in progress
-    if (typeof dtcTool !== 'undefined' && dtcTool) return;
+    // Skip entirely if no canvas pointerdown started this interaction
+    if (canvasPointerId === -1) return;
+    // Only handle events from our owned pointer
+    if (e.pointerId !== canvasPointerId) return;
     canvasPointerId = -1;
 
     // End pan drag


### PR DESCRIPTION
## Fix Pointer Event Regressions from v0.10.30

### Problem
v0.10.30 moved canvas pointer listeners to document level but left two gaps:
1. **Drag-to-create opens context menu** — canvas `pointerup` handler ran after toolbar's dtc handler cleared `dtcTool`, causing WASM `handle_pointer_up` + `updateFloatingBar()` to fire
2. **Toolbar undraggable** — canvas `pointermove` handler processed events during toolbar drag because `isDragging` was closure-scoped (invisible from pointer.js)

### Fix
- `pointerup`: skip entirely when `canvasPointerId === -1` (no canvas interaction started)
- `pointermove`: check `ftDragging` (hoisted from closure to module scope) to skip during toolbar drag
- `ftDragging` + `dtcTool` + `dtcActive` all at module scope for cross-module coordination

### Tests
- ✅ clippy clean, fmt clean, 287 Rust tests, 191 TS tests, webview built (6505 lines)