### PR TITLE
feat(site): add layers panel tree view to playground canvas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.73 — Layers Panel (R6.6)
+
+- **UX (R6.6)**: Layers panel (tree view sidebar) in playground canvas — 180px left sidebar with glassmorphic background showing hierarchical document tree parsed from FD text; displays node kind icons (◻ group, ▢ rect, ○ ellipse, T text, ⟶ edge, ◆ style), click-to-select, and chevron expand/collapse for groups
+- **SITE**: Ported `parseLayerTree()` and `renderLayerNode()` from VS Code extension `panels.js`; `refreshLayersPanel()` with diff-based skip (text + selectedId); throttled at ~10fps in render loop
+- **SITE**: Canvas and floating toolbar offset by 180px to accommodate sidebar; `resizeCanvas()` and `FdCanvas` init adjusted for panel width
+
 ### v0.10.72 — Undo/Redo Buttons + Canvas Header Cleanup (R6.6)
 
 - **UX (R6.6)**: Undo/redo buttons in playground canvas header — ↶ and ↷ ghost buttons with keyboard shortcut tooltips; calls `fdCanvas.undo()` / `fdCanvas.redo()` and syncs canvas + code editor

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), layers panel (tree view sidebar with expand/collapse), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -114,6 +114,7 @@
             </div>
           </div>
           <div id="canvas-wrapper">
+            <div id="layers-panel"></div>
             <canvas id="fd-canvas"></canvas>
             <div id="floating-toolbar">
               <button class="ft-btn active" data-tool="select" title="Select (V)"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 2L3.5 13.5L7 10L11.5 14.5L13 13L9 8.5L13 8.5Z"/></svg></button>

--- a/site/playground.js
+++ b/site/playground.js
@@ -261,6 +261,173 @@ function updateFab(canvas) {
   }
 }
 
