### PR TITLE
feat(site): add minimap with zoom controls to playground canvas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.71 — Minimap + Zoom Controls (R6.6)
+
+- **UX (R6.6)**: Minimap in playground canvas — glassmorphic 150×100px thumbnail in bottom-right showing scaled scene overview with purple node rects and blue viewport rectangle; click/drag on minimap pans the canvas to that scene position
+- **UX (R6.6)**: Zoom control buttons embedded in minimap — `−` (÷1.25), zoom percentage (click to reset 100%/0,0), `+` (×1.25); all zoom centered on canvas midpoint; synced with header zoom indicator and Ctrl+scroll zoom
+- **SITE**: `renderMinimap()` extracts `@id` tokens from FD text, queries `get_node_bounds()` per node, computes scene bounding box, renders scaled rects + viewport rect; throttled to ~10fps in render loop
+- **SITE**: `updateZoomIndicator()` now also syncs `#zoom-reset-btn` text
+
 ### v0.10.70 — Floating Toolbar on Playground Canvas (R6.6)
 
 - **UX (R6.6)**: Floating toolbar on playground canvas — vertical glassmorphic toolbar on left side of canvas with 7 SVG tool buttons (Select, Rect, Ellipse, Text, Arrow, Pen, Eraser) matching the VS Code extension's floating toolbar; replaces inline header tool buttons

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -119,6 +119,14 @@
               <button class="ft-btn" data-tool="pen" title="Pen (P)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 3.5L14.5 7.5L6.5 15.5H2.5V11.5Z"/><path d="M10.5 3.5L14.5 7.5"/><path d="M8.5 5.5L12.5 9.5"/></svg></button>
               <button class="ft-btn" data-tool="eraser" title="Eraser (E)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg></button>
             </div>
+            <div id="minimap-container">
+              <canvas id="minimap-canvas"></canvas>
+              <div id="minimap-zoom">
+                <button class="mz-btn" id="zoom-out-btn">−</button>
+                <button class="mz-btn" id="zoom-reset-btn">100%</button>
+                <button class="mz-btn" id="zoom-in-btn">+</button>
+              </div>
+            </div>
             <div id="fab" class="fab">
               <label class="fab-item" title="Fill color">
                 <span class="fab-label">Fill</span>

