### PR TITLE
feat(site): interactive playground with canvas tools, bidi sync, zoom/pan (R6.6)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,15 @@
 
 ## Completed Requirements
 
+### v0.10.66 — Interactive Playground (R6.6)
+
+- **FEATURE (R6.6)**: Playground canvas is now fully interactive — pointer events (click to select, drag to move/resize, draw shapes) wired through WASM `handle_pointer_down/move/up` APIs; bidirectional sync with `suppressSync` echo prevention ensures canvas→code and code→canvas stay in sync
+- **UX (R6.6)**: 7-tool toolbar in canvas header — Select (↖), Rect (□), Ellipse (○), Text (T), Arrow (→), Pen (✎), Eraser (◎); active tool highlighted with accent purple; auto-switches back to Select after drawing gesture
+- **UX (R6.6)**: Floating action bar (FAB) — frosted-glass popup above selected nodes with Fill/Stroke color pickers and Delete button; positioned relative to node bounds accounting for zoom/pan
+- **UX (R6.6)**: Zoom/pan navigation — scroll wheel pans, Ctrl/⌘+scroll zooms, Space+drag for hand-tool pan, middle-click pan; zoom indicator shows current level in canvas header
+- **UX (R6.6)**: Keyboard shortcuts — V/R/O/T/A/P/E for tool switching, Delete/Backspace to remove nodes, ⌘Z/⌘⇧Z for undo/redo; focus management ensures shortcuts fire on canvas (not textarea)
+- **SITE**: Zero Rust changes — all interactivity implemented in `playground.js` (~330 lines), `index.html` (toolbar + FAB markup), `style.css` (+95 lines)
+
 ### v0.10.65 — Playground-First Landing Page (R6.5)
 
 - **UX (R6.5)**: Playground now visible on landing — embedded live playground directly in the hero section; users see code editor + canvas split-pane within the first viewport without scrolling

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -161,6 +161,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), 7-tool toolbar, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 
@@ -271,7 +272,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | style / theme       | R1.4, R4.3, R4.18                                                        |
 | animation           | R1.5, R1.11, R1.12, R3.29, R4.18, R5.6, R5.8                             |
 | rendering           | R5.1, R5.2, R5.4, R5.5                                                   |
-| platform            | R6.1, R6.2, R6.3, R6.4, R6.5                                             |
+| platform            | R6.1, R6.2, R6.3, R6.4, R6.5, R6.6                                       |
 | inline editing      | R3.28                                                                    |
 | text alignment      | R1.17, R3.28, R3.36, R3.37                                               |
 | layout / centering  | R3.36, R3.37                                                             |

--- a/site/index.html
+++ b/site/index.html
@@ -106,9 +106,32 @@
         <div class="playground-canvas">
           <div class="editor-header">
             <span class="editor-dot canvas-dot"></span> Canvas Mode
+            <div id="canvas-tools" class="canvas-tools">
+              <button class="canvas-tool active" data-tool="select" title="Select (V)">↖</button>
+              <button class="canvas-tool" data-tool="rect" title="Rectangle (R)">□</button>
+              <button class="canvas-tool" data-tool="ellipse" title="Ellipse (O)">○</button>
+              <button class="canvas-tool" data-tool="text" title="Text (T)">T</button>
+              <button class="canvas-tool" data-tool="arrow" title="Arrow (A)">→</button>
+              <button class="canvas-tool" data-tool="pen" title="Pen (P)">✎</button>
+              <button class="canvas-tool" data-tool="eraser" title="Eraser (E)">◎</button>
+            </div>
+            <span id="zoom-level" class="zoom-indicator">100%</span>
           </div>
           <div id="canvas-wrapper">
             <canvas id="fd-canvas"></canvas>
+            <div id="fab" class="fab">
+              <label class="fab-item" title="Fill color">
+                <span class="fab-label">Fill</span>
+                <input type="color" id="fab-fill" class="fab-color" value="#6C5CE7">
+              </label>
+              <div class="fab-sep"></div>
+              <label class="fab-item" title="Stroke color">
+                <span class="fab-label">Stroke</span>
+                <input type="color" id="fab-stroke" class="fab-color" value="#333333">
+              </label>
+              <div class="fab-sep"></div>
+              <button id="fab-delete" class="fab-delete" title="Delete (⌫)">🗑</button>
+            </div>
             <div id="canvas-loading" class="canvas-loading">
               <div class="skeleton-preview">
                 <div class="skeleton-shape skeleton-rect"></div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -1,4 +1,4 @@
