### PR TITLE
feat(site): add floating toolbar to playground canvas

### DIFF
--- a/.agents/workflows/prompts.md
+++ b/.agents/workflows/prompts.md
@@ -26,20 +26,19 @@ Each prompt must be: **self-contained** (all context inline), **one concern**, *
 
 ### 3. Prompt Format
 
-````markdown
+> [!IMPORTANT]
+> **Each prompt MUST be a single fenced code block** (` ````text `) so the user can copy the entire prompt in one click. Do NOT put metadata (Depends on, Files, Verify) outside the code block — embed everything inside it.
+
+`````markdown
 ### Prompt N: [Short Title]
 
-**Depends on:** Prompt N-1 (or "None")
-**Files:** `path/to/file1`, `path/to/file2`
-
-```
+````text
 [Complete instruction — what, where, why, expected result.
 Reference specific file paths, line numbers, CSS selectors.
-End with verification step.]
-```
-
-**Verify:** [What "done" looks like]
+End with "Verify: [what done looks like]"
+End with /yolo /nonstop /e2e]
 ````
+`````
 
 ### 4. Standard Sequences
 
@@ -85,6 +84,7 @@ After implementation prompts, always include:
 
 | Rule                  | Description                                                                                                                              |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Single copy block** | Each prompt MUST be one fenced code block (` ````text `) — no metadata outside it                                                        |
 | **Min 3 prompts**     | We want agents to spend time doing work                                                                                                  |
 | **Max 10 prompts**    | If more needed, split into sub-features                                                                                                  |
 | **Copy-paste ready**  | Each prompt works standalone — no "see above"                                                                                            |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.70 — Floating Toolbar on Playground Canvas (R6.6)
+
+- **UX (R6.6)**: Floating toolbar on playground canvas — vertical glassmorphic toolbar on left side of canvas with 7 SVG tool buttons (Select, Rect, Ellipse, Text, Arrow, Pen, Eraser) matching the VS Code extension's floating toolbar; replaces inline header tool buttons
+- **SITE**: Removed inline `#canvas-tools` div from `.editor-header`; added `#floating-toolbar` inside `#canvas-wrapper` with `position: absolute; left: 12px; top: 50%; transform: translateY(-50%)`; `.ft-btn` buttons styled as 32×32 rounded with accent highlight on active; SVG icons from `fd-vscode/src/webview-html.ts`
+- **SITE**: Updated `playground.js` selectors from `.canvas-tool` to `.ft-btn` in `updateToolbar()` and click handler
+
 ### v0.10.69 — Rename `theme` → `style` Keyword (R4.18)
 
 - **RENAME (R4.18)**: `theme` keyword → `style` — reusable property bundles now use the universal CSS/Figma term; emitter outputs `style` keyword and `# ─── Styles ───` section header; parser still accepts `theme` for backward compatibility

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), 7-tool toolbar, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -106,19 +106,19 @@
         <div class="playground-canvas">
           <div class="editor-header">
             <span class="editor-dot canvas-dot"></span> Canvas Mode
-            <div id="canvas-tools" class="canvas-tools">
-              <button class="canvas-tool active" data-tool="select" title="Select (V)">↖</button>
-              <button class="canvas-tool" data-tool="rect" title="Rectangle (R)">□</button>
-              <button class="canvas-tool" data-tool="ellipse" title="Ellipse (O)">○</button>
-              <button class="canvas-tool" data-tool="text" title="Text (T)">T</button>
-              <button class="canvas-tool" data-tool="arrow" title="Arrow (A)">→</button>
-              <button class="canvas-tool" data-tool="pen" title="Pen (P)">✎</button>
-              <button class="canvas-tool" data-tool="eraser" title="Eraser (E)">◎</button>
-            </div>
             <span id="zoom-level" class="zoom-indicator">100%</span>
           </div>
           <div id="canvas-wrapper">
             <canvas id="fd-canvas"></canvas>
