### PR TITLE
feat(site): add undo/redo buttons + canvas header cleanup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.72 — Undo/Redo Buttons + Canvas Header Cleanup (R6.6)
+
+- **UX (R6.6)**: Undo/redo buttons in playground canvas header — ↶ and ↷ ghost buttons with keyboard shortcut tooltips; calls `fdCanvas.undo()` / `fdCanvas.redo()` and syncs canvas + code editor
+- **UX (R6.6)**: Clickable zoom indicator — clicking the zoom percentage in the header resets to 100% and pans to origin (0,0); hover shows subtle background highlight
+- **SITE**: New `.canvas-header-actions` flex group, `.ch-btn` ghost buttons with border, `.ch-sep` vertical divider; `.zoom-indicator` now has `cursor: pointer` and hover state
+
 ### v0.10.71 — Minimap + Zoom Controls (R6.6)
 
 - **UX (R6.6)**: Minimap in playground canvas — glassmorphic 150×100px thumbnail in bottom-right showing scaled scene overview with purple node rects and blue viewport rectangle; click/drag on minimap pans the canvas to that scene position

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -106,7 +106,12 @@
         <div class="playground-canvas">
           <div class="editor-header">
             <span class="editor-dot canvas-dot"></span> Canvas Mode
-            <span id="zoom-level" class="zoom-indicator">100%</span>
+            <div class="canvas-header-actions">
+              <button class="ch-btn" id="undo-btn" title="Undo (⌘Z)">↶</button>
+              <button class="ch-btn" id="redo-btn" title="Redo (⇧⌘Z)">↷</button>
+              <span class="ch-sep"></span>
+              <span id="zoom-level" class="zoom-indicator" title="Click to reset zoom">100%</span>
+            </div>
           </div>
           <div id="canvas-wrapper">
             <canvas id="fd-canvas"></canvas>

--- a/site/playground.js
+++ b/site/playground.js
@@ -657,6 +657,26 @@ async function initPlayground() {
     });
     minimapCanvas.addEventListener('pointerup', () => { mmDragging = false; });
 
+    // ── Undo/Redo Buttons ─────────────────────────────────────────────
+    document.getElementById('undo-btn').addEventListener('click', () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.undo();
+      if (changed) { renderCanvas(); syncCanvasToEditor(editor); }
+    });
+    document.getElementById('redo-btn').addEventListener('click', () => {
+      if (!fdCanvas) return;
+      const changed = fdCanvas.redo();
+      if (changed) { renderCanvas(); syncCanvasToEditor(editor); }
+    });
+
+    // ── Zoom Indicator Click → Reset ──────────────────────────────────
+    document.getElementById('zoom-level').addEventListener('click', () => {
+      zoomLevel = 1.0; panX = 0; panY = 0;
+      updateZoomIndicator();
+      renderCanvas();
+      renderMinimap(canvas);
+    });
+
     // ── Zoom Buttons ──────────────────────────────────────────────────
     const applyZoomCenter = (newZoom) => {
       const cr = canvas.getBoundingClientRect();

--- a/site/style.css
+++ b/site/style.css
@@ -465,13 +465,54 @@ code {
 .ft-btn:active {
   transform: scale(0.92);
 }
+.canvas-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+}
+.ch-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.15s ease;
+  padding: 0;
+}
+.ch-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.ch-btn:active {
+  transform: scale(0.92);
+}
+.ch-sep {
+  width: 1px;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  margin: 0 4px;
+}
 .zoom-indicator {
   font-size: 10px;
   color: var(--text-muted);
   font-family: var(--mono);
   padding: 2px 6px;
-  margin-left: auto;
   user-select: none;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: all 0.15s ease;
+}
+.zoom-indicator:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
 }
 
 /* ─── Minimap ─── */


### PR DESCRIPTION
## Summary

Add undo/redo buttons and clean up the canvas header on the fast-draft.com playground.

## Changes

### site/index.html
- Replaced flat header with structured `.canvas-header-actions` group
- Added ↶ undo and ↷ redo ghost buttons with tooltip hints
- Added `.ch-sep` vertical divider between undo/redo and zoom
- Made zoom indicator clickable with tooltip "Click to reset zoom"

### site/style.css (+45 lines)
- `.canvas-header-actions`: flex row with auto margin-left
- `.ch-btn`: 26×22 ghost buttons with border, hover/active states
- `.ch-sep`: 1px vertical divider
- `.zoom-indicator`: now clickable with cursor:pointer and hover highlight

### site/playground.js (+20 lines)
- `#undo-btn` click → `fdCanvas.undo()` + render + sync
- `#redo-btn` click → `fdCanvas.redo()` + render + sync
- `#zoom-level` click → reset zoom to 100% and pan to origin

### docs/
- CHANGELOG.md: v0.10.72 entry
- REQUIREMENTS.md: Updated R6.6