### PR TITLE
fix(toolbar): snap to ghost position, match ghost shapes, fix tooltip clipping

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.43 — Fix Toolbar Snap & Ghost Shape Bugs (4 Fixes)
+
+- **FIX (R3.39)**: Toolbar now lands at the exact ghost position — `pointerup` reuses `getSnapPosition()` instead of computing a separate `vw`/`vh` position that could diverge
+- **FIX (R3.39)**: Ghost shapes now match WASM `create_node_at` defaults — rect: 100×80 (was 120×80), ellipse: 100×80 oval (was 100×100 circle), frame: 200×150 (was 140×100)
+- **FIX (R3.39)**: Toolbar tooltips now visible in horizontal mode — changed `.scroll-paper-body` from `overflow: hidden` to `overflow: visible`
+- **FIX (R3.39)**: Vertical toolbar tooltips now appear to the right instead of above, preventing overlap
+
 ### v0.10.42 — Fix Toolbar Ghost Orientation on Cross-Side Drag
 
 - **FIX (R3.39)**: Snap guide ghost now correctly shows vertical orientation when dragging toolbar to the opposite left/right edge — previously the ghost appeared horizontal because `getSnapPosition()` used live `offsetWidth`/`offsetHeight` which flip with toolbar orientation; now captures canonical (horizontal-layout) dimensions at drag start and uses those for ghost sizing regardless of current state

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.42",
+  "version": "0.10.43",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2064,7 +2064,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       padding: 0 4px;
       box-shadow: inset 0 2px 4px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.15);
       z-index: 1;
-      overflow: hidden;
+      overflow: visible;
       transition: padding 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
     }
     .dark-theme .scroll-paper-body {
@@ -2188,6 +2188,13 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     }
     #floating-toolbar.rolled-up .ft-tooltip {
       display: none;
+    }
+    /* Vertical toolbar: show tooltip to the right instead of above */
+    .vertical .ft-tool-btn .ft-tooltip {
+      bottom: auto;
+      left: calc(100% + 8px);
+      top: 50%;
+      transform: translateY(-50%);
     }
 
     /* ── Shortcut Help (Apple sheet) ── */

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4710,39 +4710,34 @@ function setupFloatingToolbar() {
       return;
     }
 
-    // Commit final position — normalize to px now (not on pointerdown)
+    // Commit final position — reuse getSnapPosition() for exact ghost match
     const finalX = initialLeft + dx;
     const finalY = initialTop + dy;
-
-    const viewW = window.innerWidth;
-    const viewH = window.innerHeight;
     const edge = computeSnap(finalX, finalY);
-
-    let newPos = {};
-    let newOrientation = "horizontal";
-
-    if (edge === "right") {
-      newOrientation = "vertical";
-      newPos = { right: "2vw", top: Math.max(2, (finalY / viewH) * 100) + "vh" };
-    } else if (edge === "left") {
-      newOrientation = "vertical";
-      newPos = { left: "calc(232px + 2vw)", top: Math.max(2, (finalY / viewH) * 100) + "vh" };
-    } else if (edge === "top") {
-      newOrientation = "horizontal";
-      newPos = { top: "2vh", left: Math.max(2, (finalX / viewW) * 100) + "vw" };
-    } else {
-      newOrientation = "horizontal";
-      newPos = { bottom: "1.5vh", left: Math.max(2, (finalX / viewW) * 100) + "vw" };
-    }
+    const newOrientation = (edge === "left" || edge === "right") ? "vertical" : "horizontal";
 
     toolbar.classList.remove("horizontal", "vertical");
     toolbar.classList.add(newOrientation);
 
-    toolbar.style.left = newPos.left || "auto";
-    toolbar.style.right = newPos.right || "auto";
-    toolbar.style.top = newPos.top || "auto";
-    toolbar.style.bottom = newPos.bottom || "auto";
+    // Get the exact same position the ghost showed
+    const snapPos = getSnapPosition(edge, finalX, finalY);
 
