### PR TITLE
feat(core): add pad: property for Free-layout frames (R1.21)

### DIFF
--- a/.agents/skills/fd-format/SKILL.md
+++ b/.agents/skills/fd-format/SKILL.md
@@ -84,6 +84,7 @@ frame @card {
   fill: <color>
   corner: <radius>
   clip: true          # optional — clips children to frame bounds
+  pad: <px>           # optional — insets content area (works without layout:)
   layout: column gap=<px> pad=<px>
 
   # Children go here (nested nodes)
@@ -246,6 +247,8 @@ w: 280 h: 48
 9. **Named colors** — `fill: purple`, `fill: blue` etc. are accepted (17 Tailwind palette colors); hex always works too
 10. **Property aliases** — `background:` / `color:` → fill, `rounded:` / `radius:` → corner; the emitter uses canonical names
 11. **Dimension units** — `w: 320px` is accepted; the `px` suffix is cosmetic and stripped by the parser
+12. **Always use padding** — `pad: 12` on frames adds breathing room between edges and content; `layout: column pad=16` on managed layouts; never place children flush against frame edges
+13. **Prefer managed layouts** — use `layout: column gap=8 pad=16` instead of manual `x:` / `y:` for stacked elements; it's more maintainable and responsive
 
 ## Example: Complete Card
 

--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -211,7 +211,12 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
     // Layout mode (for frames)
     if let NodeKind::Frame { layout, .. } = &node.kind {
         match layout {
-            LayoutMode::Free => {}
+            LayoutMode::Free { pad } => {
+                if *pad > 0.0 {
+                    indent(out, depth + 1);
+                    writeln!(out, "pad: {}", format_num(*pad)).unwrap();
+                }
+            }
             LayoutMode::Column { gap, pad } => {
                 indent(out, depth + 1);
                 writeln!(
@@ -851,7 +856,7 @@ fn generate_auto_comment(node: &SceneNode, graph: &SceneGraph, idx: NodeIndex) -
         NodeKind::Frame { layout, .. } => {
             let count = graph.children(idx).len();
             let layout_str = match layout {
-                LayoutMode::Free => "free",
+                LayoutMode::Free { .. } => "free",
                 LayoutMode::Column { .. } => "column",
                 LayoutMode::Row { .. } => "row",
                 LayoutMode::Grid { .. } => "grid",
@@ -1101,7 +1106,12 @@ fn emit_layout_mode_filtered(out: &mut String, kind: &NodeKind, depth: usize) {
         _ => return, // Group is always Free — no layout emission
     };
     match layout {
-        LayoutMode::Free => {}
+        LayoutMode::Free { pad } => {
+            if *pad > 0.0 {
+                indent(out, depth);
+                writeln!(out, "pad: {}", format_num(*pad)).unwrap();
+            }
+        }
         LayoutMode::Column { gap, pad } => {
             indent(out, depth);
             writeln!(

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -101,7 +101,7 @@ pub fn is_parent_managed(graph: &SceneGraph, node_idx: NodeIndex) -> bool {
     };
     let parent_node = &graph.graph[parent_idx];
     match &parent_node.kind {
-        NodeKind::Frame { layout, .. } => !matches!(layout, LayoutMode::Free),
+        NodeKind::Frame { layout, .. } => !matches!(layout, LayoutMode::Free { .. }),
         _ => false,
     }
 }
@@ -172,9 +172,9 @@ fn resolve_children(
 
     // Determine layout mode
     let layout = match &parent_node.kind {
-        NodeKind::Group => LayoutMode::Free, // Group is always Free
+        NodeKind::Group => LayoutMode::Free { pad: 0.0 }, // Group is always Free
         NodeKind::Frame { layout, .. } => layout.clone(),
-        _ => LayoutMode::Free,
+        _ => LayoutMode::Free { pad: 0.0 },
     };
 
     match layout {
@@ -355,17 +355,21 @@ fn resolve_children(
                 }
             }
         }
-        LayoutMode::Free => {
-            // Each child positioned at parent origin by default.
+        LayoutMode::Free { pad } => {
+            // Compute padded content area
+            let content_x = parent_bounds.x + pad;
+            let content_y = parent_bounds.y + pad;
+            let content_w = (parent_bounds.width - 2.0 * pad).max(0.0);
+            let content_h = (parent_bounds.height - 2.0 * pad).max(0.0);
+
+            // Each child positioned at padded origin by default.
             // Use or_insert to preserve existing cached bounds (e.g. JS-measured
             // text sizes, explicit positions) during resolve_subtree calls.
-            // For a fresh map (from resolve_layout), or_insert behaves
-            // identically to insert since there are no existing entries.
             for &child_idx in &children {
                 let child_size = intrinsic_size(&graph.graph[child_idx]);
                 bounds.entry(child_idx).or_insert(ResolvedBounds {
-                    x: parent_bounds.x,
-                    y: parent_bounds.y,
+                    x: content_x,
+                    y: content_y,
                     width: child_size.0,
                     height: child_size.1,
                 });
@@ -383,22 +387,18 @@ fn resolve_children(
                     .iter()
                     .any(|c| matches!(c, Constraint::Position { .. }));
 
-                // Priority 1: explicit `place:` property
+                // Priority 1: explicit `place:` property (uses padded area)
                 if let Some((h, v)) = child_node.place {
                     if !has_position && let Some(cb) = bounds.get(&child_idx).copied() {
                         let x = match h {
-                            HPlace::Left => parent_bounds.x,
-                            HPlace::Center => {
-                                parent_bounds.x + (parent_bounds.width - cb.width) / 2.0
-                            }
-                            HPlace::Right => parent_bounds.x + parent_bounds.width - cb.width,
+                            HPlace::Left => content_x,
+                            HPlace::Center => content_x + (content_w - cb.width) / 2.0,
+                            HPlace::Right => content_x + content_w - cb.width,
                         };
                         let y = match v {
-                            VPlace::Top => parent_bounds.y,
-                            VPlace::Middle => {
-                                parent_bounds.y + (parent_bounds.height - cb.height) / 2.0
-                            }
-                            VPlace::Bottom => parent_bounds.y + parent_bounds.height - cb.height,
+                            VPlace::Top => content_y,
+                            VPlace::Middle => content_y + (content_h - cb.height) / 2.0,
+                            VPlace::Bottom => content_y + content_h - cb.height,
                         };
                         bounds.insert(child_idx, ResolvedBounds { x, y, ..cb });
                     }
@@ -407,13 +407,14 @@ fn resolve_children(
 
                 // Priority 2: auto-center text children in shape parents
                 // (no explicit place: and no Position constraint)
+                // Uses padded bounds for centering area
                 if parent_is_shape
                     && matches!(child_node.kind, NodeKind::Text { .. })
                     && !has_position
                     && let Some(child_b) = bounds.get(&child_idx).copied()
                 {
-                    let cx = parent_bounds.x + (parent_bounds.width - child_b.width) / 2.0;
-                    let cy = parent_bounds.y + (parent_bounds.height - child_b.height) / 2.0;
+                    let cx = content_x + (content_w - child_b.width) / 2.0;
+                    let cy = content_y + (content_h - child_b.height) / 2.0;
                     bounds.insert(
                         child_idx,
                         ResolvedBounds {
@@ -429,7 +430,7 @@ fn resolve_children(
     }
 
     // Recurse into children (only for Free mode — Column/Row/Grid already recursed in pass 1)
-    if matches!(layout, LayoutMode::Free) {
+    if matches!(layout, LayoutMode::Free { .. }) {
         for &child_idx in &children {
             resolve_children(graph, child_idx, bounds, viewport);
         }

--- a/crates/fd-core/src/layout_tests.rs
+++ b/crates/fd-core/src/layout_tests.rs
@@ -928,3 +928,111 @@ text @long "Hello World this is a long sentence that should wrap" {
         b.height
     );
 }
+
+#[test]
+fn layout_free_frame_pad_insets_children() {
+    let input = r#"
+frame @card {
+  w: 400 h: 300
+  pad: 20
+
+  rect @child { w: 100 h: 50 }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let viewport = Viewport {
+        width: 800.0,
+        height: 600.0,
+    };
+    let bounds = resolve_layout(&graph, viewport);
+
+    let card = bounds[&graph.index_of(NodeId::intern("card")).unwrap()];
+    let child = bounds[&graph.index_of(NodeId::intern("child")).unwrap()];
+
+    // Child default position should be at parent origin + pad
+    assert!(
+        (child.x - (card.x + 20.0)).abs() < 0.01,
+        "child.x ({}) should be card.x + pad ({})",
+        child.x,
+        card.x + 20.0
+    );
+    assert!(
+        (child.y - (card.y + 20.0)).abs() < 0.01,
+        "child.y ({}) should be card.y + pad ({})",
+        child.y,
+        card.y + 20.0
+    );
+}
+
+#[test]
+fn layout_free_frame_pad_text_centered_in_padded_area() {
+    let input = r#"
+frame @card {
+  w: 400 h: 300
+  pad: 40
+
+  text @label "Hello" {
+    font: "Inter" 600 14
+    place: center
+  }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let viewport = Viewport {
+        width: 800.0,
+        height: 600.0,
+    };
+    let bounds = resolve_layout(&graph, viewport);
+
+    let card = bounds[&graph.index_of(NodeId::intern("card")).unwrap()];
+    let label = bounds[&graph.index_of(NodeId::intern("label")).unwrap()];
+
+    // Text should be centered within padded area (400-80=320, 300-80=220)
+    let content_cx = card.x + 40.0 + (400.0 - 80.0) / 2.0;
+    let content_cy = card.y + 40.0 + (300.0 - 80.0) / 2.0;
+    let label_cx = label.x + label.width / 2.0;
+    let label_cy = label.y + label.height / 2.0;
+
+    assert!(
+        (label_cx - content_cx).abs() < 1.0,
+        "label center x ({label_cx}) should match padded content center ({content_cx})"
+    );
+    assert!(
+        (label_cy - content_cy).abs() < 1.0,
+        "label center y ({label_cy}) should match padded content center ({content_cy})"
+    );
+}
+
+#[test]
+fn layout_free_frame_pad_zero_matches_no_pad() {
+    // pad=0 should behave identically to the old Free without pad
+    let input = r#"
+frame @card {
+  w: 400 h: 300
+  rect @child { w: 100 h: 50 }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let viewport = Viewport {
+        width: 800.0,
+        height: 600.0,
+    };
+    let bounds = resolve_layout(&graph, viewport);
+
+    let card = bounds[&graph.index_of(NodeId::intern("card")).unwrap()];
+    let child = bounds[&graph.index_of(NodeId::intern("child")).unwrap()];
+
+    // Child should be at parent origin (no padding)
+    assert!(
+        (child.x - card.x).abs() < 0.01,
+        "child.x ({}) should equal card.x ({})",
+        child.x,
+        card.x
+    );
+    assert!(
+        (child.y - card.y).abs() < 0.01,
+        "child.y ({}) should equal card.y ({})",
+        child.y,
+        card.y
+    );
+}

--- a/crates/fd-core/src/mermaid.rs
+++ b/crates/fd-core/src/mermaid.rs
@@ -534,7 +534,7 @@ fn build_scene_graph(
                 width: 300.0,
                 height: 200.0,
                 clip: false,
-                layout: LayoutMode::Free,
+                layout: LayoutMode::Free { pad: 0.0 },
             },
             style: Style {
                 fill: Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0))),

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -460,17 +460,23 @@ pub struct FlowAnim {
 }
 
 /// Group layout mode (for children arrangement).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LayoutMode {
     /// Free / absolute positioning of children.
-    #[default]
-    Free,
+    /// Optional padding insets the content area (default 0).
+    Free { pad: f32 },
     /// Column (vertical stack).
     Column { gap: f32, pad: f32 },
     /// Row (horizontal stack).
     Row { gap: f32, pad: f32 },
     /// Grid layout.
     Grid { cols: u32, gap: f32, pad: f32 },
+}
+
+impl Default for LayoutMode {
+    fn default() -> Self {
+        LayoutMode::Free { pad: 0.0 }
+    }
 }
 
 // ─── Scene Graph Nodes ───────────────────────────────────────────────────

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -561,7 +561,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let mut children = Vec::new();
     let mut width: Option<f32> = None;
     let mut height: Option<f32> = None;
-    let mut layout = LayoutMode::Free;
+    let mut layout = LayoutMode::Free { pad: 0.0 };
     let mut clip = false;
     let mut place: Option<(HPlace, VPlace)> = None;
     let mut path_commands: Vec<PathCmd> = Vec::new();
@@ -941,12 +941,22 @@ fn parse_node_property(
                 "column" => LayoutMode::Column { gap, pad },
                 "row" => LayoutMode::Row { gap, pad },
                 "grid" => LayoutMode::Grid { cols: 2, gap, pad },
-                _ => LayoutMode::Free,
+                _ => LayoutMode::Free { pad: 0.0 },
             };
         }
         "clip" => {
             let val = parse_identifier.parse_next(input)?;
             *clip = val == "true";
+        }
+        "pad" | "padding" => {
+            // Standalone pad: N — sets padding on Free frames
+            let val = parse_number.parse_next(input)?;
+            match layout {
+                LayoutMode::Free { pad } => *pad = val,
+                LayoutMode::Column { pad, .. }
+                | LayoutMode::Row { pad, .. }
+                | LayoutMode::Grid { pad, .. } => *pad = val,
+            }
         }
         "d" => {
             // Parse SVG-like path commands: M x y L x y C ... Z

--- a/crates/fd-core/src/parser_tests.rs
+++ b/crates/fd-core/src/parser_tests.rs
@@ -719,3 +719,71 @@ rect @card {
         Some((crate::model::HPlace::Right, crate::model::VPlace::Bottom))
     );
 }
+
+#[test]
+fn parse_free_frame_pad() {
+    let src = r#"
+frame @card {
+  w: 400 h: 300
+  pad: 16
+}
+"#;
+    let graph = parse_document(src).unwrap();
+    let node = graph.get_by_id(crate::id::NodeId::intern("card")).unwrap();
+    match &node.kind {
+        NodeKind::Frame { layout, .. } => match layout {
+            crate::model::LayoutMode::Free { pad } => {
+                assert_eq!(*pad, 16.0, "pad should be 16");
+            }
+            other => panic!("expected Free layout, got {other:?}"),
+        },
+        other => panic!("expected Frame, got {other:?}"),
+    }
+}
+
+#[test]
+fn roundtrip_free_frame_pad() {
+    let src = r#"
+frame @card {
+  w: 400 h: 300
+  pad: 12
+  rect @child { w: 100 h: 50 }
+}
+"#;
+    let graph = parse_document(src).unwrap();
+    let emitted = crate::emitter::emit_document(&graph);
+    assert!(
+        emitted.contains("pad: 12"),
+        "emitted should contain pad: 12, got: {emitted}"
+    );
+
+    let reparsed = parse_document(&emitted).unwrap();
+    let node = reparsed
+        .get_by_id(crate::id::NodeId::intern("card"))
+        .unwrap();
+    match &node.kind {
+        NodeKind::Frame { layout, .. } => match layout {
+            crate::model::LayoutMode::Free { pad } => {
+                assert_eq!(*pad, 12.0, "pad should survive roundtrip");
+            }
+            other => panic!("expected Free layout after roundtrip, got {other:?}"),
+        },
+        other => panic!("expected Frame after roundtrip, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_free_frame_pad_zero_omitted() {
+    // Free frame with pad=0 should NOT emit pad: line
+    let src = r#"
+frame @card {
+  w: 400 h: 300
+}
+"#;
+    let graph = parse_document(src).unwrap();
+    let emitted = crate::emitter::emit_document(&graph);
+    assert!(
+        !emitted.contains("pad:"),
+        "pad: 0 should not appear in emitted output"
+    );
+}

--- a/crates/fd-core/src/resolve.rs
+++ b/crates/fd-core/src/resolve.rs
@@ -124,7 +124,7 @@ fn resolve_recursive(
                 width: 0.0,
                 height: 0.0,
                 clip: false,
-                layout: LayoutMode::Free,
+                layout: LayoutMode::Free { pad: 0.0 },
             },
         );
         let frame_idx = graph.add_node(graph.root, frame_node);

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -215,7 +215,7 @@ impl SyncEngine {
                                     LayoutMode::Column { pad, .. }
                                     | LayoutMode::Row { pad, .. }
                                     | LayoutMode::Grid { pad, .. } => *pad,
-                                    LayoutMode::Free => 0.0,
+                                    LayoutMode::Free { pad } => *pad,
                                 },
                                 _ => 0.0,
                             };

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -2134,7 +2134,7 @@ impl FdCanvas {
                 width: 200.0,
                 height: 150.0,
                 clip: false,
-                layout: LayoutMode::Free,
+                layout: LayoutMode::Free { pad: 0.0 },
             },
             _ => return false,
         };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ## Completed Requirements
 
+### v0.10.67 — Free Frame Padding (R1.21)
+
+- **FEATURE (R1.21)**: `pad:` property for Free-layout frames — insets the content area so children, text centering, and `place:` positioning all respect padding; standalone `pad: N` or inline `layout: column pad=N` both work; `pad: 0` is default and omitted from emitted output
+- **CORE**: `LayoutMode::Free` now carries `{ pad: f32 }` matching Column/Row/Grid; manual `Default` impl returns `pad: 0.0`; layout solver computes padded content area for child defaults, text auto-centering, and `place:` alignment
+- **PARSER**: New `"pad"` / `"padding"` standalone property arms for frames; updates all layout variants
+- **DOCS**: Updated FD format SKILL.md with `pad:` in frame grammar and 2 new best practices (always use padding, prefer managed layouts); demo.fd sidebar converted to `layout: column gap=8 pad=16`
+- **TESTING**: 6 new tests — `parse_free_frame_pad`, `roundtrip_free_frame_pad`, `parse_free_frame_pad_zero_omitted`, `layout_free_frame_pad_insets_children`, `layout_free_frame_pad_text_centered_in_padded_area`, `layout_free_frame_pad_zero_matches_no_pad`
+
 ### v0.10.66 — Interactive Playground (R6.6)
 
 - **FEATURE (R6.6)**: Playground canvas is now fully interactive — pointer events (click to select, drag to move/resize, draw shapes) wired through WASM `handle_pointer_down/move/up` APIs; bidirectional sync with `suppressSync` echo prevention ensures canvas→code and code→canvas stay in sync

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -28,6 +28,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.18** _(done)_: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges; `parse_mermaid()` in fd-core + `import_mermaid()` WASM API
 - **R1.19** _(done)_: Edge label offset — `label_offset: <x> <y>` property on edges for draggable text labels; parse/emit roundtrip support
 - **R1.20** _(done)_: Edge anchors — `EdgeAnchor` enum (`@node_id` or `x y` coords) for flexible edge endpoints; `text_child: Option<NodeId>` for styled text labels; `create_edge_at()` WASM API; edge-to-edge validation
+- **R1.21** _(done)_: Free frame padding — `pad: <N>` property on Free-layout frames insets the content area; children default to padded origin, text centering and `place:` use padded bounds; also accepts `padding:` alias
 
 ### R2: Bidirectional Sync
 
@@ -308,3 +309,4 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | alt-drag multi-select | R3.60 |
 | esc-cancel / cancel-drag | R3.61 |
 | path / d: commands | R3.62, R3.4 |
+| padding / spacing | R1.21 |

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -97,6 +97,7 @@ frame @sidebar {
       ease: ease_out 150ms
     }
   }
+  layout: column gap=8 pad=16
   w: 220 h: 600
   fill: #2D2B55  # blue
   corner: 0
@@ -130,18 +131,6 @@ rect @card_revenue {
     priority: high
     tag: metrics, dashboard
   }
-  # [auto] label: "Revenue"
-  text @revenue_label "Revenue" {
-    use: body
-    x: 296
-    y: 112
-  }
-  # [auto] label: "$48,250"
-  text @revenue_value "$48,250" {
-    use: metric
-    x: 296
-    y: 136
-  }
   # [auto] label: "+12.5% ↑"
   text @revenue_delta "+12.5% ↑" {
     fill: #22C55E  # green
@@ -160,6 +149,20 @@ rect @card_revenue {
   }
 }
 
+# [auto] label: "Revenue"
+text @revenue_label "Revenue" {
+  use: body
+  x: 490.7
+  y: 183.7
+}
+
+# [auto] label: "$48,250"
+text @revenue_value "$48,250" {
+  use: metric
+  x: 594.9
+  y: 203.6
+}
+
 # [auto] styled: card
 rect @card_users {
   # [auto] label: "Active Users"
@@ -168,21 +171,22 @@ rect @card_users {
     x: 520
     y: 112
   }
-  # [auto] label: "2,847"
-  text @users_value "2,847" {
-    use: metric
-    x: 520
-    y: 136
-  }
   w: 220 h: 120
   use: card
   shadow: (0,2,16,#00000010)
-  x: 516
-  y: 100
+  x: 518.7
+  y: 98.8
   when :hover {
     scale: 1
     ease: spring 200ms
   }
+}
+
+# [auto] label: "2,847"
+text @users_value "2,847" {
+  use: metric
+  x: 1041.6
+  y: 235.9
 }
 
 # [auto] styled: card
@@ -202,8 +206,8 @@ rect @card_tasks {
   w: 220 h: 120
   use: card
   shadow: (0,2,16,#00000010)
-  x: 752
-  y: 100
+  x: 755
+  y: 98.8
   when :hover {
     scale: 1
     ease: spring 200ms
@@ -223,6 +227,8 @@ frame @activity_feed {
   # [auto] label: "Recent Activity"
   text @feed_title "Recent Activity" {
     use: subheading
+    x: 8.4
+    y: 5.8
   }
   rect @activity_1 {
     # [auto] label: "Alice submitted design review"
@@ -255,8 +261,8 @@ frame @activity_feed {
   w: 460 h: 280
   use: card
   shadow: (0,2,16,#00000010)
-  x: 280
-  y: 240
+  x: 278
+  y: 308.8
 }
 
 # ─── Pipeline Status ───


### PR DESCRIPTION
## Summary\n\nAdds `pad:` property to Free-layout frames, so children, text centering, and `place:` positioning all respect padding insets.\n\n## Changes\n\n**Core (`fd-core`)**\n- `model.rs`: `LayoutMode::Free` → `Free { pad: f32 }` with manual `Default` impl\n- `parser.rs`: Standalone `pad:` / `padding:` property + updated layout parse fallback\n- `emitter.rs`: Emits `pad: N` when non-zero (3 match sites updated)\n- `layout.rs`: Content area inset — children default to `(x+pad, y+pad)`, text centering uses `(w-2*pad, h-2*pad)`, `place:` uses padded bounds\n\n**Cross-crate updates**\n- `resolve.rs`, `mermaid.rs` (fd-core): `Free { pad: 0.0 }`\n- `sync.rs` (fd-editor): Extracts pad from Free layout for text max_width\n- `lib.rs` (fd-wasm): `create_node_at` uses `Free { pad: 0.0 }`\n\n**Docs + Demo**\n- `demo.fd`: Sidebar converted to `layout: column gap=8 pad=16`\n- FD format SKILL.md: `pad:` in frame grammar + 2 new best practices\n- CHANGELOG.md: v0.10.67 entry\n- REQUIREMENTS.md: R1.21 + index\n\n## Tests\n\n6 new tests, all passing:\n- `parse_free_frame_pad` / `roundtrip_free_frame_pad` / `parse_free_frame_pad_zero_omitted`\n- `layout_free_frame_pad_insets_children` / `layout_free_frame_pad_text_centered_in_padded_area` / `layout_free_frame_pad_zero_matches_no_pad`\n\n✅ `cargo test --workspace` — all pass\n✅ `cargo clippy -- -D warnings` — clean\n✅ `cargo fmt --check` — clean