-// ─── FD Playground — WASM-powered live editor ───
+// ─── FD Playground — WASM-powered interactive editor ───
 
 const EXAMPLES = {
   card: `# A card with a button that reacts on hover
@@ -163,10 +163,102 @@ ellipse @step3_demo {
 }`
 };
 
+// ─── State ───────────────────────────────────────────────────────────────
 let fdCanvas = null;
+let ctx = null;
 let isDark = true;
 let isSketchy = false;
 let animFrameId = null;
+let suppressSync = false;
+
+// Pointer tracking
+let activePointerId = -1;
+
+// Zoom / Pan
+let panX = 0, panY = 0;
+let panStartX = 0, panStartY = 0;
+let panDragging = false;
+let zoomLevel = 1.0;
+const ZOOM_MIN = 0.1, ZOOM_MAX = 5;
+let isPanning = false;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/** Convert screen (client) coords to scene coords accounting for zoom+pan */
+function screenToScene(clientX, clientY, canvasEl) {
+  const rect = canvasEl.getBoundingClientRect();
+  return {
+    x: ((clientX - rect.left) - panX) / zoomLevel,
+    y: ((clientY - rect.top) - panY) / zoomLevel
+  };
+}
+
+/** Render the scene with DPR + zoom/pan transform */
+function renderCanvas() {
+  if (!fdCanvas || !ctx) return;
+  const canvas = ctx.canvas;
+  const dpr = window.devicePixelRatio || 1;
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.setTransform(dpr * zoomLevel, 0, 0, dpr * zoomLevel, panX * dpr, panY * dpr);
+  fdCanvas.render(ctx, performance.now());
+}
+
+/** Update toolbar active state */
+function updateToolbar(activeTool) {
+  document.querySelectorAll('.canvas-tool').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector(`.canvas-tool[data-tool="${activeTool}"]`);
+  if (btn) btn.classList.add('active');
+}
+
+/** Update zoom indicator text */
+function updateZoomIndicator() {
+  const el = document.getElementById('zoom-level');
+  if (el) el.textContent = Math.round(zoomLevel * 100) + '%';
+}
+
+/** Sync canvas text back to textarea with echo suppression */
+function syncCanvasToEditor(editor) {
+  if (!fdCanvas) return;
+  suppressSync = true;
+  editor.value = fdCanvas.get_text();
+  suppressSync = false;
+}
+
+/** Show/hide and position the floating action bar above the selected node */
+function updateFab(canvas) {
+  const fab = document.getElementById('fab');
+  if (!fab || !fdCanvas) { fab?.classList.remove('visible'); return; }
+
+  const selectedId = fdCanvas.get_selected_id();
+  if (!selectedId) { fab.classList.remove('visible'); return; }
+
+  try {
+    const boundsJson = fdCanvas.get_node_bounds(selectedId);
+    if (!boundsJson) { fab.classList.remove('visible'); return; }
+    const b = JSON.parse(boundsJson);
+    if (!b.width) { fab.classList.remove('visible'); return; }
+
+    // Position above node center (screen coords with zoom+pan)
+    const screenX = b.x * zoomLevel + panX + (b.width * zoomLevel) / 2;
+    const screenY = b.y * zoomLevel + panY - 14;
+    fab.style.left = screenX + 'px';
+    fab.style.top = screenY + 'px';
+    fab.classList.add('visible');
+
+    // Read current props
+    const propsJson = fdCanvas.get_selected_node_props();
+    if (propsJson) {
+      const props = JSON.parse(propsJson);
+      if (props.fill) document.getElementById('fab-fill').value = props.fill;
+      if (props.strokeColor) document.getElementById('fab-stroke').value = props.strokeColor;
+    }
+  } catch (_) {
+    fab.classList.remove('visible');
+  }
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────
 
 async function initPlayground() {
   const editor = document.getElementById('fd-editor');
@@ -190,7 +282,6 @@ async function initPlayground() {
       canvas.height = rect.height * dpr;
       canvas.style.width = rect.width + 'px';
       canvas.style.height = rect.height + 'px';
-
       if (fdCanvas) {
         fdCanvas.resize(rect.width, rect.height);
       }
@@ -205,65 +296,265 @@ async function initPlayground() {
     fdCanvas.set_text(editor.value);
 
     // Get canvas 2D context
-    const ctx = canvas.getContext('2d');
+    ctx = canvas.getContext('2d');
 
-    // Render loop
+    // Render loop — continuous for hover effects and animations
     const renderLoop = (time) => {
-      const dpr = window.devicePixelRatio || 1;
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      fdCanvas.render(ctx, time);
+      renderCanvas();
       animFrameId = requestAnimationFrame(renderLoop);
     };
-
     animFrameId = requestAnimationFrame(renderLoop);
 
     // Hide loading overlay
     loading.classList.add('hidden');
 
-    // Wire editor input
+    // ── Text Editor → Canvas ──────────────────────────────────────────
     let debounceTimer = null;
     editor.addEventListener('input', () => {
+      if (suppressSync) return;
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
-        if (fdCanvas) {
-          fdCanvas.set_text(editor.value);
-        }
+        if (fdCanvas) fdCanvas.set_text(editor.value);
       }, 50);
     });
 
-    // Resize observer
-    const resizeObserver = new ResizeObserver(() => {
-      resizeCanvas();
+    // ── Pointer Events ────────────────────────────────────────────────
+    canvas.addEventListener('pointerdown', (e) => {
+      if (!fdCanvas) return;
+      // Blur textarea so keyboard shortcuts work on canvas
+      editor.blur();
+
+      const { x, y } = screenToScene(e.clientX, e.clientY, canvas);
+
+      // Middle-click or Space+click → start pan
+      if (e.button === 1 || isPanning) {
+        panDragging = true;
+        panStartX = e.clientX - panX;
+        panStartY = e.clientY - panY;
+        canvas.style.cursor = 'grabbing';
+        activePointerId = e.pointerId;
+        e.preventDefault();
+        return;
+      }
+
+      // Hide FAB during interaction
+      document.getElementById('fab')?.classList.remove('visible');
+
+      const changed = fdCanvas.handle_pointer_down(
+        x, y, e.pressure || 1.0,
+        e.shiftKey, e.ctrlKey, e.altKey, e.metaKey
+      );
+      activePointerId = e.pointerId;
+      if (changed) renderCanvas();
     });
+
+    document.addEventListener('pointermove', (e) => {
+      if (!fdCanvas) return;
+
+      // Only process our owned pointer or hover over canvas
+      if (activePointerId !== -1 && e.pointerId !== activePointerId) return;
+      if (activePointerId === -1 && e.target !== canvas) return;
+
+      // Pan drag
+      if (panDragging) {
+        panX = e.clientX - panStartX;
+        panY = e.clientY - panStartY;
+        renderCanvas();
+        return;
+      }
+
+      const { x, y } = screenToScene(e.clientX, e.clientY, canvas);
+      const changed = fdCanvas.handle_pointer_move(
+        x, y, e.pressure || 1.0,
+        e.shiftKey, e.ctrlKey, e.altKey, e.metaKey
+      );
+      if (changed) renderCanvas();
+    });
+
+    document.addEventListener('pointerup', (e) => {
+      if (!fdCanvas) return;
+      if (activePointerId === -1) return;
+      if (e.pointerId !== activePointerId) return;
+      activePointerId = -1;
+
+      // End pan drag
+      if (panDragging) {
+        panDragging = false;
+        canvas.style.cursor = isPanning ? 'grab' : '';
+        return;
+      }
+
+      const { x, y } = screenToScene(e.clientX, e.clientY, canvas);
+      const resultJson = fdCanvas.handle_pointer_up(
+        x, y, e.shiftKey, e.ctrlKey, e.altKey, e.metaKey
+      );
+      const result = JSON.parse(resultJson);
+
+      if (result.changed) {
+        renderCanvas();
+        syncCanvasToEditor(editor);
+      }
+
+      // Auto-switch toolbar after drawing gesture
+      if (result.toolSwitched) {
+        updateToolbar(result.tool);
+        canvas.style.cursor = '';
+      }
+
+      // Show FAB if node selected
+      updateFab(canvas);
+    });
+
+    // ── Wheel → Pan / Zoom ────────────────────────────────────────────
+    canvas.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      if (e.ctrlKey || e.metaKey) {
+        // Zoom toward cursor
+        const canvasRect = canvas.getBoundingClientRect();
+        const mx = e.clientX - canvasRect.left;
+        const my = e.clientY - canvasRect.top;
+        const factor = e.deltaY < 0 ? 1.05 : 1 / 1.05;
+        const newZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, zoomLevel * factor));
+        panX = mx - (mx - panX) * (newZoom / zoomLevel);
+        panY = my - (my - panY) * (newZoom / zoomLevel);
+        zoomLevel = newZoom;
+        updateZoomIndicator();
+      } else {
+        // Two-finger scroll → pan
+        panX -= e.deltaX;
+        panY -= e.deltaY;
+      }
+      renderCanvas();
+    }, { passive: false });
+
+    // ── Tool Toolbar ──────────────────────────────────────────────────
+    document.querySelectorAll('.canvas-tool').forEach(btn => {
+      btn.addEventListener('click', () => {
+        if (!fdCanvas) return;
+        const tool = btn.dataset.tool;
+        fdCanvas.set_tool(tool);
+        updateToolbar(tool);
+        canvas.style.cursor = (tool === 'select' || tool === 'eraser') ? '' : 'crosshair';
+      });
+    });
+
+    // ── Floating Action Bar ───────────────────────────────────────────
+    document.getElementById('fab-fill')?.addEventListener('input', (e) => {
+      if (!fdCanvas) return;
+      fdCanvas.set_node_prop('fill', e.target.value);
+      renderCanvas();
+      syncCanvasToEditor(editor);
+    });
+    document.getElementById('fab-stroke')?.addEventListener('input', (e) => {
+      if (!fdCanvas) return;
+      fdCanvas.set_node_prop('stroke', e.target.value);
+      renderCanvas();
+      syncCanvasToEditor(editor);
+    });
+    document.getElementById('fab-delete')?.addEventListener('click', () => {
+      if (!fdCanvas) return;
+      fdCanvas.handle_key('Backspace', false, false, false, false);
+      renderCanvas();
+      syncCanvasToEditor(editor);
+      document.getElementById('fab')?.classList.remove('visible');
+    });
+
+    // ── Keyboard Shortcuts ────────────────────────────────────────────
+    document.addEventListener('keydown', (e) => {
+      if (!fdCanvas) return;
+      const editorFocused = document.activeElement === editor;
+
+      // Space → pan mode
+      if (e.code === 'Space' && !e.repeat && !editorFocused) {
+        isPanning = true;
+        canvas.style.cursor = 'grab';
+        e.preventDefault();
+        return;
+      }
+
+      // Tool shortcuts (only when canvas focused)
+      if (!editorFocused && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const toolMap = { v:'select', r:'rect', o:'ellipse', t:'text', a:'arrow', p:'pen', e:'eraser' };
+        const tool = toolMap[e.key.toLowerCase()];
+        if (tool) {
+          fdCanvas.set_tool(tool);
+          updateToolbar(tool);
+          canvas.style.cursor = (tool === 'select' || tool === 'eraser') ? '' : 'crosshair';
+          e.preventDefault();
+          return;
+        }
+      }
+
+      // Delete (only when canvas focused)
+      if (!editorFocused && (e.key === 'Delete' || e.key === 'Backspace')) {
+        const r = JSON.parse(fdCanvas.handle_key(e.key, e.ctrlKey, e.shiftKey, e.altKey, e.metaKey));
+        if (r.changed) {
+          renderCanvas();
+          syncCanvasToEditor(editor);
+        }
+        document.getElementById('fab')?.classList.remove('visible');
+        e.preventDefault();
+        return;
+      }
+
+      // Undo/Redo (always — override textarea undo)
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        const changed = e.shiftKey ? fdCanvas.redo() : fdCanvas.undo();
+        if (changed) {
+          renderCanvas();
+          syncCanvasToEditor(editor);
+        }
+        return;
+      }
+
+      // Forward remaining keys to WASM (when canvas focused)
+      if (!editorFocused) {
+        try {
+          const r = JSON.parse(fdCanvas.handle_key(e.key, e.ctrlKey, e.shiftKey, e.altKey, e.metaKey));
+          if (r.changed) {
+            renderCanvas();
+            syncCanvasToEditor(editor);
+          }
+        } catch (_) {}
+      }
+    });
+
+    document.addEventListener('keyup', (e) => {
+      if (e.code === 'Space') {
+        isPanning = false;
+        if (!panDragging) canvas.style.cursor = '';
+      }
+    });
+
+    // ── Resize Observer ───────────────────────────────────────────────
+    const resizeObserver = new ResizeObserver(() => resizeCanvas());
     resizeObserver.observe(wrapper);
 
