### PR TITLE
fix: unify Alt+drag duplication via FdCanvas

### DIFF
--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -63,11 +63,9 @@ pub struct SelectTool {
     /// `selected` holds the group, `visual_highlight` holds the clicked child.
     pub visual_highlight: Vec<NodeId>,
     /// Drag state (moving a selected node).
-    dragging: bool,
-    last_x: f32,
-    last_y: f32,
-    /// Whether we duplicated on this drag (Alt+drag).
-    alt_duplicated: bool,
+    pub dragging: bool,
+    pub last_x: f32,
+    pub last_y: f32,
     /// Marquee (rubber-band) selection state.
     /// Set when pointer-down hits empty space. `(start_x, start_y)`.
     pub marquee_start: Option<(f32, f32)>,
@@ -95,7 +93,6 @@ impl SelectTool {
             dragging: false,
             last_x: 0.0,
             last_y: 0.0,
-            alt_duplicated: false,
             marquee_start: None,
             marquee_rect: None,
             resize_handle: None,
@@ -173,13 +170,9 @@ impl Tool for SelectTool {
                     self.dragging = true;
                     self.last_x = *x;
                     self.last_y = *y;
-                    self.alt_duplicated = false;
 
-                    // Alt+click on a node → duplicate
-                    if modifiers.alt && self.selected.len() == 1 {
-                        self.alt_duplicated = true;
-                        return vec![GraphMutation::DuplicateNode { id: hit_id }];
-                    }
+                    // Alt+click duplication is handled by FdCanvas (not here)
+                    // so that selection can transfer to the clone properly.
 
                     vec![]
                 } else {
@@ -278,26 +271,8 @@ impl Tool for SelectTool {
 
                 // Node drag
                 if self.dragging && !self.selected.is_empty() {
-                    // Alt pressed mid-drag: clone-and-drag (Figma behavior)
-                    if modifiers.alt && !self.alt_duplicated && self.selected.len() == 1 {
-                        self.alt_duplicated = true;
-                        let id = self.selected[0];
-                        let mut dx = x - self.last_x;
-                        let mut dy = y - self.last_y;
-                        self.last_x = *x;
-                        self.last_y = *y;
-                        if modifiers.shift {
-                            if dx.abs() > dy.abs() {
-                                dy = 0.0;
-                            } else {
-                                dx = 0.0;
-                            }
-                        }
-                        return vec![
-                            GraphMutation::DuplicateNode { id },
-                            GraphMutation::MoveNode { id, dx, dy },
-                        ];
-                    }
+                    // Alt mid-drag duplication is handled by FdCanvas (not here)
+                    // so that selection can transfer to the clone properly.
 
                     let mut dx = x - self.last_x;
                     let mut dy = y - self.last_y;
@@ -325,7 +300,6 @@ impl Tool for SelectTool {
             InputEvent::PointerUp { .. } => {
                 // Marquee end is handled by FdCanvas (it calls hit_test_rect)
                 self.dragging = false;
-                self.alt_duplicated = false;
                 self.resize_handle = None;
                 vec![]
             }

--- a/crates/fd-editor/src/tools_tests.rs
+++ b/crates/fd-editor/src/tools_tests.rs
@@ -123,7 +123,9 @@ fn rect_tool_shift_draw_constrains_square() {
 }
 
 #[test]
-fn select_tool_alt_click_produces_duplicate() {
+fn select_tool_alt_click_no_duplicate() {
+    // Alt+click duplication is handled by FdCanvas (not SelectTool).
+    // SelectTool should just select the node without emitting DuplicateNode.
     let mut tool = SelectTool::new();
     let target = NodeId::intern("box_alt");
     let alt = Modifiers {
@@ -140,17 +142,21 @@ fn select_tool_alt_click_produces_duplicate() {
         },
         Some(target),
     );
-    assert_eq!(mutations.len(), 1);
-    match &mutations[0] {
-        GraphMutation::DuplicateNode { id } => {
-            assert_eq!(*id, target);
-        }
-        _ => panic!("expected DuplicateNode"),
-    }
+    // SelectTool no longer emits DuplicateNode — FdCanvas does that
+    assert!(
+        mutations.is_empty(),
+        "SelectTool should not emit DuplicateNode on Alt+click"
+    );
+    assert!(
+        tool.selected.contains(&target),
+        "Node should be selected for drag"
+    );
 }
 
 #[test]
-fn select_tool_mid_drag_alt_produces_duplicate() {
+fn select_tool_mid_drag_alt_no_duplicate() {
+    // Alt mid-drag duplication is handled by FdCanvas (not SelectTool).
+    // SelectTool should just emit MoveNode without DuplicateNode.
     let mut tool = SelectTool::new();
     let target = NodeId::intern("box_mid");
 
@@ -172,7 +178,7 @@ fn select_tool_mid_drag_alt_produces_duplicate() {
         ..Modifiers::NONE
     };
 
-    // First move with Alt → should duplicate + move
+    // Move with Alt → SelectTool should only produce MoveNode (no DuplicateNode)
     let mutations = tool.handle(
         &InputEvent::PointerMove {
             x: 120.0,
@@ -184,44 +190,15 @@ fn select_tool_mid_drag_alt_produces_duplicate() {
     );
     assert_eq!(
         mutations.len(),
-        2,
-        "mid-drag Alt should emit DuplicateNode + MoveNode"
+        1,
+        "SelectTool should only emit MoveNode, not DuplicateNode"
     );
     match &mutations[0] {
-        GraphMutation::DuplicateNode { id } => {
-            assert_eq!(*id, target);
-        }
-        _ => panic!("expected DuplicateNode first"),
-    }
-    match &mutations[1] {
         GraphMutation::MoveNode { dx, dy, .. } => {
             assert!((dx - 20.0).abs() < 0.01, "dx={dx}");
             assert!((dy - 10.0).abs() < 0.01, "dy={dy}");
         }
-        _ => panic!("expected MoveNode second"),
-    }
-
-    // Second move with Alt → only MoveNode (no second duplicate)
-    let mutations = tool.handle(
-        &InputEvent::PointerMove {
-            x: 130.0,
-            y: 115.0,
-            pressure: 1.0,
-            modifiers: alt,
-        },
-        None,
-    );
-    assert_eq!(
-        mutations.len(),
-        1,
-        "second Alt move should only emit MoveNode"
-    );
-    match &mutations[0] {
-        GraphMutation::MoveNode { dx, dy, .. } => {
-            assert!((dx - 10.0).abs() < 0.01, "dx={dx}");
-            assert!((dy - 5.0).abs() < 0.01, "dy={dy}");
-        }
-        _ => panic!("expected MoveNode only"),
+        _ => panic!("expected MoveNode, got {:?}", mutations[0]),
     }
 }
 

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -59,6 +59,9 @@ pub struct FdCanvas {
     pointer_down_pos: Option<(f32, f32)>,
     /// Style clipboard for Copy/Paste Style (⌥⌘C / ⌥⌘V).
     style_clipboard: Option<fd_core::model::Style>,
+    /// Whether we already duplicated during this drag (Alt+drag).
+    /// Reset on pointer-up. Prevents re-duplication on subsequent move events.
+    alt_duplicated: bool,
 }
 
 #[wasm_bindgen]
@@ -98,6 +101,7 @@ impl FdCanvas {
             hover_start_ms: 0.0,
             pointer_down_pos: None,
             style_clipboard: None,
+            alt_duplicated: false,
         }
     }
 
@@ -273,8 +277,25 @@ impl FdCanvas {
             ToolKind::Eraser => unreachable!("handled above"),
         };
         let changed = self.apply_mutations(mutations);
+
+        // Alt+click on select tool: duplicate in-place, then drag the clone
+        if self.active_tool == ToolKind::Select
+            && alt
+            && !ctrl
+            && !meta
+            && hit.is_some()
+            && self.select_tool.selected.len() == 1
+        {
+            self.alt_duplicated = true;
+            self.duplicate_selected_at(0.0, 0.0);
+        }
+
         // Marquee start also counts as a visual change (need re-render)
-        changed || self.select_tool.marquee_start.is_some() || pressed_changed || hovered_changed
+        changed
+            || self.select_tool.marquee_start.is_some()
+            || pressed_changed
+            || hovered_changed
+            || self.alt_duplicated
     }
 
     /// Handle pointer move event. Returns true if the graph changed.
@@ -319,6 +340,22 @@ impl FdCanvas {
                 return true;
             }
             return hovered_changed;
+        }
+
+        // Alt pressed mid-drag: clone-and-drag (Figma behavior)
+        // Handled here in FdCanvas (not in SelectTool) so selection
+        // can transfer to the clone via duplicate_selected_at.
+        if self.active_tool == ToolKind::Select
+            && alt
+            && !self.alt_duplicated
+            && self.select_tool.dragging
+            && self.select_tool.selected.len() == 1
+        {
+            self.alt_duplicated = true;
+            self.duplicate_selected_at(0.0, 0.0);
+            // Update last_x/y so the next delta is computed from here
+            self.select_tool.last_x = x;
+            self.select_tool.last_y = y;
         }
 
         let mutations = match self.active_tool {
@@ -482,6 +519,7 @@ impl FdCanvas {
         };
 
         self.pointer_down_pos = None;
+        self.alt_duplicated = false;
 
         let visual_changed = changed
             || marquee_changed

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -393,17 +393,15 @@ function setupPointerEvents() {
       updateToolbarActive("eraser");
     }
 
-    // ── Alt+drag = clone and drag ──
+    // Alt+drag duplication is handled entirely by WASM via
+    // duplicate_selected_at(0,0) — JS only tracks altCloneActive
+    // to suppress the style-picker eyedropper on pointer-up.
     const isAlt = e.altKey || modAltHeld;
     if (isAlt && !e.metaKey && !e.ctrlKey) {
       const hitId = fdCanvas.hit_test_at(x, y);
       if (hitId) {
-        // Ensure the node is selected first
-        fdCanvas.select_by_id(hitId);
-        // WASM handle_pointer_down (below) handles the actual DuplicateNode
-        // when alt=true — we just set flags here for JS-side state management
         altCloneActive = true;
-        // Now switch to select to drag the clone
+        // Switch to select for drawing tools so WASM sees SelectTool
         if (isDrawingTool) {
           cmdTempSelectActive = true;
           cmdTempSelectOriginalTool = currentTool;

--- a/fd-vscode/webview/src/pointer.js
+++ b/fd-vscode/webview/src/pointer.js
@@ -59,17 +59,15 @@ function setupPointerEvents() {
       updateToolbarActive("eraser");
     }
 
-    // ── Alt+drag = clone and drag ──
+    // Alt+drag duplication is handled entirely by WASM via
+    // duplicate_selected_at(0,0) — JS only tracks altCloneActive
+    // to suppress the style-picker eyedropper on pointer-up.
     const isAlt = e.altKey || modAltHeld;
     if (isAlt && !e.metaKey && !e.ctrlKey) {
       const hitId = fdCanvas.hit_test_at(x, y);
       if (hitId) {
-        // Ensure the node is selected first
-        fdCanvas.select_by_id(hitId);
-        // WASM handle_pointer_down (below) handles the actual DuplicateNode
-        // when alt=true — we just set flags here for JS-side state management
         altCloneActive = true;
-        // Now switch to select to drag the clone
+        // Switch to select for drawing tools so WASM sees SelectTool
         if (isDrawingTool) {
           cmdTempSelectActive = true;
           cmdTempSelectOriginalTool = currentTool;


### PR DESCRIPTION
## Problem

Alt+drag duplication had two critical bugs:

1. **Jumping/jittery behavior**: Clone was positioned at +20,+20 Offset from original, while selection stayed on original — causing visual jitter as MoveNode moved the original instead of the clone
2. **Mid-drag Alt not working**: `DuplicateNode` via SelectTool didn't update selection to the clone, so all subsequent drag frames moved the original

### Root Cause

Two separate duplication paths disagreed:
- `duplicate_selected_at()` (⌘D) — ✅ correctly updates selection to clone
- `DuplicateNode` mutation (via SelectTool) — ❌ never updates selection

Additionally, JS `pointer.js` pre-selected nodes on Alt+click before WASM also handled the same event, causing fighting between JS and WASM.

## Solution

Unified onto `duplicate_selected_at(0, 0)` as the single duplication path for Alt+drag:

- **SelectTool** no longer handles Alt duplication (simpler)
- **FdCanvas** detects Alt in `handle_pointer_down`/`handle_pointer_move` and calls `duplicate_selected_at(0,0)` which properly transfers selection to the clone
- **JS pointer.js** only tracks `altCloneActive` flag for style-picker suppression, no longer pre-selects nodes

## Files Changed

- `crates/fd-editor/src/tools.rs` — Removed Alt handling from SelectTool
- `crates/fd-wasm/src/lib.rs` — Added Alt handling to FdCanvas
- `fd-vscode/webview/src/pointer.js` — Removed JS pre-selection
- `fd-vscode/webview/main.js` — Mirror of pointer.js changes
- `crates/fd-editor/src/tools_tests.rs` — Updated tests

## Verification

- `cargo check --workspace` ✅
- `cargo test --workspace` ✅ (17/17)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