### PR TITLE
fix(webview): close context menu/FAB on init to prevent stale menu on launch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.34 — Fix Context Menu Shown on Launch
+
+- **FIX**: Close context menu, floating action bar, and edge context menu at end of `main()` init to prevent stale menus appearing on canvas launch.
+
 ### v0.10.33 — Fix Init Crash: setupSelectionBar + CSP Inline Styles
 
 - **FIX (R3.42)**: Remove call to non-existent `setupSelectionBar()` in `main()` — this crashed WASM init and prevented `setupFloatingToolbar()` (including drag-to-create) from ever executing. Dead code from a prior refactor.

--- a/examples/design_system.fd
+++ b/examples/design_system.fd
@@ -225,4 +225,19 @@ ellipse @ellipse_3 {
   y: 592.42
 }
 
+rect @_rect_0 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: 109.25
+  y: 744.84
+}
+
+ellipse @_ellipse_1 {
+  w: 50 h: 40
+  stroke: #333333 2.5
+  x: 351.95
+  y: 667.47
+}
+
 @color_palette -> center_in: canvas

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.33",
+  "version": "0.10.34",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -6285,6 +6285,11 @@ async function main() {
     setupFloatingToolbar();
     setupEdgeContextMenu();
 
+    // Ensure no stale menus are visible after init
+    closeContextMenu();
+    hideFloatingBar();
+    closeEdgeContextMenu();
+
     // Tell extension we're ready
     vscode.postMessage({ type: "ready" });
   } catch (err) {

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -87,6 +87,11 @@ async function main() {
     setupFloatingToolbar();
     setupEdgeContextMenu();
 
+    // Ensure no stale menus are visible after init
+    closeContextMenu();
+    hideFloatingBar();
+    closeEdgeContextMenu();
+
     // Tell extension we're ready
     vscode.postMessage({ type: "ready" });
   } catch (err) {


### PR DESCRIPTION
## Fix: Context Menu Showing on Canvas Launch

Closes context menu, floating action bar, and edge context menu at end of `main()` init to prevent stale menus from appearing when canvas first launches.

### CI Results
- ✅ cargo clippy, fmt, test
- ✅ pnpm run build:webview (6507 lines)