### PR TITLE
fix(toolbar): ghost shows correct orientation on cross-side drag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.42 — Fix Toolbar Ghost Orientation on Cross-Side Drag
+
+- **FIX (R3.39)**: Snap guide ghost now correctly shows vertical orientation when dragging toolbar to the opposite left/right edge — previously the ghost appeared horizontal because `getSnapPosition()` used live `offsetWidth`/`offsetHeight` which flip with toolbar orientation; now captures canonical (horizontal-layout) dimensions at drag start and uses those for ghost sizing regardless of current state
+
 ### v0.10.41 — Fix Text Wrap Regressions (3 Bugs)
 
 - **FIX (R3.46)**: Text height no longer reverts on pointer release — `set_text()` now skips re-parse and `resolve()` when incoming text is identical to current text, preventing JS-measured bounds from being overwritten by heuristic (KI Lesson #9)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.41",
+  "version": "0.10.42",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4582,6 +4582,10 @@ function setupFloatingToolbar() {
   let initialLeft = 0;
   let initialTop = 0;
   let activePointerId = -1;
+  // Canonical toolbar dimensions (as if horizontal) — captured on drag start
+  // so the snap ghost always reflects the target orientation, not the current one
+  let canonW = 0;
+  let canonH = 0;
 
   /** Compute snap target using closest-edge comparison */
   function computeSnap(projX, projY) {
@@ -4608,35 +4612,30 @@ function setupFloatingToolbar() {
     return edges[0].edge;
   }
 
-  /** Compute the exact landing position for each snap edge */
+  /** Compute the exact landing position for each snap edge.
+   *  Uses canonW/canonH (horizontal-layout dimensions) captured at drag start
+   *  so the ghost reflects the TARGET orientation, not the current one. */
   function getSnapPosition(edge, projX, projY) {
     const viewW = window.innerWidth;
-    const viewH = window.innerHeight;
     const container = document.getElementById("canvas-container");
     const cr = container.getBoundingClientRect();
     const panelW = getLayersPanelWidth();
-    // Toolbar dimensions (approximate for the snapped orientation)
-    const tbW = toolbar.offsetWidth;
-    const tbH = toolbar.offsetHeight;
 
-    if (edge === "top") {
-      // Horizontal at top: left based on drag X, clamped
-      const left = Math.max(panelW + 8, Math.min(projX, viewW - tbW - 8)) - cr.left;
-      return { left: left + "px", top: "8px", width: tbW + "px", height: tbH + "px" };
+    if (edge === "top" || edge === "bottom") {
+      // Horizontal: width = canonW (long side), height = canonH (short side)
+      const left = Math.max(panelW + 8, Math.min(projX, viewW - canonW - 8)) - cr.left;
+      const pos = { left: left + "px", width: canonW + "px", height: canonH + "px" };
+      if (edge === "top") pos.top = "8px";
+      else pos.bottom = "8px";
+      return pos;
     }
-    if (edge === "bottom") {
-      const left = Math.max(panelW + 8, Math.min(projX, viewW - tbW - 8)) - cr.left;
-      return { left: left + "px", bottom: "8px", width: tbW + "px", height: tbH + "px" };
-    }
+    // Vertical (left/right): width = canonH (short), height = canonW (long)
+    const top = Math.max(8, Math.min(projY - cr.top, cr.height - canonW - 8));
     if (edge === "left") {
-      // Vertical on left: after layers panel
       const leftPx = panelW + 8 - cr.left;
-      const top = Math.max(8, Math.min(projY - cr.top, cr.height - tbW - 8));
-      return { left: Math.max(0, leftPx) + "px", top: top + "px", width: tbH + "px", height: tbW + "px" };
+      return { left: Math.max(0, leftPx) + "px", top: top + "px", width: canonH + "px", height: canonW + "px" };
     }
-    // right
-    const top = Math.max(8, Math.min(projY - cr.top, cr.height - tbW - 8));
-    return { right: "8px", top: top + "px", width: tbH + "px", height: tbW + "px" };
+    return { right: "8px", top: top + "px", width: canonH + "px", height: canonW + "px" };
   }
 
   /** Show snap guide as a ghost rectangle at the exact landing position */
@@ -4766,6 +4765,12 @@ function setupFloatingToolbar() {
     const rect = toolbar.getBoundingClientRect();
     initialLeft = rect.left;
     initialTop = rect.top;
+
+    // Capture canonical (horizontal-layout) dimensions so snap ghost
+    // reflects the target orientation regardless of current state
+    const isHoriz = toolbar.classList.contains("horizontal");
+    canonW = isHoriz ? rect.width : rect.height; // long side
+    canonH = isHoriz ? rect.height : rect.width; // short side
 
     // Set ftDragging AFTER recording initial state
     ftDragging = true;

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -414,6 +414,10 @@ function setupFloatingToolbar() {
   let initialLeft = 0;
   let initialTop = 0;
   let activePointerId = -1;
+  // Canonical toolbar dimensions (as if horizontal) — captured on drag start
+  // so the snap ghost always reflects the target orientation, not the current one
+  let canonW = 0;
+  let canonH = 0;
 
   /** Compute snap target using closest-edge comparison */
   function computeSnap(projX, projY) {
@@ -440,35 +444,30 @@ function setupFloatingToolbar() {
     return edges[0].edge;
   }
 
-  /** Compute the exact landing position for each snap edge */
+  /** Compute the exact landing position for each snap edge.
+   *  Uses canonW/canonH (horizontal-layout dimensions) captured at drag start
+   *  so the ghost reflects the TARGET orientation, not the current one. */
   function getSnapPosition(edge, projX, projY) {
     const viewW = window.innerWidth;
-    const viewH = window.innerHeight;
     const container = document.getElementById("canvas-container");
     const cr = container.getBoundingClientRect();
     const panelW = getLayersPanelWidth();
-    // Toolbar dimensions (approximate for the snapped orientation)
-    const tbW = toolbar.offsetWidth;
-    const tbH = toolbar.offsetHeight;
 
-    if (edge === "top") {
-      // Horizontal at top: left based on drag X, clamped
-      const left = Math.max(panelW + 8, Math.min(projX, viewW - tbW - 8)) - cr.left;
-      return { left: left + "px", top: "8px", width: tbW + "px", height: tbH + "px" };
+    if (edge === "top" || edge === "bottom") {
+      // Horizontal: width = canonW (long side), height = canonH (short side)
+      const left = Math.max(panelW + 8, Math.min(projX, viewW - canonW - 8)) - cr.left;
+      const pos = { left: left + "px", width: canonW + "px", height: canonH + "px" };
+      if (edge === "top") pos.top = "8px";
+      else pos.bottom = "8px";
+      return pos;
     }
-    if (edge === "bottom") {
-      const left = Math.max(panelW + 8, Math.min(projX, viewW - tbW - 8)) - cr.left;
-      return { left: left + "px", bottom: "8px", width: tbW + "px", height: tbH + "px" };
-    }
+    // Vertical (left/right): width = canonH (short), height = canonW (long)
+    const top = Math.max(8, Math.min(projY - cr.top, cr.height - canonW - 8));
     if (edge === "left") {
-      // Vertical on left: after layers panel
       const leftPx = panelW + 8 - cr.left;
-      const top = Math.max(8, Math.min(projY - cr.top, cr.height - tbW - 8));
-      return { left: Math.max(0, leftPx) + "px", top: top + "px", width: tbH + "px", height: tbW + "px" };
+      return { left: Math.max(0, leftPx) + "px", top: top + "px", width: canonH + "px", height: canonW + "px" };
     }
-    // right
-    const top = Math.max(8, Math.min(projY - cr.top, cr.height - tbW - 8));
-    return { right: "8px", top: top + "px", width: tbH + "px", height: tbW + "px" };
+    return { right: "8px", top: top + "px", width: canonH + "px", height: canonW + "px" };
   }
 
   /** Show snap guide as a ghost rectangle at the exact landing position */
@@ -598,6 +597,12 @@ function setupFloatingToolbar() {
     const rect = toolbar.getBoundingClientRect();
     initialLeft = rect.left;
     initialTop = rect.top;
+
+    // Capture canonical (horizontal-layout) dimensions so snap ghost
+    // reflects the target orientation regardless of current state
+    const isHoriz = toolbar.classList.contains("horizontal");
+    canonW = isHoriz ? rect.width : rect.height; // long side
+    canonH = isHoriz ? rect.height : rect.width; // short side
 
     // Set ftDragging AFTER recording initial state
     ftDragging = true;


### PR DESCRIPTION
## Fix: Toolbar Ghost Orientation on Cross-Side Drag

When the toolbar is vertically placed on the left or right, dragging it to the opposite snap position showed a **horizontal** ghost instead of vertical.

### Root Cause
`getSnapPosition()` used live `toolbar.offsetWidth`/`offsetHeight` which flip when the toolbar's orientation changes. The swap logic in the function assumed horizontal layout, so when the toolbar was already vertical, the swap produced incorrect (horizontal) ghost dimensions.

### Fix
Capture canonical (horizontal-layout) dimensions at drag start (`pointerdown`) and use those in `getSnapPosition()` — the ghost now always reflects the **target** orientation regardless of the toolbar's current state.

### Changes
- `navigation.js`: Added `canonW`/`canonH` state, captured on drag start, used in `getSnapPosition()`
- `main.js`: Rebuilt from source modules
- Version bumped to 0.10.42
- CHANGELOG updated

### Testing
- ✅ 191/191 TS tests pass
- ✅ No Rust changes needed"