### PR TITLE
refactor(ui): Properties panel Actions section + FAB overflow removal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.38 — Properties Panel Actions + FAB Cleanup
+
+- **UX (R3.8)**: Added "Actions" section to the Properties panel — 8 buttons in a 2-column grid (Group, Ungroup, Duplicate, Frame, Front, Back, Copy PNG, Delete) with keyboard shortcut hints; Group/Frame buttons auto-disable when <2 nodes selected; Ungroup auto-disables when no group is selected; matches Figma right-inspector pattern
+- **CLEANUP**: Removed FAB overflow menu (⋯ button + 5-item dropdown) — all actions now in Properties panel + context menu + keyboard shortcuts; declutters the Floating Action Bar to style-only controls
+- **CLEANUP**: Removed `fab-overflow-menu` reference from `hideFloatingBar()` in context-menu.js
+
 ### v0.10.37 — Fix Default Style Chain + Drag-to-Create UX
 
 - **FIX (R3.52)**: New shapes (canvas-drawn and click-to-create) now render with transparent fill + bordered stroke — previously `RectTool`/`EllipseTool` created bare nodes with no style, renderer defaulted `None` fill to grey `#CCCCCC`, and `set_node_prop("fill", "none")` silently failed because `Color::from_hex("none")` returned None.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -85,7 +85,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 #### R3d: Panels & UI
 
 - **R3.7** _(done)_: Undo/redo — full command stack, works across text and canvas edits
-- **R3.8** _(done)_: Properties panel — frosted glass inspector for position, size, fill, stroke, corner, opacity
+- **R3.8** _(done)_: Properties panel — frosted glass inspector for position, size, fill, stroke, corner, opacity; includes Actions section with Group, Ungroup, Duplicate, Frame, Front, Back, Copy PNG, Delete buttons; auto-disables state-dependent actions
 - **R3.9** _(done)_: Insert dropdown — `＋ Insert` button in top bar with shape/layout popover; replaces bottom shape palette
 - **R3.10** _(done)_: Apple Pencil Pro squeeze — toggle between last two tools
 - **R3.11** _(done)_: Per-tool cursor feedback (crosshair, text cursor, default)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.37",
+  "version": "0.10.38",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -1592,7 +1592,35 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       font-weight: 500;
     }
 
