### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons in webview

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - [ARIA Labels for Custom Webview UI Components]
+**Learning:** Icon-only interactive elements in the custom UI of `fd-vscode/src/webview-html.ts` (like `zen-toggle-btn`, `settings-menu-btn`, and alignment grid cells) lack screen reader compatibility because they rely solely on visual cues or title attributes instead of explicit ARIA labels.
+**Action:** Always ensure that icon-only buttons (`.tool-btn`, `.align-cell`, etc.) in custom webview interfaces include descriptive `aria-label` attributes to maintain accessibility standards alongside visual design.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2457,10 +2457,10 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
     <div class="tb-zone tb-right">
       <span class="zen-full-only" id="status">Loading WASM…</span>
-      <button class="tool-btn" id="zen-toggle-btn" title="Switch to Zen mode">🧘</button>
+      <button class="tool-btn" id="zen-toggle-btn" title="Switch to Zen mode" aria-label="Switch to Zen mode">🧘</button>
       <!-- Settings Hamburger ☰ -->
       <div class="settings-dropdown-container" id="settings-dropdown-container">
-      <button class="tool-btn" id="settings-menu-btn" title="Settings & tools">☰</button>
+      <button class="tool-btn" id="settings-menu-btn" title="Settings & tools" aria-label="Settings and tools">☰</button>
       <div class="settings-menu" id="settings-menu">
         <button class="settings-menu-item" id="sm-grid-toggle"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span><span class="sm-shortcut">G</span></button>
         <button class="settings-menu-item" id="sm-spec-badge-toggle"><span class="sm-icon">◇</span><span class="sm-label">Spec Badges</span></button>
@@ -2603,15 +2603,15 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         <div class="props-section" id="props-align-section" style="display:none">
           <div class="props-section-label">Alignment</div>
           <div class="align-grid" id="align-grid">
-            <button class="align-cell" data-h="left"   data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="top" aria-label="Align left top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="top" aria-label="Align center top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="top" aria-label="Align right top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="middle" aria-label="Align left middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="middle" aria-label="Align center middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="middle" aria-label="Align right middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="bottom" aria-label="Align left bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="bottom" aria-label="Align center bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="bottom" aria-label="Align right bottom"><span class="align-dot"></span></button>
           </div>
         </div>
         <div class="props-section" id="props-actions-section">


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to icon-only buttons in the webview custom UI, specifically the Zen mode toggle, the Settings menu button, and the 9 alignment grid cells in the properties panel.

🎯 **Why:** These buttons previously relied solely on visual icons or title attributes, making their function unclear or inaccessible to users relying on screen readers.

♿ **Accessibility:**
- `zen-toggle-btn` now announces "Switch to Zen mode"
- `settings-menu-btn` now announces "Settings and tools"
- `.align-cell` buttons now announce their specific 2D alignment (e.g., "Align left top", "Align center middle")

📸 **Before/After:** Visually identical, but semantically improved for assistive technologies.

---
*PR created automatically by Jules for task [5198245586103135975](https://jules.google.com/task/5198245586103135975) started by @khangnghiem*