-    // Example selector
+    // ── Example Selector ──────────────────────────────────────────────
     document.getElementById('example-select').addEventListener('change', (e) => {
       const example = EXAMPLES[e.target.value];
       if (example) {
         editor.value = example;
-        if (fdCanvas) {
-          fdCanvas.set_text(example);
-        }
+        if (fdCanvas) fdCanvas.set_text(example);
+        // Reset zoom/pan for new example
+        panX = 0; panY = 0; zoomLevel = 1.0;
+        updateZoomIndicator();
       }
     });
 
-    // Theme toggle
+    // ── Theme Toggle ──────────────────────────────────────────────────
     document.getElementById('theme-toggle').addEventListener('click', function() {
       isDark = !isDark;
-      if (fdCanvas) {
-        fdCanvas.set_theme(isDark);
-      }
+      if (fdCanvas) fdCanvas.set_theme(isDark);
       this.textContent = isDark ? '🌙 Dark' : '☀️ Light';
       this.classList.toggle('active', !isDark);
     });
 
-    // Sketchy toggle
+    // ── Sketchy Toggle ────────────────────────────────────────────────
     document.getElementById('sketchy-toggle').addEventListener('click', function() {
       isSketchy = !isSketchy;
-      if (fdCanvas) {
-        fdCanvas.set_sketchy_mode(isSketchy);
-      }
+      if (fdCanvas) fdCanvas.set_sketchy_mode(isSketchy);
       this.classList.toggle('active', isSketchy);
     });
 