-
+    /* ── Props Actions ── */
+    .props-actions-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 4px;
+    }
+    .props-action-btn {
+      padding: 5px 8px;
+      border: 0.5px solid var(--fd-border);
+      border-radius: 6px;
+      background: var(--fd-input-bg);
+      color: var(--fd-text-secondary);
+      font-size: 11px;
+      font-family: inherit;
+      cursor: pointer;
+      transition: all 0.15s;
+      text-align: left;
+    }
+    .props-action-btn:hover {
+      background: var(--fd-surface-hover);
+      color: var(--fd-text);
+    }
+    .props-action-btn:active { transform: scale(0.97); }
+    .props-action-btn.disabled {
+      opacity: 0.4;
+      pointer-events: none;
+    }
+    .props-delete-btn { color: #FF453A; }
+    .props-delete-btn:hover { background: rgba(255,69,58,0.12); color: #FF453A; }
 
     /* ── Annotation Card ── */
     #annotation-card {
@@ -2462,14 +2490,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <input type="number" id="fab-font-size" class="fab-input fab-text-only" min="8" max="200" step="1" value="16" title="Font size">
       <div class="fab-sep"></div>
       <button class="fab-delete-btn" id="deleteSelectedBtn" title="Delete (⌫)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
-      <button class="fab-btn" id="fab-more-btn" aria-label="More actions" title="More actions">⋯</button>
-      <div id="fab-overflow-menu">
-        <button class="fab-menu-item" data-action="group">⌘G Group</button>
-        <button class="fab-menu-item" data-action="ungroup">⌘⇧G Ungroup</button>
-        <button class="fab-menu-item" data-action="duplicate">⌘D Duplicate</button>
-        <button class="fab-menu-item" data-action="copy-png">⌘⇧C Copy as PNG</button>
-        <button class="fab-menu-item" data-action="delete" style="color:#e57373">⌫ Delete</button>
-      </div>
+
     </div>
     <canvas id="fd-canvas" class="tool-select"></canvas>
     <div id="dimension-tooltip"></div>
@@ -2584,6 +2605,19 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
             <button class="align-cell" data-h="left"   data-v="bottom"><span class="align-dot"></span></button>
             <button class="align-cell" data-h="center" data-v="bottom"><span class="align-dot"></span></button>
             <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
+          </div>
+        </div>
+        <div class="props-section" id="props-actions-section">
+          <div class="props-section-label">Actions</div>
+          <div class="props-actions-grid">
+            <button class="props-action-btn" id="props-group" title="Group ⌘G">◻ Group</button>
+            <button class="props-action-btn" id="props-ungroup" title="Ungroup ⇧⌘G">◫ Ungroup</button>
+            <button class="props-action-btn" id="props-duplicate" title="Duplicate ⌘D">⊕ Duplicate</button>
+            <button class="props-action-btn" id="props-frame" title="Frame Selection">⊞ Frame</button>
+            <button class="props-action-btn" id="props-bring-front" title="Bring to Front ⌘⇧]">↑ Front</button>
+            <button class="props-action-btn" id="props-send-back" title="Send to Back ⌘⇧[">↓ Back</button>
+            <button class="props-action-btn" id="props-copy-png" title="Copy as PNG ⌘⇧C">🖼 PNG</button>
+            <button class="props-action-btn props-delete-btn" id="props-delete" title="Delete ⌫">🗑 Delete</button>
           </div>
         </div>
     </div>

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1912,8 +1912,6 @@ function updateFloatingBar() {
 function hideFloatingBar() {
   const fab = document.getElementById("floating-action-bar");
   if (fab) fab.classList.remove("visible");
-  const menu = document.getElementById("fab-overflow-menu");
-  if (menu) menu.classList.remove("visible");
 }
 
 // ─── Delete Button (Floating Action Bar) ───────────────────────────────────
@@ -2864,6 +2862,9 @@ function updatePropertiesPanel() {
     appearance.style.display = (props.kind === "root" || props.kind === "group") ? "none" : "";
   }
 
+  // Actions section state
+  updatePropsActionsState();
+
   propsSuppressSync = false;
 }
 
@@ -2883,6 +2884,88 @@ function setupAlignGrid() {
     syncTextToExtension();
     updatePropertiesPanel();
   });
+}
+
+// ─── Props Actions (Group, Ungroup, Duplicate, etc.) ───────────────────────
+
+function setupPropsActions() {
+  const actions = {
+    "props-group": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.group_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-ungroup": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.ungroup_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-duplicate": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.duplicate_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-frame": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("f", false, false, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-bring-front": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("]", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-send-back": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("[", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-copy-png": () => {
+      if (!fdCanvas) return;
+      copySelectionAsPng();
+    },
+    "props-delete": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.delete_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+  };
+
+  for (const [id, handler] of Object.entries(actions)) {
+    document.getElementById(id)?.addEventListener("click", (e) => {
+      e.stopPropagation();
+      handler();
+      updatePropertiesPanel();
+      updateFloatingBar();
+      refreshLayersPanel();
+    });
+  }
+}
+
+/** Enable/disable action buttons based on current selection state. */
+function updatePropsActionsState() {
+  if (!fdCanvas) return;
+  const selectedIds = JSON.parse(fdCanvas.get_selected_ids());
+  const canGroup = selectedIds.length >= 2;
+
+  // Check if any selected node is a group
+  let canUngroup = false;
+  if (selectedIds.length >= 1) {
+    const source = fdCanvas.get_text();
+    for (const id of selectedIds) {
+      if (new RegExp(`(?:^|\\n)\\s*group\\s+@${id}\\b`).test(source)) {
+        canUngroup = true;
+        break;
+      }
+    }
+  }
+
+  document.getElementById("props-group")?.classList.toggle("disabled", !canGroup);
+  document.getElementById("props-ungroup")?.classList.toggle("disabled", !canUngroup);
+  document.getElementById("props-frame")?.classList.toggle("disabled", !canGroup);
 }
 
 
@@ -6433,6 +6516,7 @@ async function main() {
     setupPropertiesPanel();
     setupInlineEditor();
     setupAlignGrid();
+    setupPropsActions();
     setupDragAndDrop();
     setupAnimPicker();
     setupHelpButton();

--- a/fd-vscode/webview/src/context-menu.js
+++ b/fd-vscode/webview/src/context-menu.js
@@ -94,8 +94,6 @@ function updateFloatingBar() {
 function hideFloatingBar() {
   const fab = document.getElementById("floating-action-bar");
   if (fab) fab.classList.remove("visible");
-  const menu = document.getElementById("fab-overflow-menu");
-  if (menu) menu.classList.remove("visible");
 }
 
 // ─── Delete Button (Floating Action Bar) ───────────────────────────────────

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -64,6 +64,7 @@ async function main() {
     setupPropertiesPanel();
     setupInlineEditor();
     setupAlignGrid();
+    setupPropsActions();
     setupDragAndDrop();
     setupAnimPicker();
     setupHelpButton();

--- a/fd-vscode/webview/src/panels.js
+++ b/fd-vscode/webview/src/panels.js
@@ -147,6 +147,9 @@ function updatePropertiesPanel() {
     appearance.style.display = (props.kind === "root" || props.kind === "group") ? "none" : "";
   }
 
+  // Actions section state
+  updatePropsActionsState();
+
   propsSuppressSync = false;
 }
 
@@ -166,6 +169,88 @@ function setupAlignGrid() {
     syncTextToExtension();
     updatePropertiesPanel();
   });
+}
+
+// ─── Props Actions (Group, Ungroup, Duplicate, etc.) ───────────────────────
+
+function setupPropsActions() {
+  const actions = {
+    "props-group": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.group_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-ungroup": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.ungroup_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-duplicate": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.duplicate_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+    "props-frame": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("f", false, false, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-bring-front": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("]", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-send-back": () => {
+      if (!fdCanvas) return;
+      const resultJson = fdCanvas.handle_key("[", false, true, false, true);
+      const result = JSON.parse(resultJson);
+      if (result.changed) { render(); syncTextToExtension(); }
+    },
+    "props-copy-png": () => {
+      if (!fdCanvas) return;
+      copySelectionAsPng();
+    },
+    "props-delete": () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.delete_selected();
+      if (changed) { render(); syncTextToExtension(); }
+    },
+  };
+
+  for (const [id, handler] of Object.entries(actions)) {
+    document.getElementById(id)?.addEventListener("click", (e) => {
+      e.stopPropagation();
+      handler();
+      updatePropertiesPanel();
+      updateFloatingBar();
+      refreshLayersPanel();
+    });
+  }
+}
+
+/** Enable/disable action buttons based on current selection state. */
+function updatePropsActionsState() {
+  if (!fdCanvas) return;
+  const selectedIds = JSON.parse(fdCanvas.get_selected_ids());
+  const canGroup = selectedIds.length >= 2;
+
+  // Check if any selected node is a group
+  let canUngroup = false;
+  if (selectedIds.length >= 1) {
+    const source = fdCanvas.get_text();
+    for (const id of selectedIds) {
+      if (new RegExp(`(?:^|\\n)\\s*group\\s+@${id}\\b`).test(source)) {
+        canUngroup = true;
+        break;
+      }
+    }
+  }
+
+  document.getElementById("props-group")?.classList.toggle("disabled", !canGroup);
+  document.getElementById("props-ungroup")?.classList.toggle("disabled", !canUngroup);
+  document.getElementById("props-frame")?.classList.toggle("disabled", !canGroup);
 }
 
 


### PR DESCRIPTION
## Properties Panel Actions + FAB Cleanup (v0.10.38)

### Changes
- **Added 8-button Actions section** to the Properties panel (Group, Ungroup, Duplicate, Frame, Front, Back, Copy PNG, Delete)
- Auto-disable Group/Frame buttons when <2 nodes selected
- Auto-disable Ungroup when no group is selected
- **Removed FAB overflow menu** (⋯ button + 5-item dropdown) — FAB is now style-only
- Cleaned up `hideFloatingBar()` reference to removed element

### Files Changed
- `fd-vscode/src/webview-html.ts` — Actions CSS + HTML, removed FAB overflow HTML
- `fd-vscode/webview/src/panels.js` — `setupPropsActions()`, `updatePropsActionsState()`
- `fd-vscode/webview/src/main.js` — Wire `setupPropsActions()` in init
- `fd-vscode/webview/src/context-menu.js` — Remove defunct overflow ref
- `fd-vscode/webview/main.js` — Rebuilt bundle (6762 lines)

### Tests
- ✅ 191/191 TypeScript tests pass
- ✅ Webview builds clean
- ✅ esbuild compile clean