### PR TITLE
🎨 Palette: [UX improvement] Add missing aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-07 - Button Accessibility Enhancement
+**Learning:** Icon-only buttons or minimal-text buttons in VSCode extension webviews and web playgrounds often lack proper `aria-label`s, which significantly hampers screen reader accessibility. Titles alone do not suffice.
+**Action:** When adding new UI components, always ensure that any icon-only button contains a clear `aria-label` explaining its function.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2497,7 +2497,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <label class="fab-label fab-text-only" for="fab-font-size">Size</label>
       <input type="number" id="fab-font-size" class="fab-input fab-text-only" min="8" max="200" step="1" value="16" title="Font size">
       <div class="fab-sep"></div>
-      <button class="fab-delete-btn" id="deleteSelectedBtn" title="Delete (⌫)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
+      <button class="fab-delete-btn" id="deleteSelectedBtn" title="Delete (⌫)" aria-label="Delete selected"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
 
     </div>
     <canvas id="fd-canvas" class="tool-select"></canvas>
@@ -2515,7 +2515,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <div id="center-snap-guides"></div>
     <div id="layers-panel"></div>
     <div id="library-panel"></div>
-    <div id="minimap-container"><canvas id="minimap-canvas"></canvas><div id="minimap-zoom-controls"><button class="bl-btn" id="zoom-out-btn" title="Zoom out">−</button><div class="bl-sep"></div><button class="bl-btn" id="zoom-reset-btn" title="Reset zoom (click)">100%</button><div class="bl-sep"></div><button class="bl-btn" id="zoom-in-btn" title="Zoom in">+</button></div></div>
+    <div id="minimap-container"><canvas id="minimap-canvas"></canvas><div id="minimap-zoom-controls"><button class="bl-btn" id="zoom-out-btn" title="Zoom out" aria-label="Zoom out">−</button><div class="bl-sep"></div><button class="bl-btn" id="zoom-reset-btn" title="Reset zoom (click)" aria-label="Reset zoom">100%</button><div class="bl-sep"></div><button class="bl-btn" id="zoom-in-btn" title="Zoom in" aria-label="Zoom in">+</button></div></div>
     <!-- Floating Bottom Toolbar (Scroll UX) -->
     <div id="floating-toolbar" class="scroll-toolbar horizontal unrolled">
       <div class="scroll-handle handle-start" title="Drag to move, click to roll">
@@ -2523,14 +2523,14 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         <div class="paper-roll left-roll"></div>
       </div>
       <div class="scroll-paper-body">
