### PR TITLE
fix(toolbar): ghost resizes dynamically when zooming mid-drag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.46 — Ghost Resizes Dynamically During Zoom
+
+- **FIX (R3.39)**: Drag-to-create ghost now resizes in real-time when zooming mid-drag — scroll-wheel zoom during a drag updates ghost width/height every frame to match the current zoom level
+
 ### v0.10.45 — Ghost Scales with Zoom Level
 
 - **FIX (R3.39)**: Drag-to-create ghost now scales with canvas zoom — at 200% zoom the ghost is 2× larger, at 50% it's half-sized, matching how the created shape will actually appear on screen

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.45",
+  "version": "0.10.46",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -4907,6 +4907,19 @@ function setupFloatingToolbar() {
       }
 
       if (!dtcCancelled && dtcGhost) {
+        // ── Keep ghost sized to current zoom (handles zoom-while-dragging) ──
+        const shape = ghostShapes[dtcTool] || ghostShapes.rect;
+        const sw = Math.round(shape.w * zoomLevel) + "px";
+        const sh = Math.round(shape.h * zoomLevel) + "px";
+        if (dtcTool === "arrow") {
+          dtcGhost.style.width = sw;
+          dtcGhost.style.height = sw;
+          const svgEl = dtcGhost.querySelector("svg");
+          if (svgEl) { svgEl.setAttribute("width", sw); svgEl.setAttribute("height", sw); }
+        } else {
+          dtcGhost.style.width = sw;
+          dtcGhost.style.height = sh;
+        }
         // ── Alt+drag: snap ghost to cardinal position near node ──
         const canvasEl = document.getElementById("fd-canvas");
         if (e.altKey && canvasEl && fdCanvas && dtcTool !== "text") {

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -739,6 +739,19 @@ function setupFloatingToolbar() {
       }
 
       if (!dtcCancelled && dtcGhost) {
+        // ── Keep ghost sized to current zoom (handles zoom-while-dragging) ──
+        const shape = ghostShapes[dtcTool] || ghostShapes.rect;
+        const sw = Math.round(shape.w * zoomLevel) + "px";
+        const sh = Math.round(shape.h * zoomLevel) + "px";
+        if (dtcTool === "arrow") {
+          dtcGhost.style.width = sw;
+          dtcGhost.style.height = sw;
+          const svgEl = dtcGhost.querySelector("svg");
+          if (svgEl) { svgEl.setAttribute("width", sw); svgEl.setAttribute("height", sw); }
+        } else {
+          dtcGhost.style.width = sw;
+          dtcGhost.style.height = sh;
+        }
         // ── Alt+drag: snap ghost to cardinal position near node ──
         const canvasEl = document.getElementById("fd-canvas");
         if (e.altKey && canvasEl && fdCanvas && dtcTool !== "text") {


### PR DESCRIPTION
Ghost now resizes dynamically when zooming during a drag — `pointermove` updates ghost `width`/`height` every tick using `shape.w * zoomLevel`.

**Testing:** 191/191 TS tests pass