### PR TITLE
docs(site): custom domain fast-draft.com + SEO meta tags

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+fast-draft.com

--- a/site/index.html
+++ b/site/index.html
@@ -9,6 +9,8 @@
   <meta property="og:title" content="Fast Draft — Design as Code" />
   <meta property="og:description" content="A file format and canvas for drawing, design, and animation — right inside your code editor." />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://fast-draft.com" />
+  <link rel="canonical" href="https://fast-draft.com" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -65,7 +67,7 @@
         </div>
         <div class="stat-divider"></div>
         <div class="stat">
-          <span class="stat-value">331</span>
+          <span class="stat-value">370</span>
           <span class="stat-label">tests passing</span>
         </div>
       </div>


### PR DESCRIPTION
- Add `site/CNAME` pointing to `fast-draft.com`
- Add `og:url` and `canonical` meta tags for SEO
- Update hero test count from 331 → 370

DNS already configured on Cloudflare. Once merged, GitHub Pages will auto-deploy to `https://fast-draft.com`.