### PR TITLE
fix(ui): suppress FAB popup on Layers/Code selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.39 — Fix FAB Popup on Layers/Code Selection
+
+- **FIX (R3.8)**: Floating Action Bar (fill/stroke/opacity controls) no longer pops up when selecting a node via Layers panel or Code cursor — FAB is now canvas-contextual only; Properties panel is the correct surface for non-canvas interactions
+
 ### v0.10.38 — Properties Panel Actions + FAB Cleanup
 
 - **UX (R3.8)**: Added "Actions" section to the Properties panel — 8 buttons in a 2-column grid (Group, Ungroup, Duplicate, Frame, Front, Back, Copy PNG, Delete) with keyboard shortcut hints; Group/Frame buttons auto-disable when <2 nodes selected; Ungroup auto-disables when no group is selected; matches Figma right-inspector pattern

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.38",
+  "version": "0.10.39",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1144,7 +1144,9 @@ function syncSelection(id, source) {
 
   // 6. Side panels
   updatePropertiesPanel();
-  updateFloatingBar();
+  // FAB is canvas-contextual — only show when selecting via canvas click
+  if (source === "canvas") updateFloatingBar();
+  else hideFloatingBar();
 }
 
 window.addEventListener("message", (event) => {

--- a/fd-vscode/webview/src/sync.js
+++ b/fd-vscode/webview/src/sync.js
@@ -45,7 +45,9 @@ function syncSelection(id, source) {
 
   // 6. Side panels
   updatePropertiesPanel();
-  updateFloatingBar();
+  // FAB is canvas-contextual — only show when selecting via canvas click
+  if (source === "canvas") updateFloatingBar();
+  else hideFloatingBar();
 }
 
 window.addEventListener("message", (event) => {


### PR DESCRIPTION
## Fix FAB Popup on Layers/Code Selection (v0.10.39)

2-line fix: FAB (fill/stroke/opacity controls) now only appears when selecting via canvas click. Layers/Code selections hide the FAB — Properties panel is the correct surface.

### Root cause
`syncSelection()` called `updateFloatingBar()` unconditionally regardless of source.

### Fix
```diff
- updateFloatingBar();
+ if (source === "canvas") updateFloatingBar();
+ else hideFloatingBar();
```