### PR TITLE
fix(webview): remove undefined setupSelectionBar() + fix CSP inline styles

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.33 — Fix Init Crash: setupSelectionBar + CSP Inline Styles
+
+- **FIX (R3.42)**: Remove call to non-existent `setupSelectionBar()` in `main()` — this crashed WASM init and prevented `setupFloatingToolbar()` (including drag-to-create) from ever executing. Dead code from a prior refactor.
+- **FIX**: Add `'unsafe-inline'` to CSP `style-src` — JS-set inline styles (ghost preview, toolbar drag, minimap overlays) were being silently blocked by Content Security Policy.
+
 ### v0.10.32 — Fix Drag-to-Create: Prevent Native Drag Hijack on SVG Icons
 
 - **FIX (R3.42)**: Drag-to-create now works — added `e.preventDefault()` in tool button `pointerdown` handler to prevent browser-native drag-and-drop on `<svg>` icons inside `<button>` elements, which was hijacking all `pointermove` events before the drag threshold could be reached (7th fix attempt — previous 6 fixed event routing but not the native drag takeover)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.32",
+  "version": "0.10.33",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -31,7 +31,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <meta http-equiv="Content-Security-Policy" content="
     default-src 'none';
     script-src 'nonce-{nonce}' 'wasm-unsafe-eval' {cspSource};
-    style-src 'nonce-{nonce}';
+    style-src 'nonce-{nonce}' 'unsafe-inline';
     img-src {cspSource};
     connect-src {cspSource};
     font-src {cspSource};

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -6278,7 +6278,6 @@ async function main() {
     setupInsertMenu();
     setupMinimap();
     setupColorSwatches();
-    setupSelectionBar();
     setupTouchGestures();
     setupZoomControls();
     setupUndoRedoControls();

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -80,7 +80,6 @@ async function main() {
     setupInsertMenu();
     setupMinimap();
     setupColorSwatches();
-    setupSelectionBar();
     setupTouchGestures();
     setupZoomControls();
     setupUndoRedoControls();


### PR DESCRIPTION
## Fix: Init Crash — setupSelectionBar() + CSP Inline Styles

### Root cause found 🎯

The WASM init was **crashing** at startup because `setupSelectionBar()` was called in `main()` but the function doesn't exist — it's dead code from a prior refactor. This caused a `ReferenceError` which was caught by the try/catch, but it meant `setupFloatingToolbar()` (and ALL subsequent setup functions) **never executed**.

This was the REAL root cause of drag-to-create never working — the event listeners were never registered.

### Changes
- **Remove `setupSelectionBar()` call** — function doesn't exist, crashes main()
- **Add `'unsafe-inline'` to CSP style-src** — JS-set inline styles (ghost preview, toolbar drag, minimap) were silently blocked by Content Security Policy
- **Bump version to 0.10.33**

### CI Results
- ✅ cargo check --workspace
- ✅ cargo test --workspace  
- ✅ cargo clippy --workspace -- -D warnings
- ✅ cargo fmt --all
- ✅ pnpm run build:webview (6502 lines)