+            <div id="floating-toolbar">
+              <button class="ft-btn active" data-tool="select" title="Select (V)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 2L3.5 13.5L7 10L11.5 14.5L13 13L9 8.5L13 8.5Z"/></svg></button>
+              <button class="ft-btn" data-tool="rect" title="Rectangle (R)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="12" height="10" rx="2"/></svg></button>
+              <button class="ft-btn" data-tool="ellipse" title="Ellipse (O)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="9" r="6"/></svg></button>
+              <button class="ft-btn" data-tool="text" title="Text (T)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4H14"/><path d="M9 4V15"/><path d="M6 15H12"/></svg></button>
+              <button class="ft-btn" data-tool="arrow" title="Arrow (A)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14L14 4"/><path d="M7 4H14V11"/></svg></button>
+              <button class="ft-btn" data-tool="pen" title="Pen (P)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 3.5L14.5 7.5L6.5 15.5H2.5V11.5Z"/><path d="M10.5 3.5L14.5 7.5"/><path d="M8.5 5.5L12.5 9.5"/></svg></button>
+              <button class="ft-btn" data-tool="eraser" title="Eraser (E)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg></button>
+            </div>
             <div id="fab" class="fab">
               <label class="fab-item" title="Fill color">
                 <span class="fab-label">Fill</span>

--- a/site/playground.js
+++ b/site/playground.js
@@ -206,8 +206,8 @@ function renderCanvas() {
 
 /** Update toolbar active state */
 function updateToolbar(activeTool) {
-  document.querySelectorAll('.canvas-tool').forEach(b => b.classList.remove('active'));
-  const btn = document.querySelector(`.canvas-tool[data-tool="${activeTool}"]`);
+  document.querySelectorAll('.ft-btn').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector(`.ft-btn[data-tool="${activeTool}"]`);
   if (btn) btn.classList.add('active');
 }
 
@@ -428,7 +428,7 @@ async function initPlayground() {
     }, { passive: false });
 
     // ── Tool Toolbar ──────────────────────────────────────────────────
-    document.querySelectorAll('.canvas-tool').forEach(btn => {
+    document.querySelectorAll('.ft-btn').forEach(btn => {
       btn.addEventListener('click', () => {
         if (!fdCanvas) return;
         const tool = btn.dataset.tool;

--- a/site/style.css
+++ b/site/style.css
@@ -415,43 +415,62 @@ code {
   display: block;
 }
 
-/* ─── Canvas Tool Buttons ─── */
-.canvas-tools {
+/* ─── Floating Toolbar ─── */
+#floating-toolbar {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
   display: flex;
+  flex-direction: column;
   gap: 2px;
-  margin-left: auto;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 6px;
-  padding: 2px;
+  padding: 6px;
+  background: rgba(22, 27, 34, 0.88);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
-.canvas-tool {
+.ft-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   border: none;
   background: transparent;
   color: var(--text-secondary);
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 12px;
   transition: all 0.15s ease;
+  padding: 0;
 }
-.canvas-tool:hover {
-  background: rgba(255, 255, 255, 0.08);
+.ft-btn svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+.ft-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
   color: var(--text-primary);
 }
-.canvas-tool.active {
+.ft-btn.active {
   background: var(--accent);
   color: #fff;
-  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(108, 92, 231, 0.35);
+}
+.ft-btn:active {
+  transform: scale(0.92);
 }
 .zoom-indicator {
   font-size: 10px;
   color: var(--text-muted);
   font-family: var(--mono);
   padding: 2px 6px;
+  margin-left: auto;
   user-select: none;
 }
 


### PR DESCRIPTION
## Summary

Add a floating toolbar to the fast-draft.com playground canvas, matching the VS Code extension's floating toolbar design.

## Changes

### site/index.html
- Removed inline tool buttons (`#canvas-tools` div with `.canvas-tool` buttons) from `.editor-header`
- Added `#floating-toolbar` inside `#canvas-wrapper` with 7 SVG tool buttons (select, rect, ellipse, text, arrow, pen, eraser)
- SVG icons sourced from `fd-vscode/src/webview-html.ts`

### site/style.css
- Replaced `.canvas-tools` / `.canvas-tool` styles with `#floating-toolbar` / `.ft-btn` styles
- Glassmorphic vertical toolbar: `position: absolute; left: 12px; top: 50%`
- 32×32 rounded buttons with accent highlight on `.active`

### site/playground.js
- Updated `updateToolbar()` selectors: `.canvas-tool` → `.ft-btn`
- Updated click handler selectors: `.canvas-tool` → `.ft-btn`

### docs/
- CHANGELOG.md: Added v0.10.70 entry
- REQUIREMENTS.md: Updated R6.6 wording

## Verification
- Pure HTML/CSS/JS change — no Rust code modified
- Tool selection works via click and keyboard (V/R/O/T/A/P/E)