-        <button class="ft-tool-btn active" data-tool="select"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 2L3.5 13.5L7 10L11.5 14.5L13 13L9 8.5L13 8.5Z"/></svg><span class="ft-tooltip">Select<span class="tt-shortcut">V</span></span></button>
-        <button class="ft-tool-btn" data-tool="rect"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="12" height="10" rx="2"/></svg><span class="ft-tooltip">Rectangle<span class="tt-shortcut">R</span></span></button>
-        <button class="ft-tool-btn" data-tool="ellipse"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="9" r="6"/></svg><span class="ft-tooltip">Ellipse<span class="tt-shortcut">O</span></span></button>
-        <button class="ft-tool-btn" data-tool="pen"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 3.5L14.5 7.5L6.5 15.5H2.5V11.5Z"/><path d="M10.5 3.5L14.5 7.5" /><path d="M8.5 5.5L12.5 9.5"/></svg><span class="ft-tooltip">Pen<span class="tt-shortcut">P</span></span></button>
-        <button class="ft-tool-btn" data-tool="arrow"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14L14 4"/><path d="M7 4H14V11"/></svg><span class="ft-tooltip">Arrow<span class="tt-shortcut">A</span></span></button>
-        <button class="ft-tool-btn" data-tool="text"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4H14"/><path d="M9 4V15"/><path d="M6 15H12"/></svg><span class="ft-tooltip">Text<span class="tt-shortcut">T</span></span></button>
-        <button class="ft-tool-btn" data-tool="frame"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="14" height="14" rx="2"/><rect x="5.5" y="5.5" width="7" height="7" rx="1"/></svg><span class="ft-tooltip">Frame<span class="tt-shortcut">F</span></span></button>
-        <button class="ft-tool-btn" data-tool="eraser"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg><span class="ft-tooltip">Eraser<span class="tt-shortcut">E</span></span></button>
+        <button class="ft-tool-btn active" data-tool="select" aria-label="Select tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 2L3.5 13.5L7 10L11.5 14.5L13 13L9 8.5L13 8.5Z"/></svg><span class="ft-tooltip">Select<span class="tt-shortcut">V</span></span></button>
+        <button class="ft-tool-btn" data-tool="rect" aria-label="Rectangle tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="12" height="10" rx="2"/></svg><span class="ft-tooltip">Rectangle<span class="tt-shortcut">R</span></span></button>
+        <button class="ft-tool-btn" data-tool="ellipse" aria-label="Ellipse tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="9" r="6"/></svg><span class="ft-tooltip">Ellipse<span class="tt-shortcut">O</span></span></button>
+        <button class="ft-tool-btn" data-tool="pen" aria-label="Pen tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 3.5L14.5 7.5L6.5 15.5H2.5V11.5Z"/><path d="M10.5 3.5L14.5 7.5" /><path d="M8.5 5.5L12.5 9.5"/></svg><span class="ft-tooltip">Pen<span class="tt-shortcut">P</span></span></button>
+        <button class="ft-tool-btn" data-tool="arrow" aria-label="Arrow tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14L14 4"/><path d="M7 4H14V11"/></svg><span class="ft-tooltip">Arrow<span class="tt-shortcut">A</span></span></button>
+        <button class="ft-tool-btn" data-tool="text" aria-label="Text tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4H14"/><path d="M9 4V15"/><path d="M6 15H12"/></svg><span class="ft-tooltip">Text<span class="tt-shortcut">T</span></span></button>
+        <button class="ft-tool-btn" data-tool="frame" aria-label="Frame tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="14" height="14" rx="2"/><rect x="5.5" y="5.5" width="7" height="7" rx="1"/></svg><span class="ft-tooltip">Frame<span class="tt-shortcut">F</span></span></button>
+        <button class="ft-tool-btn" data-tool="eraser" aria-label="Eraser tool"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg><span class="ft-tooltip">Eraser<span class="tt-shortcut">E</span></span></button>
       </div>
       <div class="scroll-handle handle-end" title="Drag to move, click to roll">
         <div class="paper-roll right-roll"></div>
@@ -2604,15 +2604,15 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         <div class="props-section" id="props-align-section" style="display:none">
           <div class="props-section-label">Alignment</div>
           <div class="align-grid" id="align-grid">
-            <button class="align-cell" data-h="left"   data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="top" aria-label="Align left top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="top" aria-label="Align center top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="top" aria-label="Align right top"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="middle" aria-label="Align left middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="middle" aria-label="Align center middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="middle" aria-label="Align right middle"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="bottom" aria-label="Align left bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="bottom" aria-label="Align center bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="bottom" aria-label="Align right bottom"><span class="align-dot"></span></button>
           </div>
         </div>
         <div class="props-section" id="props-actions-section">
@@ -2633,7 +2633,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <div id="annotation-card">
     <div class="card-header">
       <span id="card-title">Spec</span>
-      <button class="card-close" id="card-close-btn">×</button>
+      <button class="card-close" id="card-close-btn" aria-label="Close">×</button>
     </div>
     <div class="field-group">
       <label class="field-label" for="ann-description">Description</label>
@@ -2696,7 +2696,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <div id="renamify-panel">
     <div class="renamify-header">
       <span class="renamify-title">✦ Renamify</span>
-      <button class="renamify-close" id="renamify-close">×</button>
+      <button class="renamify-close" id="renamify-close" aria-label="Close Renamify">×</button>
     </div>
     <div class="renamify-body" id="renamify-body"></div>
     <div class="renamify-footer" id="renamify-footer" style="display:none">
