### PR TITLE
feat(sync): click-to-highlight code on canvas re-click (R2.5)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.53 — Click-to-Highlight Code (R2.5)
+
+- **UX (R2.5)**: Clicking an already-selected node on the canvas now re-highlights its `@id` line in the code editor — previously only the first click (selection change) triggered the highlight; re-clicks on the same node were silently ignored by the dedup guard; this implements the "show me the code" intent for spatial navigation
+- **ARCH**: Split canvas→code notification into two paths in `pointer.js`: selection-change triggers full `syncSelection()` (panels + code + dedup), re-click of same node posts `nodeSelected` directly (code highlight only, no redundant panel rebuilds)
+
 ### v0.10.52 — Renamify Tests + Heuristic Renamer (R4.20)
 
 - **TESTING (R4.20)**: 50 new unit tests for Renamify in `ai-renamify.test.ts` — `parseRenamifyResponse` (17 tests: valid/malformed JSON, conflict resolution, sanitization, order), `applyGlobalRenames` (13 tests: declarations, constraints, edges, word-boundary safety), `buildRenamifyPrompt` (7 tests: prompt structure), `heuristicRename` (13 tests: text extraction, parent context, shape detection, conflicts)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -35,7 +35,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R2.2** _(done)_: Text → Canvas: Source edits re-render the canvas in <16ms
 - **R2.3** _(planned)_: Incremental: Only re-parse/re-emit changed regions, not the entire document
 - **R2.4** _(done)_: Conflict-free: Both directions funnel through a single authoritative `SceneGraph`
-- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node/edge block in the text editor selects it on canvas and pans to focus; clicking a node on canvas reveals and highlights its `@id` line in the text editor; all clicks sync the Layers panel highlight with scroll-into-view; Code→Canvas focus is debounced (150ms); edge IDs sync across Layers↔Code; all sync logic consolidated in `syncSelection(id, source)`
+- **R2.5** _(done)_: Selection sync — clicking anywhere inside a node/edge block in the text editor selects it on canvas and pans to focus; clicking a node on canvas reveals and highlights its `@id` line in the text editor (including re-clicks on already-selected nodes); all clicks sync the Layers panel highlight with scroll-into-view; Code→Canvas focus is debounced (150ms); edge IDs sync across Layers↔Code; all sync logic consolidated in `syncSelection(id, source)`
 
 ### R3: Human Editing (Canvas)
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.52",
+  "version": "0.10.53",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -621,12 +621,16 @@ function setupPointerEvents() {
     // Update properties panel after interaction ends
     updatePropertiesPanel();
     updateFloatingBar();
-    // Notify extension of canvas selection change (for Code ↔ Canvas sync)
+    // Notify extension of canvas selection (for Code ↔ Canvas sync)
     // Skip during inline editing — prevents focus stealing that kills the textarea
     if (!inlineEditorActive) {
       const selectedId = fdCanvas.get_selected_id();
       if (selectedId !== lastNotifiedSelectedId) {
+        // Selection changed — full sync (panels + code highlight)
         syncSelection(selectedId, "canvas");
+      } else if (selectedId) {
+        // Same node re-clicked — re-highlight code ("show me the code" intent)
+        vscode.postMessage({ type: "nodeSelected", id: selectedId });
       }
     }
 

--- a/fd-vscode/webview/src/pointer.js
+++ b/fd-vscode/webview/src/pointer.js
@@ -287,12 +287,16 @@ function setupPointerEvents() {
     // Update properties panel after interaction ends
     updatePropertiesPanel();
     updateFloatingBar();
-    // Notify extension of canvas selection change (for Code ↔ Canvas sync)
+    // Notify extension of canvas selection (for Code ↔ Canvas sync)
     // Skip during inline editing — prevents focus stealing that kills the textarea
     if (!inlineEditorActive) {
       const selectedId = fdCanvas.get_selected_id();
       if (selectedId !== lastNotifiedSelectedId) {
+        // Selection changed — full sync (panels + code highlight)
         syncSelection(selectedId, "canvas");
+      } else if (selectedId) {
+        // Same node re-clicked — re-highlight code ("show me the code" intent)
+        vscode.postMessage({ type: "nodeSelected", id: selectedId });
       }
     }
 


### PR DESCRIPTION
## What\n\nClicking an already-selected node on the canvas now re-highlights its `@id` line in the code editor.\n\n## Why\n\nPreviously, only the first click (selection change) triggered the code highlight. Re-clicking the same node was silently ignored by the dedup guard in `pointer.js`. This broke the \"show me the code\" spatial navigation intent — users click a node to find its code, and expect something to happen even if the node is already selected.\n\n## How\n\nSplit the canvas→code notification in `pointer.js` into two paths:\n- **Selection change** → full `syncSelection()` (panels + code + dedup)\n- **Same node re-click** → direct `nodeSelected` post (code highlight only, no redundant panel rebuilds)\n\n## Tests\n\n- ✅ `cargo clippy --workspace -- -D warnings`\n- ✅ `cargo fmt --all`\n- ✅ `cargo test --workspace` (all passed)\n- ✅ `pnpm test` (241/241 passed)\n- ✅ Webview bundle built