### PR TITLE
refactor(core): rename theme→style keyword, Style→Properties struct

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -105,7 +105,7 @@ crates/
 | **Semantic IDs**            | `@login_form` not `@rect_17` — intent over auto-generated names            |
 | **Constraints over coords** | `center_in: canvas` not `x: 400 y: 300` — relationships > pixels           |
 | **Accurate comments**       | `#` for context — wrong comments hurt more than no comments                |
-| **Theme reuse**             | Define `theme` blocks, reference with `use:` — consistency > ad-hoc        |
+| **Style reuse**             | Define `style` blocks, reference with `use:` — consistency > ad-hoc        |
 | **Spec for intent**         | `spec { ... }` metadata (status, priority, accept) — structured > freeform |
 | **Shorthand OK**            | `w:` / `h:` / `#FFF` are fine — unambiguous in context                     |
 

--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -37,7 +37,7 @@ pub fn emit_document(graph: &SceneGraph) -> String {
 
     // Emit style definitions
     if use_separators && has_styles {
-        out.push_str("# ─── Themes ───\n\n");
+        out.push_str("# ─── Styles ───\n\n");
     }
     let mut styles: Vec<_> = graph.styles.iter().collect();
     styles.sort_by_key(|(id, _)| id.as_str().to_string());
@@ -95,9 +95,9 @@ fn indent(out: &mut String, depth: usize) {
     }
 }
 
