### PR TITLE
release: v0.10.48 — fix Alt+drag mid-drag activation (R3.54)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.48 — Fix Alt+Drag Mid-Drag Activation (R3.54)
+
+- **FIX (R3.54)**: Alt+drag to duplicate now works when Alt/Option is pressed mid-drag — macOS Option key pressed during active pointer capture was not updating `e.altKey` on `pointermove` events in Electron/VS Code webviews; added global modifier state tracking via `keydown`/`keyup`/`blur` listeners and wired `(e.altKey || modAltHeld)` across all pointer event handlers (down/move/up)
+- **ROBUSTNESS**: Also tracks `modCtrlHeld`, `modMetaHeld`, `modShiftHeld` for consistent modifier detection across all pointer phases; state resets on `window.blur` to prevent stale modifiers after Alt+Tab
+
 ### v0.10.47 — Fix Alt+Drag Double-Duplicate + Mid-Drag Clone
 
 - **FIX (R3.54)**: Alt+drag no longer duplicates a node twice — removed redundant JS-side `duplicate_selected_at(0,0)` call from `pointer.js`; WASM `SelectTool::handle()` is now the single source of truth for Alt+click duplication

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -261,8 +261,8 @@ rect @_rect_28 {
   w: 155.61 h: 145.15
   stroke: #333333 2.5
   corner: 8
-  x: 59.23
-  y: 1137.6
+  x: 185.8
+  y: 1154.87
 }
 
 ellipse @_ellipse_30 {
@@ -300,8 +300,8 @@ rect @_rect_28_copy_35 {
   w: 155.61 h: 145.15
   stroke: #333333 2.5
   corner: 8
-  x: 465.9
-  y: 1536.73
+  x: -302.05
+  y: 1557.91
 }
 
 rect @rect_36 {
@@ -380,8 +380,8 @@ rect @_rect_3 {
   w: 100 h: 80
   stroke: #333333 2.5
   corner: 8
-  x: 182.29
-  y: 2316.28
+  x: 56.14
+  y: 2340.98
 }
 
 ellipse @_ellipse_5 {
@@ -444,11 +444,72 @@ rect @_rect_1_copy_12 {
   y: 2171.02
 }
 
+rect @_rect_28_copy_0 {
+  w: 155.61 h: 145.15
+  stroke: #333333 2.5
+  corner: 8
+  x: -41.97
+  y: 1034.35
+}
+
+rect @_rect_3_copy_1 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: -38.62
+  y: 2447.25
+}
+
+rect @_rect_3_copy_2 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: -120.43
+  y: 2704.96
+}
+
+rect @_rect_3_copy_4 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: 567.96
+  y: 2588.29
+}
+
+rect @_rect_3_copy_5 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: 62.37
+  y: 2600.27
+}
+
+rect @_rect_3_copy_6 {
+  w: 100 h: 80
+  stroke: #333333 2.5
+  corner: 8
+  x: 296.62
+  y: 2739.46
+}
+
+group @_group_7 {
+  rect @_rect_3_copy_3 {
+    w: 100 h: 80
+    stroke: #333333 2.5
+    corner: 8
+  }
+  x: 42.14
+  y: 2819.58
+}
+
 # ─── Constraints ───
 
 @_rect_28_copy_33 -> offset: @_rect_28_copy_32 20, 20
 @_ellipse_6_copy_8 -> offset: @_ellipse_6_copy_7 20, 20
 @_rect_1_copy_12 -> offset: @_rect_1_copy_11 20, 20
+@_rect_28_copy_0 -> offset: @_rect_28 20, 20
+@_rect_3_copy_5 -> offset: @_rect_3_copy_2 20, 20
+@_rect_3_copy_6 -> offset: @_rect_3_copy_3 20, 20
 
 # ─── Flows ───
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.47",
+  "version": "0.10.48",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",


### PR DESCRIPTION
## Release v0.10.48

Fixes Alt+drag mid-drag activation (R3.54) — macOS Option key pressed during active drag was not updating `e.altKey` on `pointermove`.

### Changes
- Version bump to 0.10.48
- CHANGELOG entry for v0.10.48
- demo.fd position updates

### E2E Smoke Test: 5/5 PASS
✅ Draw Rect · ✅ Select & Move · ✅ Zoom · ✅ Bidi Sync · ✅ Undo