+/** ─── Layers Panel ────────────────────────────────────────────────────── */
+const LAYER_ICONS = {
+  group: '◻', frame: '▣', rect: '▢', ellipse: '○',
+  path: '〜', text: 'T', style: '◆', edge: '⟶', spec: '◇'
+};
+
+function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+/** Parse FD source into a hierarchical layer tree. */
+function parseLayerTree(source) {
+  const lines = source.split('\n');
+  const root = [];
+  const stack = [];
+  let braceDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const openBraces = (trimmed.match(/\{/g) || []).length;
+    const closeBraces = (trimmed.match(/\}/g) || []).length;
+
+    // Style definition
+    const styleMatch = trimmed.match(/^style\s+(\w+)\s*\{/);
+    if (styleMatch) {
+      const node = { id: styleMatch[1], kind: 'style', text: '', children: [] };
+      if (stack.length > 0) stack[stack.length - 1].node.children.push(node);
+      else root.push(node);
+      braceDepth += openBraces - closeBraces;
+      stack.push({ node, depth: braceDepth });
+      continue;
+    }
+
+    // Edge
+    const edgeMatch = trimmed.match(/^edge\s+@(\w+)\s*\{/);
+    if (edgeMatch) {
+      const node = { id: edgeMatch[1], kind: 'edge', text: '', children: [] };
+      if (stack.length > 0) stack[stack.length - 1].node.children.push(node);
+      else root.push(node);
+      braceDepth += openBraces - closeBraces;
+      stack.push({ node, depth: braceDepth });
+      continue;
+    }
+
+    // Typed node
+    const nodeMatch = trimmed.match(/^(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?/);
+    if (nodeMatch) {
+      const node = { id: nodeMatch[2], kind: nodeMatch[1], text: nodeMatch[3] || '', children: [] };
+      if (stack.length > 0) stack[stack.length - 1].node.children.push(node);
+      else root.push(node);
+      if (trimmed.endsWith('{')) { braceDepth += 1; stack.push({ node, depth: braceDepth }); }
+      continue;
+    }
+
+    // Closing brace
+    if (trimmed === '}') {
+      braceDepth -= 1;
+      while (stack.length > 0 && stack[stack.length - 1].depth > braceDepth) stack.pop();
+      continue;
+    }
+
+    braceDepth += openBraces - closeBraces;
+  }
+  return root;
+}
+
+/** Render a layer tree node as HTML. */
+function renderLayerNode(node, selectedId, depth = 0) {
+  const icon = LAYER_ICONS[node.kind] || '•';
+  const isSelected = node.id === selectedId;
+  const hasChildren = node.children.length > 0;
+
+  let indent = '';
+  for (let i = 0; i < depth; i++) indent += '<span class="layer-indent-guide"></span>';
+
+  const chevronClass = hasChildren ? 'layer-chevron expanded' : 'layer-chevron empty';
+  const chevron = `<span class="${chevronClass}" data-toggle-id="${escHtml(node.id)}">▶</span>`;
+
+  let html = `<div class="layer-item${isSelected ? ' selected' : ''}" data-node-id="${escHtml(node.id)}">`;
+  html += `<span class="layer-indent">${indent}</span>`;
+  html += chevron;
+  html += `<span class="layer-icon">${icon}</span>`;
+  html += `<span class="layer-name">${escHtml(node.id)}</span>`;
+  html += `<span class="layer-kind">${escHtml(node.kind)}</span>`;
+  html += '</div>';
+
+  if (hasChildren) {
+    html += `<div class="layer-children" data-parent-id="${escHtml(node.id)}">`;
+    for (const child of node.children) html += renderLayerNode(child, selectedId, depth + 1);
+    html += '</div>';
+  }
+  return html;
+}
+
+let lastLayerText = '';
+let lastLayerSelectedId = '';
+
+/** Refresh the layers panel. */
+function refreshLayersPanel() {
+  const panel = document.getElementById('layers-panel');
+  if (!panel || !fdCanvas) return;
+
+  const selectedId = fdCanvas.get_selected_id() || '';
+  const source = fdCanvas.get_text();
+
+  // Selection-only change: just update highlights
+  if (source === lastLayerText && selectedId !== lastLayerSelectedId) {
+    lastLayerSelectedId = selectedId;
+    panel.querySelectorAll('.layer-item').forEach(el =>
+      el.classList.toggle('selected', el.getAttribute('data-node-id') === selectedId)
+    );
+    const sel = panel.querySelector('.layer-item.selected');
+    if (sel) sel.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    return;
+  }
+
+  // No change at all
+  if (source === lastLayerText && selectedId === lastLayerSelectedId) return;
+
+  lastLayerText = source;
+  lastLayerSelectedId = selectedId;
+
+  const tree = parseLayerTree(source);
+  const countNodes = (nodes) => nodes.reduce((s, n) => s + 1 + countNodes(n.children), 0);
+  const total = countNodes(tree);
+
+  let html = '<div class="layers-header">';
+  html += '<span class="layers-title">Layers</span>';
+  html += `<span class="layers-count">${total}</span>`;
+  html += '</div><div class="layers-body">';
+  for (const node of tree) html += renderLayerNode(node, selectedId);
+  html += '</div>';
+
+  panel.innerHTML = html;
+
+  // Wire click-to-select
+  panel.querySelectorAll('.layer-item').forEach(item => {
+    item.addEventListener('click', (e) => {
+      if (e.target.closest('.layer-chevron')) return;
+      e.stopPropagation();
+      const nodeId = item.getAttribute('data-node-id');
+      if (nodeId && fdCanvas) {
+        fdCanvas.select_by_id(nodeId);
+        renderCanvas();
+        lastLayerSelectedId = nodeId;
+        panel.querySelectorAll('.layer-item').forEach(el =>
+          el.classList.toggle('selected', el.getAttribute('data-node-id') === nodeId)
+        );
+        updateFab(document.getElementById('fd-canvas'));
+      }
+    });
+  });
+
+  // Wire chevron toggle
+  panel.querySelectorAll('.layer-chevron:not(.empty)').forEach(chevron => {
+    chevron.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const toggleId = chevron.getAttribute('data-toggle-id');
+      const childrenEl = panel.querySelector(`.layer-children[data-parent-id="${toggleId}"]`);
+      if (childrenEl) {
+        const collapsed = childrenEl.classList.toggle('collapsed');
+        chevron.classList.toggle('expanded', !collapsed);
+      }
+    });
+  });
+}
+
 /** ─── Minimap ─────────────────────────────────────────────────────────── */
 let minimapLastRender = 0;
 const MINIMAP_INTERVAL = 100; // ~10fps
