### PR TITLE
docs: add fast-draft.com domain knowledge

### DIFF
--- a/.agents/workflows/publish.md
+++ b/.agents/workflows/publish.md
@@ -80,4 +80,6 @@ cd fd-vscode && pnpm ovsx publish -p <VSX_PAT from .env>
    > This also triggers the **Zed extension update** automatically via `huacnlee/zed-extension-action`.
    > It creates a PR to `zed-industries/extensions` with the updated submodule pointer.
 
-6. Report publish results to user.
+6. **Site auto-deploys** — merging to `main` triggers `.github/workflows/pages.yml`, which rebuilds WASM and deploys `site/` to [fast-draft.com](https://fast-draft.com). No manual deploy needed.
+
+7. Report publish results to user.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -127,6 +127,21 @@ crates/
 
 ## TIER 2: CI/CD
 
+### 🌐 Site & Domain
+
+| Fact | Value |
+| ---- | ----- |
+| **Live URL** | [https://fast-draft.com](https://fast-draft.com) |
+| **Hosting** | GitHub Pages (free, static) |
+| **DNS** | Cloudflare — CNAME `@` → `khangnghiem.github.io`, proxy **OFF** |
+| **Source** | `site/` directory (index.html, style.css, playground.js, wasm/) |
+| **CNAME file** | `site/CNAME` — contains `fast-draft.com` |
+| **Deploy trigger** | Auto on push to `main` via `.github/workflows/pages.yml` |
+| **WASM build** | `wasm-pack build crates/fd-wasm --target web --out-dir ../../site/wasm` |
+
+> [!CAUTION]
+> **Never delete or modify `site/CNAME`.** Removing it breaks the custom domain binding and reverts to `khangnghiem.github.io/fast-draft/`.
+
 ### Before Completing Any Task
 
 - [ ] `cargo check --workspace` passes

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -160,7 +160,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.2** _(future)_: Desktop app via Tauri (macOS, Windows, Linux)
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
-- **R6.5** _(done)_: GitHub Pages landing site with live WASM playground and auto-deploy via GitHub Actions
+- **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
 
 ## Non-Functional Requirements
 


### PR DESCRIPTION
Add domain deployment knowledge to project docs:

- **GEMINI.md**: New 🌐 Site & Domain section in TIER 2 with live URL, hosting, DNS, source, CNAME file, deploy trigger, and WASM build command. Added CAUTION rule against deleting site/CNAME.
- **REQUIREMENTS.md**: R6.5 updated to reference fast-draft.com with custom domain and Cloudflare DNS.
- **publish.md**: Added step 6 noting that site auto-deploys on merge to main.