--- a/site/style.css
+++ b/site/style.css
@@ -415,6 +415,111 @@ code {
   display: block;
 }
 
+/* ─── Canvas Tool Buttons ─── */
+.canvas-tools {
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  padding: 2px;
+}
+.canvas-tool {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.15s ease;
+}
+.canvas-tool:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+.canvas-tool.active {
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+.zoom-indicator {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  padding: 2px 6px;
+  user-select: none;
+}
+
+/* ─── Floating Action Bar ─── */
+.fab {
+  display: none;
+  position: absolute;
+  z-index: 20;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: rgba(22, 27, 34, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+.fab.visible { display: flex; }
+.fab-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.fab-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.fab-color {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  padding: 0;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+}
+.fab-color::-webkit-color-swatch-wrapper { padding: 0; }
+.fab-color::-webkit-color-swatch { border-radius: 50%; border: none; }
+.fab-sep {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.1);
+}
+.fab-delete {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 3px 8px;
+  font-size: 12px;
+  transition: all 0.15s ease;
+}
+.fab-delete:hover {
+  background: rgba(255, 59, 48, 0.15);
+  border-color: rgba(255, 59, 48, 0.3);
+  color: #FF3B30;
+}
+
 /* ─── Skeleton Loader ─── */
 .canvas-loading {
   position: absolute;


### PR DESCRIPTION
## Interactive Playground (R6.6)

Makes the fast-draft.com Live Playground fully interactive — extension-parity canvas with zero Rust changes.

### Changes
- **`playground.js`** — Full rewrite (~330 lines): pointer events, bidi sync, tool switching, zoom/pan, keyboard shortcuts, undo/redo, floating action bar
- **`index.html`** — Tool toolbar (7 buttons), FAB HTML, zoom indicator
- **`style.css`** — +95 lines for toolbar, FAB, zoom indicator styles
- **`CHANGELOG.md`** — v0.10.66 entry
- **`REQUIREMENTS.md`** — R6.6 added

### Features
- 7-tool toolbar (Select, Rect, Ellipse, Text, Arrow, Pen, Eraser)
- Canvas→code bidirectional sync with `suppressSync` echo prevention
- Zoom/pan (scroll, Ctrl+scroll, Space+drag, middle-click)
- Keyboard shortcuts (V/R/O/T/A/P/E, Delete, ⌘Z/⌘⇧Z)
- Floating action bar with fill/stroke pickers + delete

### Verification
- `cargo clippy --workspace` ✅
- `cargo fmt --all` ✅
- `cargo test --workspace` ✅ (370 tests)
- E2E browser test ✅ (selection handles, canvas drawing, bidi sync, FAB, tool switching)