@@ -369,12 +536,13 @@ async function initPlayground() {
     const resizeCanvas = () => {
       const rect = wrapper.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
-      canvas.width = rect.width * dpr;
+      const canvasWidth = rect.width - 180; // layers panel offset
+      canvas.width = canvasWidth * dpr;
       canvas.height = rect.height * dpr;
-      canvas.style.width = rect.width + 'px';
+      canvas.style.width = canvasWidth + 'px';
       canvas.style.height = rect.height + 'px';
       if (fdCanvas) {
-        fdCanvas.resize(rect.width, rect.height);
+        fdCanvas.resize(canvasWidth, rect.height);
       }
     };
 
@@ -382,7 +550,8 @@ async function initPlayground() {
 
     // Create the FdCanvas instance
     const rect = wrapper.getBoundingClientRect();
-    fdCanvas = new wasm.FdCanvas(rect.width, rect.height);
+    const canvasW = rect.width - 180;
+    fdCanvas = new wasm.FdCanvas(canvasW, rect.height);
     fdCanvas.set_theme(isDark);
     fdCanvas.set_text(editor.value);
 
@@ -392,9 +561,10 @@ async function initPlayground() {
     // Render loop — continuous for hover effects and animations
     const renderLoop = (time) => {
       renderCanvas();
-      // Minimap at ~10fps
+      // Minimap + Layers at ~10fps
       if (time - minimapLastRender > MINIMAP_INTERVAL) {
         renderMinimap(canvas);
+        refreshLayersPanel();
         minimapLastRender = time;
       }
       animFrameId = requestAnimationFrame(renderLoop);

--- a/site/style.css
+++ b/site/style.css
@@ -410,15 +410,140 @@ code {
   overflow: hidden;
 }
 #fd-canvas {
-  width: 100%;
+  position: absolute;
+  left: 180px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: calc(100% - 180px);
   height: 100%;
   display: block;
+}
+
+/* ─── Layers Panel ─── */
+#layers-panel {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 180px;
+  background: rgba(22, 27, 34, 0.92);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  z-index: 15;
+  overflow-y: auto;
+  font-size: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+}
+#layers-panel::-webkit-scrollbar { width: 4px; }
+#layers-panel::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+.layers-header {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  position: sticky;
+  top: 0;
+  background: rgba(22, 27, 34, 0.95);
+  z-index: 1;
+}
+.layers-title {
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+.layers-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+.layers-body {
+  padding: 4px 0;
+}
+.layer-item {
+  display: flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 8px 0 4px;
+  cursor: pointer;
+  transition: background 0.1s ease;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.layer-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.layer-item.selected {
+  background: rgba(108, 92, 231, 0.25);
+}
+.layer-indent {
+  display: flex;
+  flex-shrink: 0;
+}
+.layer-indent-guide {
+  display: inline-block;
+  width: 12px;
+  flex-shrink: 0;
+}
+.layer-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  font-size: 7px;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+  user-select: none;
+}
+.layer-chevron.expanded {
+  transform: rotate(90deg);
+}
+.layer-chevron.empty {
+  visibility: hidden;
+}
+.layer-icon {
+  font-size: 11px;
+  margin-right: 4px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+.layer-name {
+  flex: 1;
+  color: var(--text-primary);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.layer-kind {
+  font-size: 9px;
+  color: var(--text-muted);
+  margin-left: 4px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.layer-item:hover .layer-kind {
+  opacity: 1;
+}
+.layer-children.collapsed {
+  display: none;
 }
 
 /* ─── Floating Toolbar ─── */
 #floating-toolbar {
   position: absolute;
-  left: 12px;
+  left: 192px;
   top: 50%;
   transform: translateY(-50%);
   z-index: 20;


### PR DESCRIPTION
## Summary

Add a layers panel (tree view sidebar) to the fast-draft.com playground canvas, matching the VS Code extension's layers panel.

## Changes

### site/index.html
- Added `#layers-panel` div inside `#canvas-wrapper` before canvas

### site/style.css (+120 lines)
- `#layers-panel`: 180px absolute left sidebar with glassmorphic background
- `.layers-header`: sticky header with title + count badge
- `.layer-item`: 26px flex rows with hover/selected states
- `.layer-indent-guide`, `.layer-chevron`, `.layer-icon`, `.layer-name`, `.layer-kind`
- `.layer-children.collapsed`: display:none for collapsed groups
- Moved `#fd-canvas` to `left: 180px; width: calc(100%-180px)`
- Moved `#floating-toolbar` to `left: 192px`

### site/playground.js (~175 lines)
- Ported `parseLayerTree()` from extension — parses FD text into `{id, kind, text, children[]}` tree
- Ported `renderLayerNode()` — generates HTML per node with indent guides and chevrons
- `refreshLayersPanel()` with diff-based skip (text + selectedId comparison)
- Click on layer item → `fdCanvas.select_by_id()` + render + FAB update
- Chevron click → expand/collapse children
- Throttled at ~10fps in render loop alongside minimap
- `resizeCanvas()` and `FdCanvas` init adjusted for 180px offset

### docs/
- CHANGELOG.md: v0.10.73 entry
- REQUIREMENTS.md: Updated R6.6