### PR TITLE
fix(toolbar): ghost scales with canvas zoom level

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.45 — Ghost Scales with Zoom Level
+
+- **FIX (R3.39)**: Drag-to-create ghost now scales with canvas zoom — at 200% zoom the ghost is 2× larger, at 50% it's half-sized, matching how the created shape will actually appear on screen
+
 ### v0.10.44 — Alt-Gated Snap-to-Node + Auto-Edge
 
 - **UX (R3.43)**: Snap-to-node + auto-edge on toolbar drag-to-create now requires ⌥ Alt modifier — without Alt, shapes drop freely at the cursor position without snapping or creating edges; reduces false positives in flowchart workflows

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.44",
+  "version": "0.10.45",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4801,19 +4801,23 @@ function setupFloatingToolbar() {
     const isDark = document.body.classList.contains("dark-theme");
     const borderColor = isDark ? "rgba(255,255,255,0.5)" : "rgba(51,51,51,0.5)";
     const bg = isDark ? "rgba(255,255,255,0.06)" : "rgba(51,51,51,0.06)";
+    // Scale ghost to match how the shape will appear on canvas at current zoom
+    const sw = Math.round(shape.w * zoomLevel);
+    const sh = Math.round(shape.h * zoomLevel);
     let content = "";
     if (tool === "text") {
-      content = `<span style="font-size:14px;color:${borderColor};font-weight:500;">T</span>`;
+      content = `<span style="font-size:${Math.round(14 * zoomLevel)}px;color:${borderColor};font-weight:500;">T</span>`;
     }
     if (tool === "arrow") {
       // Diagonal line ghost
+      const aw = Math.round(shape.w * zoomLevel);
       el.style.cssText = `
         position:fixed;pointer-events:none;z-index:10000;
-        width:${shape.w}px;height:${shape.w}px;
+        width:${aw}px;height:${aw}px;
         transform:translate(-50%,-50%);
         opacity:0.7;
       `;
-      el.innerHTML = `<svg width="${shape.w}" height="${shape.w}" viewBox="0 0 ${shape.w} ${shape.w}" fill="none">
+      el.innerHTML = `<svg width="${aw}" height="${aw}" viewBox="0 0 ${shape.w} ${shape.w}" fill="none">
         <line x1="10" y1="${shape.w - 10}" x2="${shape.w - 10}" y2="10"
           stroke="${borderColor}" stroke-width="2" stroke-dasharray="6 4"/>
         <path d="M${shape.w - 30},10 L${shape.w - 10},10 L${shape.w - 10},30"
@@ -4822,7 +4826,7 @@ function setupFloatingToolbar() {
     } else {
       el.style.cssText = `
         position:fixed;pointer-events:none;z-index:10000;
-        width:${shape.w}px;height:${shape.h}px;
+        width:${sw}px;height:${sh}px;
         border:2px dashed ${borderColor};
         background:${bg};
         ${shape.css}

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -633,19 +633,23 @@ function setupFloatingToolbar() {
     const isDark = document.body.classList.contains("dark-theme");
     const borderColor = isDark ? "rgba(255,255,255,0.5)" : "rgba(51,51,51,0.5)";
     const bg = isDark ? "rgba(255,255,255,0.06)" : "rgba(51,51,51,0.06)";
+    // Scale ghost to match how the shape will appear on canvas at current zoom
+    const sw = Math.round(shape.w * zoomLevel);
+    const sh = Math.round(shape.h * zoomLevel);
     let content = "";
     if (tool === "text") {
-      content = `<span style="font-size:14px;color:${borderColor};font-weight:500;">T</span>`;
+      content = `<span style="font-size:${Math.round(14 * zoomLevel)}px;color:${borderColor};font-weight:500;">T</span>`;
     }
     if (tool === "arrow") {
       // Diagonal line ghost
+      const aw = Math.round(shape.w * zoomLevel);
       el.style.cssText = `
         position:fixed;pointer-events:none;z-index:10000;
-        width:${shape.w}px;height:${shape.w}px;
+        width:${aw}px;height:${aw}px;
         transform:translate(-50%,-50%);
         opacity:0.7;
       `;
-      el.innerHTML = `<svg width="${shape.w}" height="${shape.w}" viewBox="0 0 ${shape.w} ${shape.w}" fill="none">
+      el.innerHTML = `<svg width="${aw}" height="${aw}" viewBox="0 0 ${shape.w} ${shape.w}" fill="none">
         <line x1="10" y1="${shape.w - 10}" x2="${shape.w - 10}" y2="10"
           stroke="${borderColor}" stroke-width="2" stroke-dasharray="6 4"/>
         <path d="M${shape.w - 30},10 L${shape.w - 10},10 L${shape.w - 10},30"
@@ -654,7 +658,7 @@ function setupFloatingToolbar() {
     } else {
       el.style.cssText = `
         position:fixed;pointer-events:none;z-index:10000;
-        width:${shape.w}px;height:${shape.h}px;
+        width:${sw}px;height:${sh}px;
         border:2px dashed ${borderColor};
         background:${bg};
         ${shape.css}


### PR DESCRIPTION
## Ghost Scales with Canvas Zoom Level

**Bug:** Drag-to-create ghost shows fixed pixel dimensions regardless of canvas zoom — at 200% zoom, the ghost is much smaller than the created shape.

**Fix:** Ghost dimensions now multiply by `zoomLevel`:
- `sw = shape.w * zoomLevel`, `sh = shape.h * zoomLevel`
- Arrow SVG uses viewBox for clean scaling
- Text ghost font size also scales

**Testing:** 191/191 TS tests pass