--- a/site/playground.js
+++ b/site/playground.js
@@ -213,8 +213,11 @@ function updateToolbar(activeTool) {
 
 /** Update zoom indicator text */
 function updateZoomIndicator() {
+  const pct = Math.round(zoomLevel * 100) + '%';
   const el = document.getElementById('zoom-level');
-  if (el) el.textContent = Math.round(zoomLevel * 100) + '%';
+  if (el) el.textContent = pct;
+  const rb = document.getElementById('zoom-reset-btn');
+  if (rb) rb.textContent = pct;
 }
 
 /** Sync canvas text back to textarea with echo suppression */
@@ -256,6 +259,94 @@ function updateFab(canvas) {
   } catch (_) {
     fab.classList.remove('visible');
   }
+}
+
+/** ─── Minimap ─────────────────────────────────────────────────────────── */
+let minimapLastRender = 0;
+const MINIMAP_INTERVAL = 100; // ~10fps
+
+/** Render the minimap: scaled scene overview + blue viewport rect */
+function renderMinimap(canvas) {
+  const mc = document.getElementById('minimap-canvas');
+  if (!mc || !fdCanvas) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const mw = 150, mh = 100;
+  mc.width = mw * dpr;
+  mc.height = mh * dpr;
+
+  const mctx = mc.getContext('2d');
+  mctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  mctx.clearRect(0, 0, mw, mh);
+
+  // Extract @ids from text
+  const text = fdCanvas.get_text();
+  const idRegex = /@([a-zA-Z_][a-zA-Z0-9_]*)/g;
+  const ids = [];
+  let m;
+  while ((m = idRegex.exec(text)) !== null) ids.push(m[1]);
+
+  // Get bounds for all nodes
+  const nodes = [];
+  for (const id of ids) {
+    try {
+      const bj = fdCanvas.get_node_bounds(id);
+      if (!bj) continue;
+      const b = JSON.parse(bj);
+      if (b.width > 0 && b.height > 0) nodes.push(b);
+    } catch (_) {}
+  }
+
+  if (nodes.length === 0) return;
+
+  // Compute scene bounding box with padding
+  let sx = Infinity, sy = Infinity, sx2 = -Infinity, sy2 = -Infinity;
+  for (const n of nodes) {
+    sx = Math.min(sx, n.x);
+    sy = Math.min(sy, n.y);
+    sx2 = Math.max(sx2, n.x + n.width);
+    sy2 = Math.max(sy2, n.y + n.height);
+  }
+  const pad = 40;
+  sx -= pad; sy -= pad; sx2 += pad; sy2 += pad;
+  const sw = sx2 - sx, sh = sy2 - sy;
+
+  // Scale to fit minimap
+  const scale = Math.min(mw / sw, mh / sh);
+  const ox = (mw - sw * scale) / 2;
+  const oy = (mh - sh * scale) / 2;
+
+  // Draw nodes
+  mctx.fillStyle = 'rgba(108, 92, 231, 0.35)';
+  mctx.strokeStyle = 'rgba(108, 92, 231, 0.6)';
+  mctx.lineWidth = 0.5;
+  for (const n of nodes) {
+    const rx = ox + (n.x - sx) * scale;
+    const ry = oy + (n.y - sy) * scale;
+    const rw = n.width * scale;
+    const rh = n.height * scale;
+    mctx.fillRect(rx, ry, rw, rh);
+    mctx.strokeRect(rx, ry, rw, rh);
+  }
+
+  // Draw viewport rect
+  if (canvas) {
+    const cr = canvas.getBoundingClientRect();
+    const vx = -panX / zoomLevel;
+    const vy = -panY / zoomLevel;
+    const vw = cr.width / zoomLevel;
+    const vh = cr.height / zoomLevel;
+    const vrx = ox + (vx - sx) * scale;
+    const vry = oy + (vy - sy) * scale;
+    const vrw = vw * scale;
+    const vrh = vh * scale;
+    mctx.strokeStyle = '#4FC3F7';
+    mctx.lineWidth = 1.5;
+    mctx.strokeRect(vrx, vry, vrw, vrh);
+  }
+
+  // Store scene info for click-to-pan
+  mc._minimap = { sx, sy, sw, sh, scale, ox, oy };
 }
 
 // ─── Init ────────────────────────────────────────────────────────────────
