### PR TITLE
feat(site): add properties panel to playground canvas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.74 — Properties Panel (R6.6)
+
+- **UX (R6.6)**: Properties panel (right sidebar) in playground canvas — 200px panel showing selected node's ID, kind, position (X/Y readonly), size (W/H editable), fill color, stroke color + width, corner radius, opacity slider, duplicate + delete actions
+- **SITE**: `updatePropertiesPanel()` reads `get_selected_node_props()` JSON; input handlers call `set_node_prop(key, value)` with debounce; minimap shifts right when panel is visible
+- **SITE**: Panel hidden by default, appears on node selection (pointerup, layer click, render loop throttle)
+
 ### v0.10.74 — Remove Redundant Auto-Comments on Text Nodes (R4.21)
 
 - **CLEANUP (R4.21)**: Text nodes no longer get `# [auto] label: "..."` comments — text content is already visible inline in the node declaration (e.g. `text @title "Dashboard"`), making the auto-comment 100% redundant; saves ~6% tokens in typical files; container, styled-shape, and edge-connection auto-comments are preserved

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), layers panel (tree view sidebar with expand/collapse), floating toolbar with 7 SVG tool buttons (matching VS Code extension), minimap with zoom controls (bottom-right, click-to-pan, +/−/reset), undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), layers panel (tree view sidebar), properties panel (right sidebar with fill/stroke/opacity/size editing + duplicate/delete), floating toolbar with 7 SVG tool buttons, minimap with zoom controls, undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -146,6 +146,38 @@
               <div class="fab-sep"></div>
               <button id="fab-delete" class="fab-delete" title="Delete (⌫)">🗑</button>
             </div>
+            <div id="props-panel">
+              <div class="pp-header">
+                <span class="pp-node-id" id="pp-node-id">—</span>
+                <span class="pp-kind" id="pp-kind"></span>
+              </div>
+              <div class="pp-section">
+                <div class="pp-section-title">Position & Size</div>
+                <div class="pp-grid">
+                  <label class="pp-field"><span>X</span><input type="number" id="pp-x" readonly></label>
+                  <label class="pp-field"><span>Y</span><input type="number" id="pp-y" readonly></label>
+                  <label class="pp-field"><span>W</span><input type="number" id="pp-w" min="1"></label>
+                  <label class="pp-field"><span>H</span><input type="number" id="pp-h" min="1"></label>
+                </div>
+              </div>
+              <div class="pp-section" id="pp-appearance">
+                <div class="pp-section-title">Appearance</div>
+                <label class="pp-row"><span>Fill</span><input type="color" id="pp-fill" value="#6C5CE7"></label>
+                <label class="pp-row"><span>Stroke</span><input type="color" id="pp-stroke" value="#333333"></label>
+                <label class="pp-row"><span>Stroke W</span><input type="number" id="pp-stroke-w" min="0" step="0.5" value="0"></label>
+                <label class="pp-row"><span>Corner</span><input type="number" id="pp-corner" min="0" value="0"></label>
+                <label class="pp-row"><span>Opacity</span>
+                  <div class="pp-opacity-wrap">
+                    <input type="range" id="pp-opacity" min="0" max="1" step="0.01" value="1">
+                    <span id="pp-opacity-val">100%</span>
+                  </div>
+                </label>
+              </div>
+              <div class="pp-section pp-actions">
+                <button class="pp-action-btn" id="pp-duplicate" title="Duplicate">⧉ Duplicate</button>
+                <button class="pp-action-btn pp-delete" id="pp-delete" title="Delete">🗑 Delete</button>
+              </div>
+            </div>
             <div id="canvas-loading" class="canvas-loading">
               <div class="skeleton-preview">
                 <div class="skeleton-shape skeleton-rect"></div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -261,6 +261,141 @@ function updateFab(canvas) {
   }
 }
 
