### PR TITLE
feat(site): add right-click context menu to playground canvas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.75 — Context Menu (R6.6)
+
+- **UX (R6.6)**: Right-click context menu on playground canvas — glassmorphic dropdown with 8 actions: Duplicate, Delete, Bring Forward, Send Backward, Group, Ungroup, Copy as .fd; auto-selects node under cursor via `hit_test_at()`; dismisses on outside click, Escape, or pointerdown
+- **SITE**: `setupContextMenu(editor)` wires contextmenu event, action dispatch via `handle_key` / `group_selected` / `ungroup_selected` / `duplicate_selected` / `delete_selected`, and viewport-aware positioning
+
 ### v0.10.74 — Properties Panel (R6.6)
 
 - **UX (R6.6)**: Properties panel (right sidebar) in playground canvas — 200px panel showing selected node's ID, kind, position (X/Y readonly), size (W/H editable), fill color, stroke color + width, corner radius, opacity slider, duplicate + delete actions

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -162,7 +162,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R6.3** _(future)_: Mobile app (iOS, Android) via native wgpu
 - **R6.4** _(future)_: Web app (standalone browser app)
 - **R6.5** _(done)_: GitHub Pages landing site at [fast-draft.com](https://fast-draft.com) with live WASM playground, custom domain (Cloudflare DNS), and auto-deploy via GitHub Actions (`pages.yml`)
-- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), layers panel (tree view sidebar), properties panel (right sidebar with fill/stroke/opacity/size editing + duplicate/delete), floating toolbar with 7 SVG tool buttons, minimap with zoom controls, undo/redo header buttons, clickable zoom reset, floating action bar (FAB), zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
+- **R6.6** _(done)_: Interactive playground — canvas supports pointer events (select, drag, draw), layers panel (tree view sidebar), properties panel (right sidebar with fill/stroke/opacity/size), right-click context menu (duplicate/delete/z-order/group/copy), floating toolbar with 7 SVG tool buttons, minimap with zoom controls, undo/redo header buttons, clickable zoom reset, FAB, zoom/pan navigation, keyboard shortcuts, undo/redo, and bidirectional code↔canvas sync; zero Rust changes, all in `playground.js`/`index.html`/`style.css`
 
 ## Non-Functional Requirements
 

--- a/site/index.html
+++ b/site/index.html
@@ -178,6 +178,18 @@
                 <button class="pp-action-btn pp-delete" id="pp-delete" title="Delete">🗑 Delete</button>
               </div>
             </div>
+            <div id="ctx-menu">
+              <button class="ctx-item" data-action="duplicate">⧉ Duplicate</button>
+              <button class="ctx-item" data-action="delete">🗑 Delete</button>
+              <div class="ctx-sep"></div>
+              <button class="ctx-item" data-action="bring-forward">↑ Bring Forward</button>
+              <button class="ctx-item" data-action="send-backward">↓ Send Backward</button>
+              <div class="ctx-sep"></div>
+              <button class="ctx-item" data-action="group">⊞ Group</button>
+              <button class="ctx-item" data-action="ungroup">⊟ Ungroup</button>
+              <div class="ctx-sep"></div>
+              <button class="ctx-item" data-action="copy-fd">📋 Copy as .fd</button>
+            </div>
             <div id="canvas-loading" class="canvas-loading">
               <div class="skeleton-preview">
                 <div class="skeleton-shape skeleton-rect"></div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -396,6 +396,99 @@ function setupPropsPanel(editor) {
   });
 }
 