@@ -2706,7 +2706,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
   </div>
   <div id="anim-picker">
-    <div class="picker-header"><span class="picker-icon">⚡</span> Add Animation <button class="picker-close" id="anim-picker-close">×</button></div>
+    <div class="picker-header"><span class="picker-icon">⚡</span> Add Animation <button class="picker-close" id="anim-picker-close" aria-label="Close Animation Picker">×</button></div>
     <div class="picker-body" id="anim-picker-body"></div>
   </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -88,10 +88,10 @@
           </select>
         </div>
         <div class="toolbar-right">
-          <button id="sketchy-toggle" class="toolbar-btn" title="Toggle sketchy mode">
+          <button id="sketchy-toggle" class="toolbar-btn" title="Toggle sketchy mode" aria-label="Toggle sketchy mode">
             ✏️ Sketchy
           </button>
-          <button id="theme-toggle" class="toolbar-btn" title="Toggle theme">
+          <button id="theme-toggle" class="toolbar-btn" title="Toggle theme" aria-label="Toggle theme">
             🌙 Dark
           </button>
         </div>
@@ -107,13 +107,13 @@
           <div class="editor-header">
             <span class="editor-dot canvas-dot"></span> Canvas Mode
             <div id="canvas-tools" class="canvas-tools">
-              <button class="canvas-tool active" data-tool="select" title="Select (V)">↖</button>
-              <button class="canvas-tool" data-tool="rect" title="Rectangle (R)">□</button>
-              <button class="canvas-tool" data-tool="ellipse" title="Ellipse (O)">○</button>
-              <button class="canvas-tool" data-tool="text" title="Text (T)">T</button>
-              <button class="canvas-tool" data-tool="arrow" title="Arrow (A)">→</button>
-              <button class="canvas-tool" data-tool="pen" title="Pen (P)">✎</button>
-              <button class="canvas-tool" data-tool="eraser" title="Eraser (E)">◎</button>
+              <button class="canvas-tool active" data-tool="select" title="Select (V)" aria-label="Select tool">↖</button>
+              <button class="canvas-tool" data-tool="rect" title="Rectangle (R)" aria-label="Rectangle tool">□</button>
+              <button class="canvas-tool" data-tool="ellipse" title="Ellipse (O)" aria-label="Ellipse tool">○</button>
+              <button class="canvas-tool" data-tool="text" title="Text (T)" aria-label="Text tool">T</button>
+              <button class="canvas-tool" data-tool="arrow" title="Arrow (A)" aria-label="Arrow tool">→</button>
+              <button class="canvas-tool" data-tool="pen" title="Pen (P)" aria-label="Pen tool">✎</button>
+              <button class="canvas-tool" data-tool="eraser" title="Eraser (E)" aria-label="Eraser tool">◎</button>
             </div>
             <span id="zoom-level" class="zoom-indicator">100%</span>
           </div>
@@ -130,7 +130,7 @@
                 <input type="color" id="fab-stroke" class="fab-color" value="#333333">
               </label>
               <div class="fab-sep"></div>
-              <button id="fab-delete" class="fab-delete" title="Delete (⌫)">🗑</button>
+              <button id="fab-delete" class="fab-delete" title="Delete (⌫)" aria-label="Delete selected">🗑</button>
             </div>
             <div id="canvas-loading" class="canvas-loading">
               <div class="skeleton-preview">


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to icon-only buttons across the standalone web playground (`site/index.html`) and the VSCode extension webview (`fd-vscode/src/webview-html.ts`).
🎯 **Why:** Icon-only buttons or those with minimal text (like "T", "O", "X") often rely solely on visual cues or `title` attributes. This poses a significant barrier for screen reader users who cannot perceive these cues visually.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce the function of tool buttons (Select, Rectangle, Ellipse, Pen, Arrow, Text, Eraser, Delete), alignment controls, zoom controls, and close buttons correctly, dramatically improving navigation for visually impaired users.

---
*PR created automatically by Jules for task [11885970709276090817](https://jules.google.com/task/11885970709276090817) started by @khangnghiem*