+/** ─── Properties Panel ──────────────────────────────────────────────── */
+let propsSuppressSync = false;
+
+/** Show/hide and populate the properties panel for the selected node. */
+function updatePropertiesPanel() {
+  const panel = document.getElementById('props-panel');
+  if (!panel || !fdCanvas) { panel?.classList.remove('visible'); adjustMinimapForProps(false); return; }
+
+  const json = fdCanvas.get_selected_node_props();
+  let props;
+  try { props = JSON.parse(json); } catch (_) { panel.classList.remove('visible'); adjustMinimapForProps(false); return; }
+
+  if (!props.id) {
+    panel.classList.remove('visible');
+    adjustMinimapForProps(false);
+    return;
+  }
+
+  propsSuppressSync = true;
+  panel.classList.add('visible');
+  adjustMinimapForProps(true);
+
+  // Header
+  document.getElementById('pp-node-id').textContent = `@${props.id}`;
+  document.getElementById('pp-kind').textContent = props.kind || '';
+
+  // Position & Size
+  const setVal = (id, val) => { const el = document.getElementById(id); if (el) el.value = val !== undefined ? Math.round(val) : ''; };
+  setVal('pp-x', props.x);
+  setVal('pp-y', props.y);
+  setVal('pp-w', props.width);
+  setVal('pp-h', props.height);
+
+  // Fill color
+  const fillEl = document.getElementById('pp-fill');
+  if (fillEl && props.fill) {
+    let hex = props.fill;
+    if (hex.length === 4) hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+    fillEl.value = hex.substring(0, 7);
+  }
+
+  // Stroke
+  const strokeEl = document.getElementById('pp-stroke');
+  if (strokeEl && props.strokeColor) {
+    let hex = props.strokeColor;
+    if (hex.length === 4) hex = `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+    strokeEl.value = hex.substring(0, 7);
+  }
+  setVal('pp-stroke-w', props.strokeWidth);
+  setVal('pp-corner', props.cornerRadius);
+
+  // Opacity
+  const opSlider = document.getElementById('pp-opacity');
+  const opVal = document.getElementById('pp-opacity-val');
+  const opacity = props.opacity !== undefined ? props.opacity : 1;
+  if (opSlider) opSlider.value = opacity;
+  if (opVal) opVal.textContent = Math.round(opacity * 100) + '%';
+
+  // Hide appearance for groups
+  const appearance = document.getElementById('pp-appearance');
+  if (appearance) appearance.style.display = (props.kind === 'root' || props.kind === 'group') ? 'none' : '';
+
+  propsSuppressSync = false;
+}
+
+/** Shift minimap when props panel is visible. */
+function adjustMinimapForProps(visible) {
+  const mc = document.getElementById('minimap-container');
+  if (mc) mc.style.right = visible ? '212px' : '12px';
+}
+
+/** Wire input handlers for the properties panel fields. */
+function setupPropsPanel(editor) {
+  const propChange = (key, el) => {
+    if (propsSuppressSync || !fdCanvas) return;
+    const changed = fdCanvas.set_node_prop(key, el.value);
+    if (changed) { renderCanvas(); syncCanvasToEditor(editor); }
+  };
+
+  // W/H inputs (debounced)
+  let debounce = null;
+  ['pp-w', 'pp-h'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const key = id === 'pp-w' ? 'width' : 'height';
+    el.addEventListener('input', () => {
+      clearTimeout(debounce);
+      debounce = setTimeout(() => propChange(key, el), 150);
+    });
+  });
+
+  // Fill color
+  document.getElementById('pp-fill')?.addEventListener('input', function() { propChange('fill', this); });
+
+  // Stroke color
+  document.getElementById('pp-stroke')?.addEventListener('input', function() { propChange('strokeColor', this); });
+
+  // Stroke width
+  document.getElementById('pp-stroke-w')?.addEventListener('input', function() {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => propChange('strokeWidth', this), 150);
+  });
+
+  // Corner radius
+  document.getElementById('pp-corner')?.addEventListener('input', function() {
+    clearTimeout(debounce);
+    debounce = setTimeout(() => propChange('cornerRadius', this), 150);
+  });
+
+  // Opacity slider
+  const opSlider = document.getElementById('pp-opacity');
+  const opVal = document.getElementById('pp-opacity-val');
+  if (opSlider) {
+    opSlider.addEventListener('input', () => {
+      if (opVal) opVal.textContent = Math.round(parseFloat(opSlider.value) * 100) + '%';
+      clearTimeout(debounce);
+      debounce = setTimeout(() => propChange('opacity', opSlider), 100);
+    });
+  }
+
+  // Duplicate
+  document.getElementById('pp-duplicate')?.addEventListener('click', () => {
+    if (!fdCanvas) return;
+    const changed = fdCanvas.duplicate_selected();
+    if (changed) { renderCanvas(); syncCanvasToEditor(editor); updatePropertiesPanel(); }
+  });
+
+  // Delete
+  document.getElementById('pp-delete')?.addEventListener('click', () => {
+    if (!fdCanvas) return;
+    const changed = fdCanvas.delete_selected();
+    if (changed) { renderCanvas(); syncCanvasToEditor(editor); updatePropertiesPanel(); }
+  });
+}
+
 /** ─── Layers Panel ────────────────────────────────────────────────────── */
 const LAYER_ICONS = {
   group: '◻', frame: '▣', rect: '▢', ellipse: '○',
@@ -410,6 +545,7 @@ function refreshLayersPanel() {
           el.classList.toggle('selected', el.getAttribute('data-node-id') === nodeId)
         );
         updateFab(document.getElementById('fd-canvas'));
+        updatePropertiesPanel();
       }
     });
   });
@@ -554,6 +690,7 @@ async function initPlayground() {
     fdCanvas = new wasm.FdCanvas(canvasW, rect.height);
     fdCanvas.set_theme(isDark);
     fdCanvas.set_text(editor.value);
+    setupPropsPanel(editor);
 
     // Get canvas 2D context
     ctx = canvas.getContext('2d');
@@ -565,6 +702,7 @@ async function initPlayground() {
       if (time - minimapLastRender > MINIMAP_INTERVAL) {
         renderMinimap(canvas);
         refreshLayersPanel();
+        updatePropertiesPanel();
         minimapLastRender = time;
       }
       animFrameId = requestAnimationFrame(renderLoop);
@@ -667,8 +805,9 @@ async function initPlayground() {
         canvas.style.cursor = '';
       }
 
-      // Show FAB if node selected
+      // Show FAB + Props if node selected
       updateFab(canvas);
+      updatePropertiesPanel();
     });
 
     // ── Wheel → Pan / Zoom ────────────────────────────────────────────

--- a/site/style.css
+++ b/site/style.css
@@ -640,6 +640,173 @@ code {
   color: var(--text-secondary);
 }
 
+/* ─── Properties Panel ─── */
+#props-panel {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 200px;
+  background: rgba(22, 27, 34, 0.92);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  z-index: 15;
+  overflow-y: auto;
+  padding: 12px;
+  font-size: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255,255,255,0.1) transparent;
+}
+#props-panel::-webkit-scrollbar { width: 4px; }
+#props-panel::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 2px; }
+#props-panel.visible { display: block; }
+.pp-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.pp-node-id {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+.pp-kind {
+  font-size: 9px;
+  color: var(--accent);
+  background: rgba(108, 92, 231, 0.15);
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.pp-section {
+  margin-bottom: 12px;
+}
+.pp-section-title {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+}
+.pp-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+}
+.pp-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.pp-field span {
+  font-size: 10px;
+  color: var(--text-muted);
+  width: 14px;
+  flex-shrink: 0;
+}
+.pp-field input {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 3px 6px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: var(--mono);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.pp-field input:focus {
+  border-color: var(--accent);
+}
+.pp-field input[readonly] {
+  opacity: 0.5;
+  cursor: default;
+}
+.pp-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.pp-row span {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.pp-row input[type="color"] {
+  width: 28px;
+  height: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+.pp-row input[type="number"] {
+  width: 60px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 3px 6px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: var(--mono);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+.pp-row input[type="number"]:focus {
+  border-color: var(--accent);
+}
+.pp-opacity-wrap {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pp-opacity-wrap input[type="range"] {
+  width: 80px;
+  accent-color: var(--accent);
+  height: 4px;
+}
+.pp-opacity-wrap span {
+  font-size: 10px;
+  color: var(--text-muted);
+  width: 32px;
+  text-align: right;
+}
+.pp-actions {
+  display: flex;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.pp-action-btn {
+  flex: 1;
+  padding: 5px 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  transition: all 0.15s ease;
+}
+.pp-action-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+}
+.pp-action-btn:active { transform: scale(0.95); }
+.pp-action-btn.pp-delete:hover {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
 /* ─── Minimap ─── */
 #minimap-container {
   position: absolute;


### PR DESCRIPTION
## Summary

Add a properties panel (right sidebar) to the fast-draft.com playground canvas for editing selected node attributes.

## Changes

### site/index.html (+32 lines)
- Added `#props-panel` div with header, position/size grid, appearance section, and action buttons

### site/style.css (+167 lines)
- `#props-panel`: 200px right sidebar, hidden by default, visible on selection
- `.pp-header`: node ID + kind badge with accent color
- `.pp-grid`: 2-column layout for X/Y/W/H fields
- `.pp-row`: key-value rows for colors, numbers, opacity
- `.pp-action-btn`: duplicate + delete with hover states
- Minimap shifts right when panel is visible

### site/playground.js (+138 lines)
- `updatePropertiesPanel()`: reads `get_selected_node_props()`, populates all fields
- `setupPropsPanel(editor)`: wires input handlers with debounce for W/H, fill, stroke, strokeWidth, cornerRadius, opacity
- Duplicate + delete action buttons
- `adjustMinimapForProps()`: shifts minimap right when panel is open
- Called after pointerup, layer click, and in throttled render loop

### docs/
- CHANGELOG.md: v0.10.74 entry
- REQUIREMENTS.md: Updated R6.6