+    // Apply position: getSnapPosition returns css values relative to canvas-container,
+    // which is what the toolbar is already positioned inside of (position:absolute)
+    toolbar.style.left = snapPos.left || "auto";
+    toolbar.style.right = snapPos.right || "auto";
+    toolbar.style.top = snapPos.top || "auto";
+    toolbar.style.bottom = snapPos.bottom || "auto";
+    // Clear width/height — toolbar auto-sizes from content
+    toolbar.style.width = "";
+    toolbar.style.height = "";
+
+    const newPos = {
+      left: snapPos.left || undefined,
+      right: snapPos.right || undefined,
+      top: snapPos.top || undefined,
+      bottom: snapPos.bottom || undefined,
+    };
     vscode.setState({ ...(vscode.getState() || {}), ftPosition: newPos, ftOrientation: newOrientation });
 
     if (toolbar.classList.contains("rolled-up")) {
@@ -4789,13 +4784,14 @@ function setupFloatingToolbar() {
   let dtcCancelled = false; // true when pointer re-enters toolbar
   let dtcGuideOverlay = null; // SVG overlay for alignment guides
 
+  // Ghost shapes match WASM create_node_at defaults exactly
   const ghostShapes = {
-    rect: { w: 120, h: 80, css: "border-radius:8px;" },
-    ellipse: { w: 100, h: 100, css: "border-radius:50%;" },
+    rect: { w: 100, h: 80, css: "border-radius:8px;" },
+    ellipse: { w: 100, h: 80, css: "border-radius:50%;" },
     pen: { w: 80, h: 60, css: "border-radius:4px;" },
     arrow: { w: 120, h: 2, css: "" },
     text: { w: 60, h: 28, css: "border-radius:4px;" },
-    frame: { w: 140, h: 100, css: "border-radius:4px;" },
+    frame: { w: 200, h: 150, css: "border-radius:4px;" },
   };
 
   function createGhost(tool) {

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -542,39 +542,34 @@ function setupFloatingToolbar() {
       return;
     }
 
-    // Commit final position — normalize to px now (not on pointerdown)
+    // Commit final position — reuse getSnapPosition() for exact ghost match
     const finalX = initialLeft + dx;
     const finalY = initialTop + dy;
-
-    const viewW = window.innerWidth;
-    const viewH = window.innerHeight;
     const edge = computeSnap(finalX, finalY);
-
-    let newPos = {};
-    let newOrientation = "horizontal";
-
-    if (edge === "right") {
-      newOrientation = "vertical";
-      newPos = { right: "2vw", top: Math.max(2, (finalY / viewH) * 100) + "vh" };
-    } else if (edge === "left") {
-      newOrientation = "vertical";
-      newPos = { left: "calc(232px + 2vw)", top: Math.max(2, (finalY / viewH) * 100) + "vh" };
-    } else if (edge === "top") {
-      newOrientation = "horizontal";
-      newPos = { top: "2vh", left: Math.max(2, (finalX / viewW) * 100) + "vw" };
-    } else {
-      newOrientation = "horizontal";
-      newPos = { bottom: "1.5vh", left: Math.max(2, (finalX / viewW) * 100) + "vw" };
-    }
+    const newOrientation = (edge === "left" || edge === "right") ? "vertical" : "horizontal";
 
     toolbar.classList.remove("horizontal", "vertical");
     toolbar.classList.add(newOrientation);
 
-    toolbar.style.left = newPos.left || "auto";
-    toolbar.style.right = newPos.right || "auto";
-    toolbar.style.top = newPos.top || "auto";
-    toolbar.style.bottom = newPos.bottom || "auto";
+    // Get the exact same position the ghost showed
+    const snapPos = getSnapPosition(edge, finalX, finalY);
 
+    // Apply position: getSnapPosition returns css values relative to canvas-container,
+    // which is what the toolbar is already positioned inside of (position:absolute)
+    toolbar.style.left = snapPos.left || "auto";
+    toolbar.style.right = snapPos.right || "auto";
+    toolbar.style.top = snapPos.top || "auto";
+    toolbar.style.bottom = snapPos.bottom || "auto";
+    // Clear width/height — toolbar auto-sizes from content
+    toolbar.style.width = "";
+    toolbar.style.height = "";
+
+    const newPos = {
+      left: snapPos.left || undefined,
+      right: snapPos.right || undefined,
+      top: snapPos.top || undefined,
+      bottom: snapPos.bottom || undefined,
+    };
     vscode.setState({ ...(vscode.getState() || {}), ftPosition: newPos, ftOrientation: newOrientation });
 
     if (toolbar.classList.contains("rolled-up")) {
@@ -621,13 +616,14 @@ function setupFloatingToolbar() {
   let dtcCancelled = false; // true when pointer re-enters toolbar
   let dtcGuideOverlay = null; // SVG overlay for alignment guides
 
+  // Ghost shapes match WASM create_node_at defaults exactly
   const ghostShapes = {
-    rect: { w: 120, h: 80, css: "border-radius:8px;" },
-    ellipse: { w: 100, h: 100, css: "border-radius:50%;" },
+    rect: { w: 100, h: 80, css: "border-radius:8px;" },
+    ellipse: { w: 100, h: 80, css: "border-radius:50%;" },
     pen: { w: 80, h: 60, css: "border-radius:4px;" },
     arrow: { w: 120, h: 2, css: "" },
     text: { w: 60, h: 28, css: "border-radius:4px;" },
-    frame: { w: 140, h: 100, css: "border-radius:4px;" },
+    frame: { w: 200, h: 150, css: "border-radius:4px;" },
   };
 
   function createGhost(tool) {


### PR DESCRIPTION
## Fix 4 Toolbar & Ghost Bugs

### Bug 1: Toolbar doesn't snap to ghost position
**Root cause:** `pointerup` handler computed final position using `vw`/`vh` units but the ghost used absolute `px` from `getSnapPosition()` — the two diverged.
**Fix:** `pointerup` now reuses `getSnapPosition()` for exact ghost match.

### Bug 2+3: Ghost shapes don't match created shapes
**Root cause:** `ghostShapes` had wrong dimensions vs WASM `create_node_at`:
- rect: 120×80 vs 100×80
- ellipse: 100×100 circle vs 100×80 oval (rx:50 ry:40)
- frame: 140×100 vs 200×150

**Fix:** Updated `ghostShapes` to match WASM defaults exactly.

### Bug 4: Tooltips hidden in horizontal mode, clipped
**Root cause:** `.scroll-paper-body` had `overflow: hidden` which clipped tooltips positioned above buttons.
**Fix:** Changed to `overflow: visible` + added vertical-mode tooltip positioning (to the right instead of above).

### Testing
- ✅ 191/191 TS tests pass
- ✅ Webview rebuilt