-fn emit_style_block(out: &mut String, name: &NodeId, style: &Style, depth: usize) {
+fn emit_style_block(out: &mut String, name: &NodeId, style: &Properties, depth: usize) {
     indent(out, depth);
-    writeln!(out, "theme {} {{", name.as_str()).unwrap();
+    writeln!(out, "style {} {{", name.as_str()).unwrap();
 
     if let Some(ref fill) = style.fill {
         emit_paint_prop(out, "fill", fill, depth + 1);
@@ -157,7 +157,7 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
         && node.annotations.is_empty()
         && node.use_styles.is_empty()
         && node.animations.is_empty()
-        && !has_inline_styles(&node.style)
+        && !has_inline_styles(&node.props)
         && !matches!(&node.kind, NodeKind::Image { .. })
     {
         return;
@@ -350,10 +350,10 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
     }
 
     // Inline style properties
-    if let Some(ref fill) = node.style.fill {
+    if let Some(ref fill) = node.props.fill {
         emit_paint_prop(out, "fill", fill, depth + 1);
     }
-    if let Some(ref stroke) = node.style.stroke {
+    if let Some(ref stroke) = node.props.stroke {
         indent(out, depth + 1);
         match &stroke.paint {
             Paint::Solid(c) => {
@@ -362,18 +362,18 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
             _ => writeln!(out, "stroke: #000 {}", format_num(stroke.width)).unwrap(),
         }
     }
-    if let Some(radius) = node.style.corner_radius {
+    if let Some(radius) = node.props.corner_radius {
         indent(out, depth + 1);
         writeln!(out, "corner: {}", format_num(radius)).unwrap();
     }
-    if let Some(ref font) = node.style.font {
+    if let Some(ref font) = node.props.font {
         emit_font_prop(out, font, depth + 1);
     }
-    if let Some(opacity) = node.style.opacity {
+    if let Some(opacity) = node.props.opacity {
         indent(out, depth + 1);
         writeln!(out, "opacity: {}", format_num(opacity)).unwrap();
     }
-    if let Some(ref shadow) = node.style.shadow {
+    if let Some(ref shadow) = node.props.shadow {
         indent(out, depth + 1);
         writeln!(
             out,
@@ -387,13 +387,13 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
     }
 
     // Text alignment
-    if node.style.text_align.is_some() || node.style.text_valign.is_some() {
-        let h = match node.style.text_align {
+    if node.props.text_align.is_some() || node.props.text_valign.is_some() {
+        let h = match node.props.text_align {
             Some(TextAlign::Left) => "left",
             Some(TextAlign::Right) => "right",
             _ => "center",
         };
-        let v = match node.style.text_valign {
+        let v = match node.props.text_valign {
             Some(TextVAlign::Top) => "top",
             Some(TextVAlign::Bottom) => "bottom",
             _ => "middle",
@@ -681,7 +681,7 @@ fn emit_constraint(out: &mut String, node_id: &NodeId, constraint: &Constraint) 
 fn emit_edge_defaults_block(out: &mut String, defaults: &EdgeDefaults) {
     out.push_str("edge_defaults {\n");
 
-    if let Some(ref stroke) = defaults.style.stroke {
+    if let Some(ref stroke) = defaults.props.stroke {
         match &stroke.paint {
             Paint::Solid(c) => {
                 writeln!(out, "  stroke: {} {}", c.to_hex(), format_num(stroke.width)).unwrap();
@@ -691,7 +691,7 @@ fn emit_edge_defaults_block(out: &mut String, defaults: &EdgeDefaults) {
             }
         }
     }
-    if let Some(opacity) = defaults.style.opacity {
+    if let Some(opacity) = defaults.props.opacity {
         writeln!(out, "  opacity: {}", format_num(opacity)).unwrap();
     }
     if let Some(arrow) = defaults.arrow
@@ -754,14 +754,14 @@ fn emit_edge(out: &mut String, edge: &Edge, graph: &SceneGraph, defaults: Option
 
     // Stroke — skip if matches edge_defaults
     let stroke_matches_default = defaults
-        .and_then(|d| d.style.stroke.as_ref())
+        .and_then(|d| d.props.stroke.as_ref())
         .is_some_and(|ds| {
-            edge.style
+            edge.props
                 .stroke
                 .as_ref()
                 .is_some_and(|es| stroke_eq(es, ds))
         });
-    if !stroke_matches_default && let Some(ref stroke) = edge.style.stroke {
+    if !stroke_matches_default && let Some(ref stroke) = edge.props.stroke {
         match &stroke.paint {
             Paint::Solid(c) => {
                 writeln!(out, "  stroke: {} {}", c.to_hex(), format_num(stroke.width)).unwrap();
@@ -773,12 +773,12 @@ fn emit_edge(out: &mut String, edge: &Edge, graph: &SceneGraph, defaults: Option
     }
 
     // Opacity — skip if matches edge_defaults
-    let opacity_matches_default = defaults.and_then(|d| d.style.opacity).is_some_and(|do_| {
-        edge.style
+    let opacity_matches_default = defaults.and_then(|d| d.props.opacity).is_some_and(|do_| {
+        edge.props
             .opacity
             .is_some_and(|eo| (eo - do_).abs() < 0.001)
     });
-    if !opacity_matches_default && let Some(opacity) = edge.style.opacity {
+    if !opacity_matches_default && let Some(opacity) = edge.props.opacity {
         writeln!(out, "  opacity: {}", format_num(opacity)).unwrap();
     }
 
@@ -947,7 +947,7 @@ pub fn emit_filtered(graph: &SceneGraph, mode: ReadMode) -> String {
     let include_constraints = matches!(mode, ReadMode::Layout | ReadMode::Visual);
     let include_edges = matches!(mode, ReadMode::Edges | ReadMode::Visual);
 
-    // Themes (Design and Visual modes)
+    // Styles (Design and Visual modes)
     if include_themes && !graph.styles.is_empty() {
         let mut styles: Vec<_> = graph.styles.iter().collect();
         styles.sort_by_key(|(id, _)| id.as_str().to_string());
@@ -1047,10 +1047,10 @@ fn emit_node_filtered(
             indent(out, depth + 1);
             writeln!(out, "use: {}", style_ref.as_str()).unwrap();
         }
-        if let Some(ref fill) = node.style.fill {
+        if let Some(ref fill) = node.props.fill {
             emit_paint_prop(out, "fill", fill, depth + 1);
         }
-        if let Some(ref stroke) = node.style.stroke {
+        if let Some(ref stroke) = node.props.stroke {
             indent(out, depth + 1);
             match &stroke.paint {
                 Paint::Solid(c) => {
@@ -1059,14 +1059,14 @@ fn emit_node_filtered(
                 _ => writeln!(out, "stroke: #000 {}", format_num(stroke.width)).unwrap(),
             }
         }
-        if let Some(radius) = node.style.corner_radius {
+        if let Some(radius) = node.props.corner_radius {
             indent(out, depth + 1);
             writeln!(out, "corner: {}", format_num(radius)).unwrap();
         }
-        if let Some(ref font) = node.style.font {
+        if let Some(ref font) = node.props.font {
             emit_font_prop(out, font, depth + 1);
         }
-        if let Some(opacity) = node.style.opacity {
+        if let Some(opacity) = node.props.opacity {
             indent(out, depth + 1);
             writeln!(out, "opacity: {}", format_num(opacity)).unwrap();
         }
@@ -1274,7 +1274,7 @@ fn emit_spec_annotations(out: &mut String, annotations: &[Annotation], prefix: &
 }
 
 /// Check if a `Style` has any non-default properties set.
-fn has_inline_styles(style: &Style) -> bool {
+fn has_inline_styles(style: &Properties) -> bool {
     style.fill.is_some()
         || style.stroke.is_some()
         || style.font.is_some()

--- a/crates/fd-core/src/emitter_tests.rs
+++ b/crates/fd-core/src/emitter_tests.rs
@@ -63,7 +63,7 @@ text @title "Hello" {
         NodeKind::Text { content, .. } => assert_eq!(content, "Hello"),
         _ => panic!("expected Text"),
     }
-    let font = node.style.font.as_ref().expect("font missing");
+    let font = node.props.font.as_ref().expect("font missing");
     assert_eq!(font.family, "Inter");
     assert_eq!(font.weight, 700);
     assert_eq!(font.size, 32.0);
@@ -339,7 +339,7 @@ edge @flow {
     let edge = &graph.edges[0];
     assert_eq!(edge.arrow, ArrowKind::Both);
     assert_eq!(edge.curve, CurveKind::Smooth);
-    assert!(edge.style.stroke.is_some());
+    assert!(edge.props.stroke.is_some());
 
     let output = emit_document(&graph);
     let graph2 = parse_document(&output).expect("styled edge roundtrip failed");
@@ -458,8 +458,8 @@ fn parse_generic_with_properties() {
     let graph = parse_document(input).unwrap();
     let card = graph.get_by_id(NodeId::intern("card")).unwrap();
     assert!(matches!(card.kind, NodeKind::Generic));
-    assert!(card.style.fill.is_some());
-    assert_eq!(card.style.corner_radius, Some(8.0));
+    assert!(card.props.fill.is_some());
+    assert_eq!(card.props.corner_radius, Some(8.0));
 }
 
 #[test]
@@ -909,8 +909,8 @@ edge @flow {
     let output = emit_document(&graph);
 
     assert!(
-        output.contains("# ─── Themes ───"),
-        "should have Themes separator"
+        output.contains("# ─── Styles ───"),
+        "should have Styles separator"
     );
     assert!(
         output.contains("# ─── Layout ───"),
@@ -962,10 +962,10 @@ fill: #F5F5F5
 }
 
 #[test]
-fn roundtrip_theme_keyword() {
-    // Verify that `theme` keyword parses and emits correctly
+fn roundtrip_style_keyword() {
+    // Verify that `style` keyword parses and emits correctly
     let input = r#"
-theme accent {
+style accent {
   fill: #6C5CE7
   corner: 12
 }
@@ -978,21 +978,21 @@ rect @btn {
     let graph = parse_document(input).unwrap();
     let output = emit_document(&graph);
 
-    // Emitter should output `theme`, not `style`
+    // Emitter should output `style`, not `theme`
     assert!(
-        output.contains("theme accent"),
-        "should emit `theme` keyword"
+        output.contains("style accent"),
+        "should emit `style` keyword"
     );
     assert!(
-        !output.contains("style accent"),
-        "should NOT emit `style` keyword"
+        !output.contains("theme accent"),
+        "should NOT emit `theme` keyword"
     );
 
     // Round-trip: re-parse emitted output
-    let graph2 = parse_document(&output).expect("re-parse of theme output failed");
+    let graph2 = parse_document(&output).expect("re-parse of style output failed");
     assert!(
         graph2.styles.contains_key(&NodeId::intern("accent")),
-        "theme definition should survive roundtrip"
+        "style definition should survive roundtrip"
     );
 }
 
@@ -1035,10 +1035,10 @@ ease: ease_out 200ms
 }
 
 #[test]
-fn parse_old_style_keyword_compat() {
-    // Old `style` keyword must still be accepted by the parser
+fn parse_old_theme_keyword_compat() {
+    // Old `theme` keyword must still be accepted by the parser
     let input = r#"
-style accent {
+theme accent {
   fill: #6C5CE7
 }
 
@@ -1050,14 +1050,14 @@ rect @btn {
     let graph = parse_document(input).unwrap();
     assert!(
         graph.styles.contains_key(&NodeId::intern("accent")),
-        "old `style` keyword should parse into a theme definition"
+        "old `theme` keyword should parse into a style definition"
     );
 
-    // Emitter should upgrade to `theme`
+    // Emitter should output `style`
     let output = emit_document(&graph);
     assert!(
-        output.contains("theme accent"),
-        "emitter should upgrade `style` to `theme`"
+        output.contains("style accent"),
+        "emitter should output `style` keyword"
     );
 }
 
@@ -1096,12 +1096,12 @@ ease: spring 150ms
 }
 
 #[test]
-fn roundtrip_theme_import() {
-    // Verify that import + theme references work together
+fn roundtrip_style_import() {
+    // Verify that import + style references work together
     let input = r#"
 import "tokens.fd" as tokens
 
-theme card_base {
+style card_base {
   fill: #FFFFFF
   corner: 16
 }
@@ -1114,14 +1114,14 @@ rect @card {
     let graph = parse_document(input).unwrap();
     let output = emit_document(&graph);
 
-    // Both import and theme should appear in output
+    // Both import and style should appear in output
     assert!(
         output.contains("import \"tokens.fd\" as tokens"),
         "import should survive roundtrip"
     );
     assert!(
-        output.contains("theme card_base"),
-        "theme should survive roundtrip"
+        output.contains("style card_base"),
+        "style should survive roundtrip"
     );
 
     // Re-parse
@@ -1129,7 +1129,7 @@ rect @card {
     assert_eq!(graph2.imports.len(), 1, "import count should survive");
     assert!(
         graph2.styles.contains_key(&NodeId::intern("card_base")),
-        "theme def should survive"
+        "style def should survive"
     );
 }
 
@@ -1276,7 +1276,7 @@ rect @grad {
     let graph = parse_document(input).unwrap();
     let node = graph.get_by_id(NodeId::intern("grad")).unwrap();
     assert!(matches!(
-        node.style.fill,
+        node.props.fill,
         Some(Paint::LinearGradient { .. })
     ));
 
@@ -1285,7 +1285,7 @@ rect @grad {
     let graph2 = parse_document(&output).expect("re-parse of linear gradient failed");
     let node2 = graph2.get_by_id(NodeId::intern("grad")).unwrap();
     assert!(matches!(
-        node2.style.fill,
+        node2.props.fill,
         Some(Paint::LinearGradient { .. })
     ));
 }
@@ -1301,7 +1301,7 @@ rect @radial_box {
     let graph = parse_document(input).unwrap();
     let node = graph.get_by_id(NodeId::intern("radial_box")).unwrap();
     assert!(matches!(
-        node.style.fill,
+        node.props.fill,
         Some(Paint::RadialGradient { .. })
     ));
 
@@ -1310,7 +1310,7 @@ rect @radial_box {
     let graph2 = parse_document(&output).expect("re-parse of radial gradient failed");
     let node2 = graph2.get_by_id(NodeId::intern("radial_box")).unwrap();
     assert!(matches!(
-        node2.style.fill,
+        node2.props.fill,
         Some(Paint::RadialGradient { .. })
     ));
 }
@@ -1325,14 +1325,14 @@ rect @shadowed {
 "#;
     let graph = parse_document(input).unwrap();
     let node = graph.get_by_id(NodeId::intern("shadowed")).unwrap();
-    let shadow = node.style.shadow.as_ref().expect("shadow should exist");
+    let shadow = node.props.shadow.as_ref().expect("shadow should exist");
     assert_eq!(shadow.blur, 20.0);
 
     let output = emit_document(&graph);
     assert!(output.contains("shadow:"), "should emit shadow");
     let graph2 = parse_document(&output).expect("re-parse of shadow failed");
     let node2 = graph2.get_by_id(NodeId::intern("shadowed")).unwrap();
-    let shadow2 = node2.style.shadow.as_ref().expect("shadow should survive");
+    let shadow2 = node2.props.shadow.as_ref().expect("shadow should survive");
     assert_eq!(shadow2.offset_y, 4.0);
     assert_eq!(shadow2.blur, 20.0);
 }
@@ -1348,12 +1348,12 @@ rect @faded {
 "#;
     let graph = parse_document(input).unwrap();
     let node = graph.get_by_id(NodeId::intern("faded")).unwrap();
-    assert_eq!(node.style.opacity, Some(0.5));
+    assert_eq!(node.props.opacity, Some(0.5));
 
     let output = emit_document(&graph);
     let graph2 = parse_document(&output).expect("re-parse of opacity failed");
     let node2 = graph2.get_by_id(NodeId::intern("faded")).unwrap();
-    assert_eq!(node2.style.opacity, Some(0.5));
+    assert_eq!(node2.props.opacity, Some(0.5));
 }
 
 #[test]
@@ -1546,7 +1546,7 @@ fn emit_filtered_layout() {
     assert!(out.contains("x: 20"), "should include position");
     // Should NOT have styles or anims
     assert!(!out.contains("fill:"), "no fill in layout mode");
-    assert!(!out.contains("theme"), "no theme in layout mode");
+    assert!(!out.contains("style"), "no style in layout mode");
     assert!(!out.contains("when :hover"), "no when in layout mode");
 }
 
@@ -1555,7 +1555,7 @@ fn emit_filtered_design() {
     let graph = make_test_graph();
     let out = emit_filtered(&graph, ReadMode::Design);
     // Should have themes + styles
-    assert!(out.contains("theme accent"), "should include theme");
+    assert!(out.contains("style accent"), "should include style");
     assert!(out.contains("use: accent"), "should include use ref");
     assert!(out.contains("fill:"), "should include fill");
     assert!(out.contains("corner: 12"), "should include corner");
@@ -1583,7 +1583,7 @@ fn emit_filtered_visual() {
     let graph = make_test_graph();
     let out = emit_filtered(&graph, ReadMode::Visual);
     // Visual = Layout + Design + When
-    assert!(out.contains("theme accent"), "should include theme");
+    assert!(out.contains("style accent"), "should include style");
     assert!(out.contains("layout: column"), "should include layout");
     assert!(out.contains("w: 200 h: 100"), "should include dims");
     assert!(out.contains("fill:"), "should include fill");
@@ -1657,8 +1657,8 @@ edge @link {
 
     // Separators should exist
     assert!(
-        pass1.contains("# ─── Themes ───"),
-        "pass 1 should have Themes separator: {pass1}"
+        pass1.contains("# ─── Styles ───"),
+        "pass 1 should have Styles separator: {pass1}"
     );
     assert!(
         pass1.contains("# ─── Layout ───"),
@@ -1670,10 +1670,10 @@ edge @link {
     let pass2 = emit_document(&graph2);
 
     // Count occurrences — must be exactly 1 each
-    let themes_count = pass2.matches("# ─── Themes ───").count();
+    let styles_count = pass2.matches("# ─── Styles ───").count();
     let layout_count = pass2.matches("# ─── Layout ───").count();
     let flows_count = pass2.matches("# ─── Flows ───").count();
-    assert_eq!(themes_count, 1, "Themes separator duplicated: {pass2}");
+    assert_eq!(styles_count, 1, "Styles separator duplicated: {pass2}");
     assert_eq!(layout_count, 1, "Layout separator duplicated: {pass2}");
     assert_eq!(flows_count, 1, "Flows separator duplicated: {pass2}");
 
@@ -1952,8 +1952,8 @@ image @styled_img {
 "#;
     let graph = parse_document(input).unwrap();
     let node = graph.get_by_id(NodeId::intern("styled_img")).unwrap();
-    assert_eq!(node.style.corner_radius, Some(12.0));
-    assert_eq!(node.style.opacity, Some(0.8));
+    assert_eq!(node.props.corner_radius, Some(12.0));
+    assert_eq!(node.props.opacity, Some(0.8));
 
     let output = emit_document(&graph);
     assert!(output.contains("corner: 12"));
@@ -1962,8 +1962,8 @@ image @styled_img {
 
     let graph2 = parse_document(&output).unwrap();
     let node2 = graph2.get_by_id(NodeId::intern("styled_img")).unwrap();
-    assert_eq!(node2.style.corner_radius, Some(12.0));
-    assert_eq!(node2.style.opacity, Some(0.8));
+    assert_eq!(node2.props.corner_radius, Some(12.0));
+    assert_eq!(node2.props.opacity, Some(0.8));
     match &node2.kind {
         NodeKind::Image { fit, .. } => assert_eq!(*fit, ImageFit::Fill),
         _ => panic!("expected Image"),
@@ -2027,7 +2027,7 @@ edge @link {
         .edge_defaults
         .as_ref()
         .expect("should have edge_defaults");
-    assert!(defaults.style.stroke.is_some());
+    assert!(defaults.props.stroke.is_some());
     assert_eq!(defaults.arrow, Some(ArrowKind::End));
     assert_eq!(defaults.curve, Some(CurveKind::Smooth));
 }
@@ -2111,7 +2111,7 @@ edge @bc {
     // bc edge should still have its own stroke/arrow
     let bc = graph2.edges.iter().find(|e| e.id.as_str() == "bc").unwrap();
     assert_eq!(bc.arrow, ArrowKind::Both);
-    assert!(bc.style.stroke.is_some());
+    assert!(bc.props.stroke.is_some());
 }
 
 // ─── F5: ReadMode::Diff tests ───────────────────────────────────────────

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -498,7 +498,7 @@ fn intrinsic_size(node: &SceneNode) -> (f32, f32) {
         NodeKind::Text {
             content, max_width, ..
         } => {
-            let font_size = node.style.font.as_ref().map_or(14.0, |f| f.size);
+            let font_size = node.props.font.as_ref().map_or(14.0, |f| f.size);
             let char_width = font_size * 0.6;
             let total_w = content.chars().count() as f32 * char_width;
             let line_height = font_size * 1.4;

--- a/crates/fd-core/src/mermaid.rs
+++ b/crates/fd-core/src/mermaid.rs
@@ -536,7 +536,7 @@ fn build_scene_graph(
                 clip: false,
                 layout: LayoutMode::Free { pad: 0.0 },
             },
-            style: Style {
+            props: Properties {
                 fill: Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0))),
                 corner_radius: Some(12.0),
                 stroke: Some(Stroke {
@@ -545,7 +545,7 @@ fn build_scene_graph(
                     cap: StrokeCap::Round,
                     join: StrokeJoin::Round,
                 }),
-                ..Style::default()
+                ..Properties::default()
             },
             use_styles: Default::default(),
             constraints: smallvec::smallvec![Constraint::Position {
@@ -641,7 +641,7 @@ fn build_scene_graph(
         let scene_node = SceneNode {
             id: fd_id,
             kind,
-            style: Style {
+            props: Properties {
                 fill: Some(Paint::Solid(Color::rgba(0.93, 0.95, 1.0, 1.0))),
                 stroke: Some(Stroke {
                     paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.3, 1.0)),
@@ -650,7 +650,7 @@ fn build_scene_graph(
                     join: StrokeJoin::Round,
                 }),
                 corner_radius,
-                ..Style::default()
+                ..Properties::default()
             },
             use_styles: Default::default(),
             constraints: smallvec::smallvec![Constraint::Position { x: rel_x, y: rel_y }],
@@ -672,14 +672,14 @@ fn build_scene_graph(
                     content: mnode.label.clone(),
                     max_width: None,
                 },
-                style: Style {
+                props: Properties {
                     font: Some(FontSpec {
                         family: "Inter".into(),
                         weight: 500,
                         size: 14.0,
                     }),
                     fill: Some(Paint::Solid(Color::rgba(0.1, 0.1, 0.15, 1.0))),
-                    ..Style::default()
+                    ..Properties::default()
                 },
                 use_styles: Default::default(),
                 constraints: Default::default(),
@@ -724,14 +724,14 @@ fn build_scene_graph(
                     content: label_text.clone(),
                     max_width: None,
                 },
-                style: Style {
+                props: Properties {
                     font: Some(FontSpec {
                         family: "Inter".into(),
                         weight: 400,
                         size: 12.0,
                     }),
                     fill: Some(Paint::Solid(Color::rgba(0.3, 0.3, 0.4, 1.0))),
-                    ..Style::default()
+                    ..Properties::default()
                 },
                 use_styles: Default::default(),
                 constraints: Default::default(),
@@ -751,7 +751,7 @@ fn build_scene_graph(
             from: EdgeAnchor::Node(from_id),
             to: EdgeAnchor::Node(to_id),
             text_child,
-            style: Style::default(),
+            props: Properties::default(),
             use_styles: Default::default(),
             arrow,
             curve: CurveKind::Smooth,
@@ -806,7 +806,7 @@ mod tests {
         let graph = parse_mermaid(input).unwrap();
         let a = graph.get_by_id(NodeId::intern("A")).unwrap();
         // Rounded gets corner_radius=30
-        assert_eq!(a.style.corner_radius, Some(30.0));
+        assert_eq!(a.props.corner_radius, Some(30.0));
     }
 
     #[test]

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -269,7 +269,7 @@ pub enum VPlace {
 
 /// A reusable theme set that nodes can reference via `use: theme_name`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Style {
+pub struct Properties {
     pub fill: Option<Paint>,
     pub stroke: Option<Stroke>,
     pub font: Option<FontSpec>,
@@ -419,7 +419,7 @@ impl EdgeAnchor {
 /// with many similarly styled edges.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EdgeDefaults {
-    pub style: Style,
+    pub props: Properties,
     pub arrow: Option<ArrowKind>,
     pub curve: Option<CurveKind>,
 }
@@ -432,7 +432,7 @@ pub struct Edge {
     pub to: EdgeAnchor,
     /// Optional text child node (max 1). The node lives in the SceneGraph.
     pub text_child: Option<NodeId>,
-    pub style: Style,
+    pub props: Properties,
     pub use_styles: SmallVec<[NodeId; 2]>,
     pub arrow: ArrowKind,
     pub curve: CurveKind,
@@ -556,7 +556,7 @@ pub struct SceneNode {
     pub kind: NodeKind,
 
     /// Inline style overrides on this node.
-    pub style: Style,
+    pub props: Properties,
 
     /// Named theme references (`use: base_text`).
     pub use_styles: SmallVec<[NodeId; 2]>,
@@ -584,7 +584,7 @@ impl SceneNode {
         Self {
             id,
             kind,
-            style: Style::default(),
+            props: Properties::default(),
             use_styles: SmallVec::new(),
             constraints: SmallVec::new(),
             animations: SmallVec::new(),
@@ -624,7 +624,7 @@ pub struct SceneGraph {
     pub root: NodeIndex,
 
     /// Named theme definitions (`theme base_text { ... }`).
-    pub styles: HashMap<NodeId, Style>,
+    pub styles: HashMap<NodeId, Properties>,
 
     /// Index from NodeId → NodeIndex for fast lookup.
     pub id_index: HashMap<NodeId, NodeIndex>,
@@ -838,13 +838,13 @@ impl SceneGraph {
     }
 
     /// Define a named style.
-    pub fn define_style(&mut self, name: NodeId, style: Style) {
+    pub fn define_style(&mut self, name: NodeId, style: Properties) {
         self.styles.insert(name, style);
     }
 
     /// Resolve a node's effective style (merging `use` references + inline overrides + active animations).
-    pub fn resolve_style(&self, node: &SceneNode, active_triggers: &[AnimTrigger]) -> Style {
-        let mut resolved = Style::default();
+    pub fn resolve_style(&self, node: &SceneNode, active_triggers: &[AnimTrigger]) -> Properties {
+        let mut resolved = Properties::default();
 
         // Apply referenced styles in order
         for style_id in &node.use_styles {
@@ -854,7 +854,7 @@ impl SceneGraph {
         }
 
         // Apply inline overrides (take precedence)
-        merge_style(&mut resolved, &node.style);
+        merge_style(&mut resolved, &node.props);
 
         // Apply active animation state overrides
         for anim in &node.animations {
@@ -884,14 +884,18 @@ impl SceneGraph {
     }
 
     /// Resolve an edge's effective style (merging `use` references + inline overrides + active animations).
-    pub fn resolve_style_for_edge(&self, edge: &Edge, active_triggers: &[AnimTrigger]) -> Style {
-        let mut resolved = Style::default();
+    pub fn resolve_style_for_edge(
+        &self,
+        edge: &Edge,
+        active_triggers: &[AnimTrigger],
+    ) -> Properties {
+        let mut resolved = Properties::default();
         for style_id in &edge.use_styles {
             if let Some(base) = self.styles.get(style_id) {
                 merge_style(&mut resolved, base);
             }
         }
-        merge_style(&mut resolved, &edge.style);
+        merge_style(&mut resolved, &edge.props);
 
         for anim in &edge.animations {
             if active_triggers.contains(&anim.trigger) {
@@ -993,7 +997,7 @@ impl Default for SceneGraph {
 }
 
 /// Merge `src` style into `dst`, overwriting only `Some` fields.
-fn merge_style(dst: &mut Style, src: &Style) {
+fn merge_style(dst: &mut Properties, src: &Properties) {
     if src.fill.is_some() {
         dst.fill = src.fill.clone();
     }
@@ -1089,7 +1093,7 @@ mod tests {
         let mut sg = SceneGraph::new();
         sg.define_style(
             NodeId::intern("base"),
-            Style {
+            Properties {
                 fill: Some(Paint::Solid(Color::rgba(0.0, 0.0, 0.0, 1.0))),
                 font: Some(FontSpec {
                     family: "Inter".into(),
@@ -1108,7 +1112,7 @@ mod tests {
             },
         );
         node.use_styles.push(NodeId::intern("base"));
-        node.style.font = Some(FontSpec {
+        node.props.font = Some(FontSpec {
             family: "Inter".into(),
             weight: 700,
             size: 24.0,
@@ -1128,7 +1132,7 @@ mod tests {
         let mut sg = SceneGraph::new();
         sg.define_style(
             NodeId::intern("centered"),
-            Style {
+            Properties {
                 text_align: Some(TextAlign::Center),
                 text_valign: Some(TextVAlign::Middle),
                 ..Default::default()
@@ -1144,7 +1148,7 @@ mod tests {
             },
         );
         node.use_styles.push(NodeId::intern("centered"));
-        node.style.text_align = Some(TextAlign::Right);
+        node.props.text_align = Some(TextAlign::Right);
 
         let resolved = sg.resolve_style(&node, &[]);
         // Horizontal should be overridden to Right
@@ -1351,7 +1355,7 @@ mod tests {
                 height: 40.0,
             },
         );
-        node.style.fill = Some(Paint::Solid(Color::rgba(1.0, 0.0, 0.0, 1.0)));
+        node.props.fill = Some(Paint::Solid(Color::rgba(1.0, 0.0, 0.0, 1.0)));
         node.animations.push(AnimKeyframe {
             trigger: AnimTrigger::Press,
             duration_ms: 100,

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -86,7 +86,7 @@ pub fn parse_document(input: &str) -> Result<SceneGraph, String> {
                         content,
                         max_width: None,
                     },
-                    style: crate::model::Style::default(),
+                    props: crate::model::Properties::default(),
                     use_styles: Default::default(),
                     constraints: Default::default(),
                     annotations: Vec::new(),
@@ -163,7 +163,7 @@ fn is_generic_node_start(s: &str) -> bool {
 struct ParsedNode {
     id: NodeId,
     kind: NodeKind,
-    style: Style,
+    props: Properties,
     use_styles: Vec<NodeId>,
     constraints: Vec<Constraint>,
     animations: Vec<AnimKeyframe>,
@@ -181,7 +181,7 @@ fn insert_node_recursive(
     parsed: ParsedNode,
 ) {
     let mut node = SceneNode::new(parsed.id, parsed.kind);
-    node.style = parsed.style;
+    node.props = parsed.props;
     node.use_styles.extend(parsed.use_styles);
     node.constraints.extend(parsed.constraints);
     node.animations.extend(parsed.animations);
@@ -218,6 +218,7 @@ fn parse_import_line(input: &mut &str) -> ModalResult<Import> {
 /// Section separators emitted automatically by the emitter.
 /// These are skipped during parsing to avoid duplication on round-trip.
 const SECTION_SEPARATORS: &[&str] = &[
+    "─── Styles ───",
     "─── Themes ───",
     "─── Layout ───",
     "─── Constraints ───",
@@ -399,14 +400,14 @@ fn parse_spec_item(input: &mut &str) -> ModalResult<Annotation> {
 
 // ─── Style block parser ─────────────────────────────────────────────────
 
-fn parse_style_block(input: &mut &str) -> ModalResult<(NodeId, Style)> {
+fn parse_style_block(input: &mut &str) -> ModalResult<(NodeId, Properties)> {
     let _ = alt(("theme", "style")).parse_next(input)?;
     let _ = space1.parse_next(input)?;
     let name = parse_identifier.map(NodeId::intern).parse_next(input)?;
     skip_space(input);
     let _ = '{'.parse_next(input)?;
 
-    let mut style = Style::default();
+    let mut style = Properties::default();
     skip_ws_and_comments(input);
 
     while !input.starts_with('}') {
@@ -418,7 +419,7 @@ fn parse_style_block(input: &mut &str) -> ModalResult<(NodeId, Style)> {
     Ok((name, style))
 }
 
-fn parse_style_property(input: &mut &str, style: &mut Style) -> ModalResult<()> {
+fn parse_style_property(input: &mut &str, style: &mut Properties) -> ModalResult<()> {
     let prop_name = parse_identifier.parse_next(input)?;
     skip_space(input);
     let _ = ':'.parse_next(input)?;
@@ -468,7 +469,7 @@ fn weight_name_to_number(name: &str) -> Option<u16> {
     }
 }
 
-fn parse_font_value(input: &mut &str, style: &mut Style) -> ModalResult<()> {
+fn parse_font_value(input: &mut &str, style: &mut Properties) -> ModalResult<()> {
     let mut font = style.font.clone().unwrap_or_default();
 
     if input.starts_with('"') {
@@ -553,7 +554,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     skip_space(input);
     let _ = '{'.parse_next(input)?;
 
-    let mut style = Style::default();
+    let mut style = Properties::default();
     let mut use_styles = Vec::new();
     let mut constraints = Vec::new();
     let mut animations = Vec::new();
@@ -639,7 +640,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     Ok(ParsedNode {
         id,
         kind,
-        style,
+        props: style,
         use_styles,
         constraints,
         animations,
@@ -766,7 +767,7 @@ fn parse_gradient_stops(input: &mut &str) -> ModalResult<Vec<GradientStop>> {
 #[allow(clippy::too_many_arguments)]
 fn parse_node_property(
     input: &mut &str,
-    style: &mut Style,
+    style: &mut Properties,
     use_styles: &mut Vec<NodeId>,
     constraints: &mut Vec<Constraint>,
     width: &mut Option<f32>,
@@ -1057,7 +1058,7 @@ fn parse_node_property(
 
 // ─── Alignment value parser ──────────────────────────────────────────────
 
-fn parse_align_value(input: &mut &str, style: &mut Style) -> ModalResult<()> {
+fn parse_align_value(input: &mut &str, style: &mut Properties) -> ModalResult<()> {
     use crate::model::{TextAlign, TextVAlign};
 
     let first = parse_identifier.parse_next(input)?;
@@ -1273,7 +1274,7 @@ fn parse_edge_defaults_block(input: &mut &str) -> ModalResult<EdgeDefaults> {
                 let color = parse_hex_color.parse_next(input)?;
                 skip_space(input);
                 let w = parse_number.parse_next(input).unwrap_or(1.0);
-                defaults.style.stroke = Some(Stroke {
+                defaults.props.stroke = Some(Stroke {
                     paint: Paint::Solid(color),
                     width: w,
                     ..Stroke::default()
@@ -1299,7 +1300,7 @@ fn parse_edge_defaults_block(input: &mut &str) -> ModalResult<EdgeDefaults> {
                 });
             }
             "opacity" => {
-                defaults.style.opacity = Some(parse_number.parse_next(input)?);
+                defaults.props.opacity = Some(parse_number.parse_next(input)?);
             }
             _ => {
                 let _ = take_till::<_, _, ContextError>(0.., |c: char| {
@@ -1335,7 +1336,7 @@ fn parse_edge_block(input: &mut &str) -> ModalResult<(Edge, Option<(NodeId, Stri
     let mut to = None;
     let mut text_child = None;
     let mut text_child_content = None; // (NodeId, content_string)
-    let mut style = Style::default();
+    let mut style = Properties::default();
     let mut use_styles = Vec::new();
     let mut arrow = ArrowKind::None;
     let mut curve = CurveKind::Straight;
@@ -1468,7 +1469,7 @@ fn parse_edge_block(input: &mut &str) -> ModalResult<(Edge, Option<(NodeId, Stri
             from: from.unwrap_or(EdgeAnchor::Point(0.0, 0.0)),
             to: to.unwrap_or(EdgeAnchor::Point(0.0, 0.0)),
             text_child,
-            style,
+            props: style,
             use_styles: use_styles.into(),
             arrow,
             curve,

--- a/crates/fd-core/src/parser_tests.rs
+++ b/crates/fd-core/src/parser_tests.rs
@@ -22,7 +22,7 @@ rect @box {
         }
         _ => panic!("expected Rect"),
     }
-    assert!(node.style.fill.is_some());
+    assert!(node.props.fill.is_some());
 }
 
 #[test]
@@ -182,8 +182,8 @@ text @greeting "Hello World" {
         }
         _ => panic!("expected Text"),
     }
-    assert!(node.style.font.is_some());
-    let font = node.style.font.as_ref().unwrap();
+    assert!(node.props.font.is_some());
+    let font = node.props.font.as_ref().unwrap();
     assert_eq!(font.family, "Inter");
     assert_eq!(font.weight, 600);
     assert_eq!(font.size, 24.0);
@@ -199,8 +199,8 @@ rect @bordered {
 "#;
     let graph = parse_document(input).expect("stroke should parse");
     let node = graph.get_by_id(NodeId::intern("bordered")).unwrap();
-    assert!(node.style.stroke.is_some());
-    let stroke = node.style.stroke.as_ref().unwrap();
+    assert!(node.props.stroke.is_some());
+    let stroke = node.props.stroke.as_ref().unwrap();
     assert_eq!(stroke.width, 2.0);
 }
 
@@ -315,9 +315,9 @@ text @title "Hello" {
     let node = graph
         .get_by_id(crate::id::NodeId::intern("title"))
         .expect("node not found");
-    assert_eq!(node.style.text_align, Some(crate::model::TextAlign::Right));
+    assert_eq!(node.props.text_align, Some(crate::model::TextAlign::Right));
     assert_eq!(
-        node.style.text_valign,
+        node.props.text_valign,
         Some(crate::model::TextVAlign::Bottom)
     );
 
@@ -329,9 +329,9 @@ text @title "Hello" {
     let node2 = reparsed
         .get_by_id(crate::id::NodeId::intern("title"))
         .expect("node not found after roundtrip");
-    assert_eq!(node2.style.text_align, Some(crate::model::TextAlign::Right));
+    assert_eq!(node2.props.text_align, Some(crate::model::TextAlign::Right));
     assert_eq!(
-        node2.style.text_valign,
+        node2.props.text_valign,
         Some(crate::model::TextVAlign::Bottom)
     );
 }
@@ -347,9 +347,9 @@ text @heading "Welcome" {
     let node = graph
         .get_by_id(crate::id::NodeId::intern("heading"))
         .expect("node not found");
-    assert_eq!(node.style.text_align, Some(crate::model::TextAlign::Center));
+    assert_eq!(node.props.text_align, Some(crate::model::TextAlign::Center));
     // Vertical not specified — should be None
-    assert_eq!(node.style.text_valign, None);
+    assert_eq!(node.props.text_valign, None);
 }
 
 #[test]
@@ -406,7 +406,7 @@ text @heading "Hello" {
     let node = graph
         .get_by_id(crate::id::NodeId::intern("heading"))
         .unwrap();
-    let font = node.style.font.as_ref().unwrap();
+    let font = node.props.font.as_ref().unwrap();
     assert_eq!(font.weight, 700);
     assert_eq!(font.size, 24.0);
 }
@@ -418,7 +418,7 @@ fn parse_font_weight_semibold() {
     let font = graph
         .get_by_id(crate::id::NodeId::intern("t"))
         .unwrap()
-        .style
+        .props
         .font
         .as_ref()
         .unwrap();
@@ -432,7 +432,7 @@ fn parse_named_color() {
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("r")).unwrap();
     assert!(
-        node.style.fill.is_some(),
+        node.props.fill.is_some(),
         "fill should be set from named color"
     );
 }
@@ -442,7 +442,7 @@ fn parse_named_color_blue() {
     let src = r#"rect @box { w: 50 h: 50 fill: blue }"#;
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("box")).unwrap();
-    if let Some(crate::model::Paint::Solid(c)) = &node.style.fill {
+    if let Some(crate::model::Paint::Solid(c)) = &node.props.fill {
         assert_eq!(c.to_hex(), "#3B82F6");
     } else {
         panic!("expected solid fill from named color");
@@ -454,7 +454,7 @@ fn parse_property_alias_background() {
     let src = r#"rect @r { w: 100 h: 50 background: #FF0000 }"#;
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("r")).unwrap();
-    assert!(node.style.fill.is_some(), "background: should map to fill");
+    assert!(node.props.fill.is_some(), "background: should map to fill");
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn parse_property_alias_rounded() {
     let src = r#"rect @r { w: 100 h: 50 rounded: 12 }"#;
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("r")).unwrap();
-    assert_eq!(node.style.corner_radius, Some(12.0));
+    assert_eq!(node.props.corner_radius, Some(12.0));
 }
 
 #[test]
@@ -470,7 +470,7 @@ fn parse_property_alias_radius() {
     let src = r#"rect @r { w: 100 h: 50 radius: 8 }"#;
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("r")).unwrap();
-    assert_eq!(node.style.corner_radius, Some(8.0));
+    assert_eq!(node.props.corner_radius, Some(8.0));
 }
 
 #[test]
@@ -491,7 +491,7 @@ fn parse_corner_px_suffix() {
     let src = r#"rect @r { w: 100 h: 50 corner: 10px }"#;
     let graph = parse_document(src).unwrap();
     let node = graph.get_by_id(crate::id::NodeId::intern("r")).unwrap();
-    assert_eq!(node.style.corner_radius, Some(10.0));
+    assert_eq!(node.props.corner_radius, Some(10.0));
 }
 
 #[test]
@@ -507,7 +507,7 @@ fn roundtrip_font_weight_name() {
     let font = reparsed
         .get_by_id(crate::id::NodeId::intern("t"))
         .unwrap()
-        .style
+        .props
         .font
         .as_ref()
         .unwrap();
@@ -526,7 +526,7 @@ fn roundtrip_named_color() {
         reparsed
             .get_by_id(crate::id::NodeId::intern("r"))
             .unwrap()
-            .style
+            .props
             .fill
             .is_some()
     );
@@ -548,8 +548,8 @@ fn roundtrip_property_aliases() {
     );
     let reparsed = parse_document(&emitted).unwrap();
     let node = reparsed.get_by_id(crate::id::NodeId::intern("r")).unwrap();
-    assert!(node.style.fill.is_some());
-    assert_eq!(node.style.corner_radius, Some(12.0));
+    assert!(node.props.fill.is_some());
+    assert_eq!(node.props.corner_radius, Some(12.0));
 }
 
 #[test]

--- a/crates/fd-core/src/transform.rs
+++ b/crates/fd-core/src/transform.rs
@@ -4,7 +4,7 @@
 //! Passes are applied by `format_document` in `format.rs` based on `FormatConfig`.
 
 use crate::id::NodeId;
-use crate::model::{NodeKind, Paint, SceneGraph, SceneNode, Style};
+use crate::model::{NodeKind, Paint, Properties, SceneGraph, SceneNode};
 use std::collections::HashMap;
 
 // ─── Dedup use-styles ─────────────────────────────────────────────────────
@@ -33,25 +33,25 @@ fn dedup_use_on_node(node: &mut SceneNode) {
 
 /// Promote repeated identical inline styles into top-level `style {}` blocks.
 ///
-/// Any two or more nodes that share the same inline `Style` fingerprint will
+/// Any two or more nodes that share the same inline `Properties` fingerprint will
 /// have their inline style replaced with a `use:` reference to a shared
 /// style block. Comment-preservation is guaranteed: only `style` and
 /// `use_styles` fields change, never node ordering or comments.
 ///
 /// New style names use the pattern `_auto_N`.
 pub fn hoist_styles(graph: &mut SceneGraph) {
-    // Build fingerprint → (list of node indices, example Style) map.
-    let mut fp_map: HashMap<String, (Vec<petgraph::graph::NodeIndex>, Style)> = HashMap::new();
+    // Build fingerprint → (list of node indices, example Properties) map.
+    let mut fp_map: HashMap<String, (Vec<petgraph::graph::NodeIndex>, Properties)> = HashMap::new();
 
     for idx in graph.graph.node_indices() {
         let node = &graph.graph[idx];
-        if is_style_empty(&node.style) {
+        if is_style_empty(&node.props) {
             continue;
         }
-        let fp = style_fingerprint(&node.style);
+        let fp = style_fingerprint(&node.props);
         let entry = fp_map
             .entry(fp)
-            .or_insert_with(|| (Vec::new(), node.style.clone()));
+            .or_insert_with(|| (Vec::new(), node.props.clone()));
         entry.0.push(idx);
     }
 
@@ -67,7 +67,7 @@ pub fn hoist_styles(graph: &mut SceneGraph) {
 
         for &idx in indices {
             let node = &mut graph.graph[idx];
-            node.style = Style::default();
+            node.props = Properties::default();
             if !node.use_styles.contains(&style_name) {
                 node.use_styles.insert(0, style_name);
             }
@@ -75,10 +75,10 @@ pub fn hoist_styles(graph: &mut SceneGraph) {
     }
 }
 
-// ─── Style fingerprint ────────────────────────────────────────────────────
+// ─── Properties fingerprint ────────────────────────────────────────────────────
 
-/// A deterministic string key for a Style, used for deduplication during hoisting.
-fn style_fingerprint(style: &Style) -> String {
+/// A deterministic string key for a Properties, used for deduplication during hoisting.
+fn style_fingerprint(style: &Properties) -> String {
     let mut parts = Vec::new();
 
     if let Some(ref fill) = style.fill {
@@ -138,7 +138,7 @@ fn paint_key(paint: &Paint) -> String {
     }
 }
 
-fn is_style_empty(style: &Style) -> bool {
+fn is_style_empty(style: &Properties) -> bool {
     style.fill.is_none()
         && style.stroke.is_none()
         && style.font.is_none()
@@ -275,11 +275,11 @@ rect @box_b {
 
         // Inline style should be cleared
         assert!(
-            box_a.style.fill.is_none(),
+            box_a.props.fill.is_none(),
             "inline fill should be cleared after hoist"
         );
         assert!(
-            box_b.style.fill.is_none(),
+            box_b.props.fill.is_none(),
             "inline fill should be cleared after hoist"
         );
     }

--- a/crates/fd-core/tests/parse_emit_roundtrip.rs
+++ b/crates/fd-core/tests/parse_emit_roundtrip.rs
@@ -219,7 +219,7 @@ rect @hero {
     let id = NodeId::intern("hero");
     let n2 = graph2.get_by_id(id).unwrap();
     assert!(
-        matches!(&n2.style.fill, Some(Paint::LinearGradient { .. })),
+        matches!(&n2.props.fill, Some(Paint::LinearGradient { .. })),
         "LinearGradient fill lost after round-trip.\nEmitted:\n{emitted}"
     );
 }
@@ -239,7 +239,7 @@ ellipse @glow {
     let id = NodeId::intern("glow");
     let n2 = graph2.get_by_id(id).unwrap();
     assert!(
-        matches!(&n2.style.fill, Some(Paint::RadialGradient { .. })),
+        matches!(&n2.props.fill, Some(Paint::RadialGradient { .. })),
         "RadialGradient fill lost after round-trip.\nEmitted:\n{emitted}"
     );
 }
@@ -260,7 +260,7 @@ rect @card {
     let id = NodeId::intern("card");
     let n2 = graph2.get_by_id(id).unwrap();
     let shadow = n2
-        .style
+        .props
         .shadow
         .as_ref()
         .unwrap_or_else(|| panic!("shadow lost after round-trip.\nEmitted:\n{emitted}"));

--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -266,7 +266,7 @@ fn compute_inverse(engine: &SyncEngine, mutation: &GraphMutation) -> GraphMutati
             let old_style = engine
                 .graph
                 .get_by_id(*id)
-                .map(|n| n.style.clone())
+                .map(|n| n.props.clone())
                 .unwrap_or_default();
             GraphMutation::SetStyle {
                 id: *id,
@@ -520,7 +520,7 @@ rect @box {
             .graph
             .get_by_id(NodeId::intern("r"))
             .unwrap()
-            .style
+            .props
             .fill
         {
             Some(fd_core::model::Paint::Solid(c)) => c.to_hex(),
@@ -532,7 +532,7 @@ rect @box {
             .graph
             .get_by_id(NodeId::intern("r"))
             .unwrap()
-            .style
+            .props
             .clone();
         new_style.fill = Some(fd_core::model::Paint::Solid(fd_core::model::Color {
             r: 0.0,
@@ -554,7 +554,7 @@ rect @box {
             .graph
             .get_by_id(NodeId::intern("r"))
             .unwrap()
-            .style
+            .props
             .fill
         {
             Some(fd_core::model::Paint::Solid(c)) => c.to_hex(),
@@ -567,7 +567,7 @@ rect @box {
             .graph
             .get_by_id(NodeId::intern("r"))
             .unwrap()
-            .style
+            .props
             .fill
         {
             Some(fd_core::model::Paint::Solid(c)) => c.to_hex(),

--- a/crates/fd-editor/src/sync.rs
+++ b/crates/fd-editor/src/sync.rs
@@ -301,7 +301,7 @@ impl SyncEngine {
             }
             GraphMutation::SetStyle { id, style } => {
                 if let Some(node) = self.graph.get_by_id_mut(id) {
-                    node.style = style;
+                    node.props = style;
                 }
             }
             GraphMutation::SetText { id, content } => {
@@ -585,7 +585,7 @@ impl SyncEngine {
 
         if let NodeKind::Text { content, .. } = child_kind {
             let font_size = self.graph.graph[child_idx]
-                .style
+                .props
                 .font
                 .as_ref()
                 .map_or(14.0, |f| f.size);
@@ -759,7 +759,7 @@ fn handle_child_group_relationship(
     if let NodeKind::Text { content, .. } = child_kind {
         // Use same heuristic as intrinsic_size() in layout.rs
         let font_size = graph.graph[child_idx]
-            .style
+            .props
             .font
             .as_ref()
             .map_or(14.0, |f| f.size);
@@ -958,7 +958,7 @@ pub enum GraphMutation {
     },
     SetStyle {
         id: NodeId,
-        style: Style,
+        style: Properties,
     },
     SetText {
         id: NodeId,

--- a/crates/fd-editor/src/sync_tests.rs
+++ b/crates/fd-editor/src/sync_tests.rs
@@ -384,8 +384,8 @@ text @heading "Hello" {
 
     // Verify no alignment initially
     let node = engine.graph.get_by_id(NodeId::intern("heading")).unwrap();
-    assert!(node.style.text_align.is_none());
-    assert!(node.style.text_valign.is_none());
+    assert!(node.props.text_align.is_none());
+    assert!(node.props.text_valign.is_none());
 
     // Apply SetStyle mutation with alignment
     let mut style = engine.graph.resolve_style(node, &[]);
@@ -399,8 +399,8 @@ text @heading "Hello" {
 
     // Verify graph updated
     let node = engine.graph.get_by_id(NodeId::intern("heading")).unwrap();
-    assert_eq!(node.style.text_align, Some(TextAlign::Right));
-    assert_eq!(node.style.text_valign, Some(TextVAlign::Bottom));
+    assert_eq!(node.props.text_align, Some(TextAlign::Right));
+    assert_eq!(node.props.text_valign, Some(TextVAlign::Bottom));
 
     // Verify text output contains align property
     assert!(
@@ -412,8 +412,8 @@ text @heading "Hello" {
     // Verify round-trip
     let engine2 = SyncEngine::from_text(&engine.text, viewport).unwrap();
     let node2 = engine2.graph.get_by_id(NodeId::intern("heading")).unwrap();
-    assert_eq!(node2.style.text_align, Some(TextAlign::Right));
-    assert_eq!(node2.style.text_valign, Some(TextVAlign::Bottom));
+    assert_eq!(node2.props.text_align, Some(TextAlign::Right));
+    assert_eq!(node2.props.text_valign, Some(TextVAlign::Bottom));
 }
 
 #[test]

--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -460,13 +460,13 @@ impl Tool for RectTool {
                 );
                 node.constraints.push(Constraint::Position { x: *x, y: *y });
                 // Transparent fill + dark stroke (matching create_node_at defaults)
-                node.style.stroke = Some(Stroke {
+                node.props.stroke = Some(Stroke {
                     paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
                     width: 2.5,
                     cap: StrokeCap::Round,
                     join: StrokeJoin::Round,
                 });
-                node.style.corner_radius = Some(8.0);
+                node.props.corner_radius = Some(8.0);
                 vec![GraphMutation::AddNode {
                     parent_id: NodeId::intern("root"),
                     node: Box::new(node),
@@ -806,7 +806,7 @@ impl Tool for EllipseTool {
                 let mut node = SceneNode::new(id, NodeKind::Ellipse { rx: 0.0, ry: 0.0 });
                 node.constraints.push(Constraint::Position { x: *x, y: *y });
                 // Transparent fill + dark stroke (matching create_node_at defaults)
-                node.style.stroke = Some(Stroke {
+                node.props.stroke = Some(Stroke {
                     paint: Paint::Solid(Color::rgba(0.2, 0.2, 0.2, 1.0)),
                     width: 2.5,
                     cap: StrokeCap::Round,
@@ -1025,7 +1025,7 @@ impl Tool for ArrowTool {
     }
 
     fn handle(&mut self, event: &InputEvent, hit_node: Option<NodeId>) -> Vec<GraphMutation> {
-        use fd_core::model::{ArrowKind, CurveKind, Edge, Style};
+        use fd_core::model::{ArrowKind, CurveKind, Edge, Properties};
 
         match event {
             InputEvent::PointerDown { x, y, .. } => {
@@ -1089,7 +1089,7 @@ impl Tool for ArrowTool {
                     from: from_anchor,
                     to: to_anchor,
                     text_child: None,
-                    style: Style::default(),
+                    props: Properties::default(),
                     use_styles: Default::default(),
                     arrow: ArrowKind::End,
                     curve: CurveKind::Smooth,

--- a/crates/fd-editor/src/tools_tests.rs
+++ b/crates/fd-editor/src/tools_tests.rs
@@ -1078,19 +1078,19 @@ fn rect_tool_creates_with_default_stroke() {
         GraphMutation::AddNode { node, .. } => {
             // Should have stroke (transparent fill + dark border)
             assert!(
-                node.style.stroke.is_some(),
+                node.props.stroke.is_some(),
                 "rect should have default stroke"
             );
-            let stroke = node.style.stroke.as_ref().unwrap();
+            let stroke = node.props.stroke.as_ref().unwrap();
             assert!(
                 (stroke.width - 2.5).abs() < 0.01,
                 "stroke width should be 2.5"
             );
             // Should have corner radius
-            assert_eq!(node.style.corner_radius, Some(8.0), "rect corner_radius=8");
+            assert_eq!(node.props.corner_radius, Some(8.0), "rect corner_radius=8");
             // Fill should be None (transparent)
             assert!(
-                node.style.fill.is_none(),
+                node.props.fill.is_none(),
                 "fill should be None (transparent)"
             );
         }
@@ -1115,22 +1115,22 @@ fn ellipse_tool_creates_with_default_stroke() {
         GraphMutation::AddNode { node, .. } => {
             // Should have stroke (transparent fill + dark border)
             assert!(
-                node.style.stroke.is_some(),
+                node.props.stroke.is_some(),
                 "ellipse should have default stroke"
             );
-            let stroke = node.style.stroke.as_ref().unwrap();
+            let stroke = node.props.stroke.as_ref().unwrap();
             assert!(
                 (stroke.width - 2.5).abs() < 0.01,
                 "stroke width should be 2.5"
             );
             // No corner radius for ellipse
             assert!(
-                node.style.corner_radius.is_none(),
+                node.props.corner_radius.is_none(),
                 "ellipse has no corner_radius"
             );
             // Fill should be None (transparent)
             assert!(
-                node.style.fill.is_none(),
+                node.props.fill.is_none(),
                 "fill should be None (transparent)"
             );
         }

--- a/crates/fd-render/src/paint.rs
+++ b/crates/fd-render/src/paint.rs
@@ -6,7 +6,7 @@
 use fd_core::NodeIndex;
 use fd_core::ResolvedBounds;
 use fd_core::SceneGraph;
-use fd_core::model::{NodeKind, Paint, PathCmd, StrokeCap, StrokeJoin, Style};
+use fd_core::model::{NodeKind, Paint, PathCmd, Properties, StrokeCap, StrokeJoin};
 use kurbo::{
     Affine, BezPath, Cap, Ellipse as KurboEllipse, Join, Point, Rect, RoundedRect,
     Stroke as KurboStroke,
@@ -80,7 +80,7 @@ fn paint_node(
 
 // ─── Shape painters ──────────────────────────────────────────────────────────
 
-fn paint_rect(scene: &mut Scene, nb: &ResolvedBounds, style: &Style) {
+fn paint_rect(scene: &mut Scene, nb: &ResolvedBounds, style: &Properties) {
     let kurbo_rect = Rect::new(
         nb.x as f64,
         nb.y as f64,
@@ -92,14 +92,14 @@ fn paint_rect(scene: &mut Scene, nb: &ResolvedBounds, style: &Style) {
     stroke_shape(scene, &shape, style);
 }
 
-fn paint_ellipse(scene: &mut Scene, nb: &ResolvedBounds, rx: f32, ry: f32, style: &Style) {
+fn paint_ellipse(scene: &mut Scene, nb: &ResolvedBounds, rx: f32, ry: f32, style: &Properties) {
     let center = Point::new((nb.x + rx) as f64, (nb.y + ry) as f64);
     let shape = KurboEllipse::new(center, (rx as f64, ry as f64), 0.0);
     fill_shape(scene, &shape, style);
     stroke_shape(scene, &shape, style);
 }
 
-fn paint_path(scene: &mut Scene, commands: &[PathCmd], nb: &ResolvedBounds, style: &Style) {
+fn paint_path(scene: &mut Scene, commands: &[PathCmd], nb: &ResolvedBounds, style: &Properties) {
     if commands.is_empty() {
         return;
     }
@@ -130,14 +130,14 @@ fn paint_path(scene: &mut Scene, commands: &[PathCmd], nb: &ResolvedBounds, styl
 
 // ─── Fill and stroke ─────────────────────────────────────────────────────────
 
-fn fill_shape<S: kurbo::Shape>(scene: &mut Scene, shape: &S, style: &Style) {
+fn fill_shape<S: kurbo::Shape>(scene: &mut Scene, shape: &S, style: &Properties) {
     if let Some(paint) = &style.fill {
         let color = paint_to_color(paint, style.opacity);
         scene.fill(Fill::NonZero, Affine::IDENTITY, color, None, shape);
     }
 }
 
-fn stroke_shape<S: kurbo::Shape>(scene: &mut Scene, shape: &S, style: &Style) {
+fn stroke_shape<S: kurbo::Shape>(scene: &mut Scene, shape: &S, style: &Properties) {
     if let Some(stroke) = &style.stroke {
         let vello_stroke = KurboStroke {
             width: stroke.width as f64,

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -58,7 +58,7 @@ pub struct FdCanvas {
     /// Pointer-down scene position — used to detect click vs drag.
     pointer_down_pos: Option<(f32, f32)>,
     /// Style clipboard for Copy/Paste Style (⌥⌘C / ⌥⌘V).
-    style_clipboard: Option<fd_core::model::Style>,
+    style_clipboard: Option<fd_core::model::Properties>,
     /// Whether we already duplicated during this drag (Alt+drag).
     /// Reset on pointer-up. Prevents re-duplication on subsequent move events.
     alt_duplicated: bool,
@@ -1049,7 +1049,7 @@ impl FdCanvas {
                     from: fd_core::model::EdgeAnchor::Node(nf),
                     to: fd_core::model::EdgeAnchor::Node(nt),
                     text_child: new_text_child,
-                    style: edge.style.clone(),
+                    props: edge.props.clone(),
                     use_styles: edge.use_styles.clone(),
                     arrow: edge.arrow,
                     curve: edge.curve,
@@ -1848,7 +1848,7 @@ impl FdCanvas {
                 if value == "none" || value == "transparent" {
                     // Clear fill → fully transparent
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         style.fill = None;
                         GraphMutation::SetStyle { id, style }
                     } else {
@@ -1856,7 +1856,7 @@ impl FdCanvas {
                     }
                 } else if let Some(color) = Color::from_hex(value) {
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         style.fill = Some(Paint::Solid(color));
                         GraphMutation::SetStyle { id, style }
                     } else {
@@ -1869,7 +1869,7 @@ impl FdCanvas {
             "strokeColor" => {
                 if let Some(color) = Color::from_hex(value) {
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         let resolved = self.engine.graph.resolve_style(node, &[]);
                         let mut stroke = style.stroke.or(resolved.stroke).unwrap_or_default();
                         stroke.paint = Paint::Solid(color);
@@ -1885,7 +1885,7 @@ impl FdCanvas {
             "strokeWidth" => {
                 if let Ok(w) = value.parse::<f32>() {
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         let resolved = self.engine.graph.resolve_style(node, &[]);
                         let mut stroke = style.stroke.or(resolved.stroke).unwrap_or_default();
                         stroke.width = w;
@@ -1901,7 +1901,7 @@ impl FdCanvas {
             "cornerRadius" => {
                 if let Ok(r) = value.parse::<f32>() {
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         style.corner_radius = Some(r);
                         GraphMutation::SetStyle { id, style }
                     } else {
@@ -1914,7 +1914,7 @@ impl FdCanvas {
             "opacity" => {
                 if let Ok(o) = value.parse::<f32>() {
                     if let Some(node) = self.engine.graph.get_by_id(id) {
-                        let mut style = node.style.clone();
+                        let mut style = node.props.clone();
                         style.opacity = Some(o);
                         GraphMutation::SetStyle { id, style }
                     } else {
@@ -1931,7 +1931,7 @@ impl FdCanvas {
                     _ => TextAlign::Center,
                 };
                 if let Some(node) = self.engine.graph.get_by_id(id) {
-                    let mut style = node.style.clone();
+                    let mut style = node.props.clone();
                     style.text_align = Some(align);
                     GraphMutation::SetStyle { id, style }
                 } else {
@@ -1945,7 +1945,7 @@ impl FdCanvas {
                     _ => TextVAlign::Middle,
                 };
                 if let Some(node) = self.engine.graph.get_by_id(id) {
-                    let mut style = node.style.clone();
+                    let mut style = node.props.clone();
                     style.text_valign = Some(valign);
                     GraphMutation::SetStyle { id, style }
                 } else {
@@ -2110,23 +2110,23 @@ impl FdCanvas {
             Color::rgba(0.2, 0.2, 0.2, 1.0) // #333333 — visible on light bg
         };
         if kind == "frame" {
-            node.style.fill = Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0)));
-            node.style.stroke = Some(Stroke {
+            node.props.fill = Some(Paint::Solid(Color::rgba(0.95, 0.95, 0.97, 1.0)));
+            node.props.stroke = Some(Stroke {
                 paint: Paint::Solid(Color::rgba(0.75, 0.75, 0.8, 1.0)),
                 width: 1.0,
                 cap: StrokeCap::Butt,
                 join: StrokeJoin::Miter,
             });
         } else if kind == "rect" {
-            node.style.stroke = Some(Stroke {
+            node.props.stroke = Some(Stroke {
                 paint: Paint::Solid(stroke_color),
                 width: 2.5,
                 cap: StrokeCap::Round,
                 join: StrokeJoin::Round,
             });
-            node.style.corner_radius = Some(8.0);
+            node.props.corner_radius = Some(8.0);
         } else if kind == "ellipse" {
-            node.style.stroke = Some(Stroke {
+            node.props.stroke = Some(Stroke {
                 paint: Paint::Solid(stroke_color),
                 width: 2.5,
                 cap: StrokeCap::Round,
@@ -2175,7 +2175,7 @@ impl FdCanvas {
             from: EdgeAnchor::Node(from),
             to: EdgeAnchor::Node(to),
             text_child: None,
-            style: fd_core::model::Style::default(),
+            props: fd_core::model::Properties::default(),
             use_styles: Default::default(),
             arrow: ArrowKind::End,
             curve: CurveKind::Smooth,
@@ -2205,7 +2205,7 @@ impl FdCanvas {
             from: EdgeAnchor::Point(x1, y1),
             to: EdgeAnchor::Point(x2, y2),
             text_child: None,
-            style: fd_core::model::Style::default(),
+            props: fd_core::model::Properties::default(),
             use_styles: Default::default(),
             arrow: ArrowKind::End,
             curve: CurveKind::Straight,
@@ -2693,7 +2693,7 @@ impl FdCanvas {
                 if let Some(id) = self.select_tool.first_selected()
                     && let Some(node) = self.engine.graph.get_by_id(id)
                 {
-                    self.style_clipboard = Some(node.style.clone());
+                    self.style_clipboard = Some(node.props.clone());
                 }
                 (false, false)
             }

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -360,7 +360,12 @@ fn render_node(
 
 // ─── Drawing primitives ─────────────────────────────────────────────────
 
-fn draw_rect(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, style: &Style, is_selected: bool) {
+fn draw_rect(
+    ctx: &CanvasRenderingContext2d,
+    b: &ResolvedBounds,
+    style: &Properties,
+    is_selected: bool,
+) {
     let (x, y, w, h) = (b.x as f64, b.y as f64, b.width as f64, b.height as f64);
     let radius = style.corner_radius.unwrap_or(0.0) as f64;
 
@@ -399,7 +404,7 @@ fn draw_rect(ctx: &CanvasRenderingContext2d, b: &ResolvedBounds, style: &Style, 
 fn draw_ellipse(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
-    style: &Style,
+    style: &Properties,
     is_selected: bool,
 ) {
     let cx = b.x as f64 + b.width as f64 / 2.0;
@@ -441,7 +446,7 @@ fn draw_text(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
     content: &str,
-    style: &Style,
+    style: &Properties,
     in_shape: bool,
     max_width: Option<f32>,
 ) {
@@ -571,7 +576,7 @@ fn draw_shape_label(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
     label: &str,
-    style: &Style,
+    style: &Properties,
 ) {
     ctx.save();
     apply_opacity(ctx, style);
@@ -598,7 +603,7 @@ fn draw_shape_label(
 
 /// Pick a readable label color based on the shape's fill luminance.
 #[allow(dead_code)]
-fn pick_label_color(style: &Style) -> String {
+fn pick_label_color(style: &Properties) -> String {
     match &style.fill {
         Some(Paint::Solid(c)) => {
             // Perceived luminance (sRGB)
@@ -618,7 +623,7 @@ fn draw_path(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
     commands: &[PathCmd],
-    style: &Style,
+    style: &Properties,
     is_selected: bool,
 ) {
     if commands.is_empty() {
@@ -1109,7 +1114,7 @@ fn rounded_rect_path(ctx: &CanvasRenderingContext2d, x: f64, y: f64, w: f64, h: 
 }
 
 /// Set the fill style — creates a CanvasGradient for gradient paints.
-fn apply_fill(ctx: &CanvasRenderingContext2d, style: &Style, x: f64, y: f64, w: f64, h: f64) {
+fn apply_fill(ctx: &CanvasRenderingContext2d, style: &Properties, x: f64, y: f64, w: f64, h: f64) {
     match &style.fill {
         Some(Paint::LinearGradient { angle, stops }) => {
             let rad = (*angle as f64).to_radians();
@@ -1151,7 +1156,7 @@ fn apply_fill(ctx: &CanvasRenderingContext2d, style: &Style, x: f64, y: f64, w: 
 }
 
 /// Apply CSS drop-shadow from Style.shadow.
-fn apply_shadow(ctx: &CanvasRenderingContext2d, style: &Style) {
+fn apply_shadow(ctx: &CanvasRenderingContext2d, style: &Properties) {
     if let Some(ref shadow) = style.shadow {
         ctx.set_shadow_blur(shadow.blur as f64);
         ctx.set_shadow_offset_x(shadow.offset_x as f64);
@@ -1168,7 +1173,7 @@ fn clear_shadow(ctx: &CanvasRenderingContext2d) {
     ctx.set_shadow_color("transparent");
 }
 
-fn resolve_fill_color(style: &Style) -> String {
+fn resolve_fill_color(style: &Properties) -> String {
     match &style.fill {
         Some(paint) => resolve_paint_color(paint),
         None => "#CCCCCC".to_string(),
@@ -1188,7 +1193,7 @@ fn resolve_paint_color(paint: &Paint) -> String {
     }
 }
 
-fn apply_opacity(ctx: &CanvasRenderingContext2d, style: &Style) {
+fn apply_opacity(ctx: &CanvasRenderingContext2d, style: &Properties) {
     if let Some(opacity) = style.opacity {
         ctx.set_global_alpha(opacity as f64);
     }
@@ -1223,7 +1228,7 @@ fn sketchy_line(ctx: &CanvasRenderingContext2d, x1: f64, y1: f64, x2: f64, y2: f
 fn draw_rect_sketchy(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
-    style: &Style,
+    style: &Properties,
     is_selected: bool,
 ) {
     let (x, y, w, h) = (b.x as f64, b.y as f64, b.width as f64, b.height as f64);
@@ -1310,7 +1315,7 @@ fn draw_rect_sketchy(
 fn draw_ellipse_sketchy(
     ctx: &CanvasRenderingContext2d,
     b: &ResolvedBounds,
-    style: &Style,
+    style: &Properties,
     is_selected: bool,
 ) {
     let cx = b.x as f64 + b.width as f64 / 2.0;
@@ -1391,7 +1396,7 @@ fn draw_ellipse_sketchy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fd_core::model::{Color, GradientStop, Paint, Style};
+    use fd_core::model::{Color, GradientStop, Paint, Properties};
 
     // ─── CanvasTheme ─────────────────────────────────────────────────────
 
@@ -1424,46 +1429,46 @@ mod tests {
 
     #[test]
     fn label_color_dark_fill_returns_white() {
-        let style = Style {
+        let style = Properties {
             fill: Some(Paint::Solid(Color {
                 r: 0.0,
                 g: 0.0,
                 b: 0.0,
                 a: 1.0,
             })),
-            ..Style::default()
+            ..Properties::default()
         };
         assert_eq!(pick_label_color(&style), "#FFFFFF");
     }
 
     #[test]
     fn label_color_light_fill_returns_dark() {
-        let style = Style {
+        let style = Properties {
             fill: Some(Paint::Solid(Color {
                 r: 1.0,
                 g: 1.0,
                 b: 1.0,
                 a: 1.0,
             })),
-            ..Style::default()
+            ..Properties::default()
         };
         assert_eq!(pick_label_color(&style), "#1C1C1E");
     }
 
     #[test]
     fn label_color_no_fill_returns_dark() {
-        let style = Style::default();
+        let style = Properties::default();
         assert_eq!(pick_label_color(&style), "#1C1C1E");
     }
 
     #[test]
     fn label_color_gradient_fill_returns_dark() {
-        let style = Style {
+        let style = Properties {
             fill: Some(Paint::LinearGradient {
                 angle: 90.0,
                 stops: vec![],
             }),
-            ..Style::default()
+            ..Properties::default()
         };
         // Gradient doesn't match Solid branch → falls through to default
         assert_eq!(pick_label_color(&style), "#1C1C1E");
@@ -1473,27 +1478,27 @@ mod tests {
 
     #[test]
     fn fill_color_solid() {
-        let style = Style {
+        let style = Properties {
             fill: Some(Paint::Solid(Color {
                 r: 1.0,
                 g: 0.0,
                 b: 0.0,
                 a: 1.0,
             })),
-            ..Style::default()
+            ..Properties::default()
         };
         assert_eq!(resolve_fill_color(&style), "#FF0000");
     }
 
     #[test]
     fn fill_color_none_returns_default() {
-        let style = Style::default();
+        let style = Properties::default();
         assert_eq!(resolve_fill_color(&style), "#CCCCCC");
     }
 
     #[test]
     fn fill_color_gradient_uses_first_stop() {
-        let style = Style {
+        let style = Properties {
             fill: Some(Paint::LinearGradient {
                 angle: 0.0,
                 stops: vec![GradientStop {
@@ -1506,7 +1511,7 @@ mod tests {
                     },
                 }],
             }),
-            ..Style::default()
+            ..Properties::default()
         };
         assert_eq!(resolve_fill_color(&style), "#00FF00");
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.69 — Rename `theme` → `style` Keyword (R4.18)
+
+- **RENAME (R4.18)**: `theme` keyword → `style` — reusable property bundles now use the universal CSS/Figma term; emitter outputs `style` keyword and `# ─── Styles ───` section header; parser still accepts `theme` for backward compatibility
+- **RENAME (R4.18)**: Internal Rust struct `Style` → `Properties` — better reflects the struct's role as a collection of visual properties (fill, stroke, font, etc.); field accessor `.style` → `.props` across all crates
+- **COMPAT**: Parser accepts both `theme` and `style` keywords, and both `# ─── Themes ───` and `# ─── Styles ───` section separators; existing `.fd` files parse without changes
+- **DOCS**: Updated `GEMINI.md` (style reuse rule), `REQUIREMENTS.md` (R4.18), `SKILL.md` (style grammar)
+
 ### v0.10.68 — Remove Click-to-Raise (R3.41)
 
 - **REMOVED (R3.41)**: Click-to-raise — selecting a node via click no longer auto-brings it forward one z-level; this caused surprise z-order changes and silent `.fd` text reordering, polluted undo stack, and was a recurring bug surface (3+ patches for group-raise, idempotency, and dead-zone guards); explicit ⌘] / ⌘⇧] remain for intentional z-order changes

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -132,7 +132,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R4.15** _(done)_: Named colors — `fill: purple` etc. accepted (17 Tailwind palette colors)
 - **R4.16** _(done)_: Property aliases — `background:`/`color:` → fill, `rounded:`/`radius:` → corner
 - **R4.17** _(done)_: Dimension units — `w: 320px` accepted, `px` stripped by parser
-- **R4.18** _(done)_: Theme/When rename + emitter reorder — `style` → `theme`, `anim` → `when` for clarity; emitter order: spec → children → style → when; old keywords accepted for backward compatibility
+- **R4.18** _(done)_: Keyword rename — `theme` → `style` (reusable property bundles), `anim` → `when` for clarity; internal Rust struct `Style` → `Properties`, field `.style` → `.props`; emitter order: spec → children → style → when; old keywords (`theme`, `style` as legacy) accepted for backward compatibility
 - **R4.19** _(done)_: ReadMode filtered views — `emit_filtered(graph, mode)` with 8 modes (Full/Structure/Layout/Design/Spec/Visual/When/Edges); CLI `fd-lsp --view <mode>` for AI token savings; VS Code read-only virtual document provider with status bar mode selector
 - **R4.20** _(planned)_: AI Assist on selection — select nodes on canvas → click "✦ AI Assist" → AI receives `.fd` text of selected nodes → returns redesigned `.fd` → bidi-sync renders changes live; undo reverts entire AI edit atomically
 - **R4.21** _(planned)_: **Comprehensibility Score** — compute a 0–100 score measuring how easily AI agents can understand an FD document. Metrics:


### PR DESCRIPTION
## Summary

Renames the `theme` keyword to `style` and the internal Rust `Style` struct to `Properties` for better semantic alignment with CSS/Figma conventions.

## Changes

- **Emitter**: `theme` → `style` keyword, `# ─── Themes ───` → `# ─── Styles ───` section header
- **Model**: `Style` struct → `Properties`, `.style` field → `.props` across all 5 crates
- **Parser**: Accepts both `theme` and `style` keywords (backward compat)
- **Tests**: All 203 tests pass, assertions updated
- **Docs**: GEMINI.md, REQUIREMENTS.md (R4.18), CHANGELOG.md (v0.10.69)

## Verification

- `cargo check --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` — 203 passed, 0 failed ✅