+/** ─── Context Menu ──────────────────────────────────────────────────── */
+function closeContextMenu() {
+  document.getElementById('ctx-menu')?.classList.remove('visible');
+}
+
+/** Wire context menu events and action handlers. */
+function setupContextMenu(editor) {
+  const menu = document.getElementById('ctx-menu');
+  const canvas = document.getElementById('fd-canvas');
+  if (!menu || !canvas) return;
+
+  // Right-click on canvas
+  canvas.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+    if (!fdCanvas) return;
+
+    const { x, y } = screenToScene(e.clientX, e.clientY, canvas);
+    const hitId = fdCanvas.hit_test_at(x, y);
+    if (hitId) {
+      fdCanvas.select_by_id(hitId);
+      renderCanvas();
+      updateFab(canvas);
+      updatePropertiesPanel();
+    }
+
+    // Position menu (keep within viewport)
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let mx = e.clientX;
+    let my = e.clientY;
+    if (mx + 170 > vw) mx = vw - 174;
+    if (my + 280 > vh) my = vh - 284;
+    menu.style.left = mx + 'px';
+    menu.style.top = my + 'px';
+    menu.classList.add('visible');
+  });
+
+  // Action handlers
+  const doAction = (action) => {
+    if (!fdCanvas) return;
+    let changed = false;
+    switch (action) {
+      case 'duplicate':
+        changed = fdCanvas.duplicate_selected();
+        break;
+      case 'delete':
+        changed = fdCanvas.delete_selected();
+        break;
+      case 'bring-forward': {
+        const r = JSON.parse(fdCanvas.handle_key(']', false, false, false, true));
+        changed = r.changed;
+        break;
+      }
+      case 'send-backward': {
+        const r = JSON.parse(fdCanvas.handle_key('[', false, false, false, true));
+        changed = r.changed;
+        break;
+      }
+      case 'group':
+        changed = fdCanvas.group_selected();
+        break;
+      case 'ungroup':
+        changed = fdCanvas.ungroup_selected();
+        break;
+      case 'copy-fd':
+        navigator.clipboard.writeText(fdCanvas.get_text()).catch(() => {});
+        break;
+    }
+    if (changed) {
+      renderCanvas();
+      syncCanvasToEditor(editor);
+      updatePropertiesPanel();
+    }
+    closeContextMenu();
+  };
+
+  menu.querySelectorAll('.ctx-item').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      doAction(btn.getAttribute('data-action'));
+    });
+  });
+
+  // Dismiss on outside click, escape, scroll
+  document.addEventListener('click', (e) => {
+    if (!menu.contains(e.target)) closeContextMenu();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeContextMenu();
+  });
+  canvas.addEventListener('pointerdown', closeContextMenu);
+}
+
 /** ─── Layers Panel ────────────────────────────────────────────────────── */
 const LAYER_ICONS = {
   group: '◻', frame: '▣', rect: '▢', ellipse: '○',
@@ -691,6 +784,7 @@ async function initPlayground() {
     fdCanvas.set_theme(isDark);
     fdCanvas.set_text(editor.value);
     setupPropsPanel(editor);
+    setupContextMenu(editor);
 
     // Get canvas 2D context
     ctx = canvas.getContext('2d');

--- a/site/style.css
+++ b/site/style.css
@@ -807,6 +807,47 @@ code {
   border-color: rgba(239, 68, 68, 0.3);
 }
 
+/* ─── Context Menu ─── */
+#ctx-menu {
+  display: none;
+  position: fixed;
+  z-index: 100;
+  min-width: 160px;
+  padding: 6px;
+  background: rgba(22, 27, 34, 0.95);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+#ctx-menu.visible { display: block; }
+.ctx-item {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.1s ease;
+}
+.ctx-item:hover {
+  background: var(--accent);
+  color: #fff;
+}
+.ctx-item[data-action="delete"]:hover {
+  background: rgba(239, 68, 68, 0.8);
+}
+.ctx-sep {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: 4px 6px;
+}
+
 /* ─── Minimap ─── */
 #minimap-container {
   position: absolute;


### PR DESCRIPTION
## Summary

Add a right-click context menu to the fast-draft.com playground canvas.

## Changes

### site/index.html (+12 lines)
- `#ctx-menu` with 8 action buttons + 3 separators

### site/style.css (+41 lines)
- Glassmorphic dropdown: `position: fixed; z-index: 100; border-radius: 10px`
- `.ctx-item`: hover → accent background, delete → red hover
- `.ctx-sep`: subtle divider lines

### site/playground.js (+93 lines)
- `setupContextMenu(editor)`: wires contextmenu event with `hit_test_at()` auto-select
- `doAction()` switch: duplicate, delete, bring-forward (⌘]), send-backward (⌘[), group, ungroup, copy-fd
- Viewport-aware positioning (stays within screen bounds)
- Dismiss: outside click, Escape, pointerdown

### docs/
- CHANGELOG.md: v0.10.75
- REQUIREMENTS.md: Updated R6.6