@@ -301,6 +392,11 @@ async function initPlayground() {
     // Render loop — continuous for hover effects and animations
     const renderLoop = (time) => {
       renderCanvas();
+      // Minimap at ~10fps
+      if (time - minimapLastRender > MINIMAP_INTERVAL) {
+        renderMinimap(canvas);
+        minimapLastRender = time;
+      }
       animFrameId = requestAnimationFrame(renderLoop);
     };
     animFrameId = requestAnimationFrame(renderLoop);
@@ -530,6 +626,58 @@ async function initPlayground() {
     // ── Resize Observer ───────────────────────────────────────────────
     const resizeObserver = new ResizeObserver(() => resizeCanvas());
     resizeObserver.observe(wrapper);
+
+    // ── Minimap Click-to-Pan ───────────────────────────────────────────
+    const minimapCanvas = document.getElementById('minimap-canvas');
+    let mmDragging = false;
+    const minimapPanTo = (e) => {
+      const mc = minimapCanvas;
+      const info = mc._minimap;
+      if (!info || !canvas) return;
+      const rect = mc.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      // Convert minimap coords to scene coords
+      const sceneX = info.sx + (mx - info.ox) / info.scale;
+      const sceneY = info.sy + (my - info.oy) / info.scale;
+      // Center viewport on clicked point
+      const cr = canvas.getBoundingClientRect();
+      panX = cr.width / 2 - sceneX * zoomLevel;
+      panY = cr.height / 2 - sceneY * zoomLevel;
+      renderCanvas();
+      renderMinimap(canvas);
+    };
+    minimapCanvas.addEventListener('pointerdown', (e) => {
+      mmDragging = true;
+      minimapCanvas.setPointerCapture(e.pointerId);
+      minimapPanTo(e);
+    });
+    minimapCanvas.addEventListener('pointermove', (e) => {
+      if (mmDragging) minimapPanTo(e);
+    });
+    minimapCanvas.addEventListener('pointerup', () => { mmDragging = false; });
+
+    // ── Zoom Buttons ──────────────────────────────────────────────────
+    const applyZoomCenter = (newZoom) => {
+      const cr = canvas.getBoundingClientRect();
+      const cx = cr.width / 2;
+      const cy = cr.height / 2;
+      newZoom = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, newZoom));
+      panX = cx - (cx - panX) * (newZoom / zoomLevel);
+      panY = cy - (cy - panY) * (newZoom / zoomLevel);
+      zoomLevel = newZoom;
+      updateZoomIndicator();
+      renderCanvas();
+      renderMinimap(canvas);
+    };
+    document.getElementById('zoom-in-btn').addEventListener('click', () => applyZoomCenter(zoomLevel * 1.25));
+    document.getElementById('zoom-out-btn').addEventListener('click', () => applyZoomCenter(zoomLevel / 1.25));
+    document.getElementById('zoom-reset-btn').addEventListener('click', () => {
+      zoomLevel = 1.0; panX = 0; panY = 0;
+      updateZoomIndicator();
+      renderCanvas();
+      renderMinimap(canvas);
+    });
 
     // ── Example Selector ──────────────────────────────────────────────
     document.getElementById('example-select').addEventListener('change', (e) => {

--- a/site/style.css
+++ b/site/style.css
@@ -474,6 +474,56 @@ code {
   user-select: none;
 }
 
+/* ─── Minimap ─── */
+#minimap-container {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 20;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  background: rgba(22, 27, 34, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+#minimap-canvas {
+  display: block;
+  width: 150px;
+  height: 100px;
+}
+#minimap-zoom {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.mz-btn {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: var(--mono);
+  padding: 4px 0;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  user-select: none;
+}
+.mz-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+}
+.mz-btn:active {
+  transform: scale(0.92);
+}
+#zoom-reset-btn {
+  font-size: 10px;
+  letter-spacing: -0.2px;
+}
+
 /* ─── Floating Action Bar ─── */
 .fab {
   display: none;


### PR DESCRIPTION
## Summary

Add a minimap with zoom controls to the fast-draft.com playground canvas, matching the VS Code extension's minimap style.

## Changes

### site/index.html
- Added `#minimap-container` inside `#canvas-wrapper` (after floating toolbar, before FAB)
- Contains 150×100px minimap canvas and zoom controls (−, %, +)

### site/style.css (+50 lines)
- Glassmorphic minimap container: absolute bottom-right, blur, border, shadow
- Zoom button strip below minimap canvas
- Frosted-glass hover states on zoom buttons

### site/playground.js (~140 lines)
- `renderMinimap()`: extracts `@id` from text, queries `get_node_bounds()`, computes scene bbox, renders scaled purple rects + blue viewport rect
- Click/drag on minimap → converts to scene coords, sets pan position
- Zoom buttons: `+` (×1.25), `−` (÷1.25), `%` (reset to 100%/0,0)
- Throttled minimap render in animation loop (~10fps)
- `updateZoomIndicator()` syncs both header and minimap zoom text

### docs/
- CHANGELOG.md: v0.10.71 entry
- REQUIREMENTS.md: Updated R6.6 wording

## Verification
- Pure HTML/CSS/JS change — no Rust code modified
- Minimap shows scaled scene overview with viewport rect
- Click-to-pan and zoom buttons functional