### PR TITLE
feat(site): replace inline toggles with settings menu dropdown

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -88,13 +88,23 @@
           </select>
         </div>
         <div class="toolbar-right">
-          <button id="sketchy-toggle" class="toolbar-btn" title="Toggle sketchy mode">
-            ✏️ Sketchy
-          </button>
-          <button id="theme-toggle" class="toolbar-btn" title="Toggle theme">
-            🌙 Dark
-          </button>
+          <button id="settings-btn" class="toolbar-btn" title="Settings">⚙</button>
         </div>
+      </div>
+      <div id="settings-menu">
+        <button class="sm-item" data-setting="dark-mode">
+          <span class="sm-label">🌙 Dark Mode</span><span class="sm-toggle" id="sm-dark"></span>
+        </button>
+        <button class="sm-item" data-setting="sketchy">
+          <span class="sm-label">✏️ Sketchy</span><span class="sm-toggle" id="sm-sketchy"></span>
+        </button>
+        <button class="sm-item" data-setting="grid">
+          <span class="sm-label">⊞ Grid</span><span class="sm-toggle" id="sm-grid"></span>
+        </button>
+        <div class="sm-sep"></div>
+        <button class="sm-item" data-setting="fit">
+          <span class="sm-label">⊡ Fit to Content</span>
+        </button>
       </div>
       <div id="playground-container" class="playground-split">
         <div class="playground-editor">

--- a/site/playground.js
+++ b/site/playground.js
@@ -1155,19 +1155,86 @@ async function initPlayground() {
       }
     });
 
-    // ── Theme Toggle ──────────────────────────────────────────────────
-    document.getElementById('theme-toggle').addEventListener('click', function() {
-      isDark = !isDark;
-      if (fdCanvas) fdCanvas.set_theme(isDark);
-      this.textContent = isDark ? '🌙 Dark' : '☀️ Light';
-      this.classList.toggle('active', !isDark);
+    // ── Settings Menu ─────────────────────────────────────────────────
+    const settingsBtn = document.getElementById('settings-btn');
+    const settingsMenu = document.getElementById('settings-menu');
+
+    function updateSettingsToggles() {
+      document.getElementById('sm-dark')?.classList.toggle('on', isDark);
+      document.getElementById('sm-sketchy')?.classList.toggle('on', isSketchy);
+      document.getElementById('sm-grid')?.classList.toggle('on', gridEnabled);
+    }
+
+    settingsBtn?.addEventListener('click', (e) => {
+      e.stopPropagation();
+      updateSettingsToggles();
+      settingsMenu?.classList.toggle('visible');
     });
 
-    // ── Sketchy Toggle ────────────────────────────────────────────────
-    document.getElementById('sketchy-toggle').addEventListener('click', function() {
-      isSketchy = !isSketchy;
-      if (fdCanvas) fdCanvas.set_sketchy_mode(isSketchy);
-      this.classList.toggle('active', isSketchy);
+    settingsMenu?.querySelectorAll('.sm-item').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const setting = btn.getAttribute('data-setting');
+        switch (setting) {
+          case 'dark-mode':
+            isDark = !isDark;
+            if (fdCanvas) fdCanvas.set_theme(isDark);
+            break;
+          case 'sketchy':
+            isSketchy = !isSketchy;
+            if (fdCanvas) fdCanvas.set_sketchy_mode(isSketchy);
+            break;
+          case 'grid':
+            gridEnabled = !gridEnabled;
+            break;
+          case 'fit': {
+            // Fit to content: scan all nodes, compute bounding box, set zoom+pan
+            if (fdCanvas) {
+              const text = fdCanvas.get_text();
+              const idRegex = /@([a-zA-Z_][a-zA-Z0-9_]*)/g;
+              const nodes = [];
+              let m;
+              while ((m = idRegex.exec(text)) !== null) {
+                try {
+                  const bj = fdCanvas.get_node_bounds(m[1]);
+                  if (!bj) continue;
+                  const b = JSON.parse(bj);
+                  if (b.width > 0 && b.height > 0) nodes.push(b);
+                } catch (_) {}
+              }
+              if (nodes.length > 0) {
+                let sx = Infinity, sy = Infinity, sx2 = -Infinity, sy2 = -Infinity;
+                for (const n of nodes) {
+                  sx = Math.min(sx, n.x);
+                  sy = Math.min(sy, n.y);
+                  sx2 = Math.max(sx2, n.x + n.width);
+                  sy2 = Math.max(sy2, n.y + n.height);
+                }
+                const pad = 40;
+                sx -= pad; sy -= pad; sx2 += pad; sy2 += pad;
+                const sw = sx2 - sx, sh = sy2 - sy;
+                const cw = canvas.clientWidth, ch = canvas.clientHeight;
+                zoomLevel = Math.min(cw / sw, ch / sh, ZOOM_MAX);
+                zoomLevel = Math.max(zoomLevel, ZOOM_MIN);
+                panX = (cw - sw * zoomLevel) / 2 - sx * zoomLevel;
+                panY = (ch - sh * zoomLevel) / 2 - sy * zoomLevel;
+                updateZoomIndicator();
+              }
+            }
+            settingsMenu?.classList.remove('visible');
+            renderCanvas();
+            return;
+          }
+        }
+        updateSettingsToggles();
+        renderCanvas();
+      });
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!settingsMenu?.contains(e.target) && e.target !== settingsBtn) {
+        settingsMenu?.classList.remove('visible');
+      }
     });
 
   } catch (err) {

--- a/site/style.css
+++ b/site/style.css
@@ -311,6 +311,7 @@ code {
   margin-bottom: 12px;
   flex-wrap: wrap;
   gap: 12px;
+  position: relative;
 }
 .toolbar-left, .toolbar-right {
   display: flex;
@@ -355,6 +356,62 @@ code {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
+}
+
+/* ─── Settings Menu ─── */
+#settings-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 50;
+  min-width: 180px;
+  padding: 6px;
+  background: rgba(22, 27, 34, 0.95);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  margin-top: 4px;
+}
+#settings-menu.visible { display: block; }
+.sm-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.1s ease;
+}
+.sm-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+}
+.sm-toggle {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: all 0.15s ease;
+}
+.sm-toggle.on {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 6px rgba(99, 102, 241, 0.5);
+}
+.sm-sep {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: 4px 6px;
 }
 
 .playground-split {


### PR DESCRIPTION
## Summary

Replace inline theme/sketchy toggle buttons with a unified ⚙ settings menu dropdown.

## Changes

### site/index.html (+10 lines)
- Replaced `#sketchy-toggle` + `#theme-toggle` with single `#settings-btn` (⚙)
- Added `#settings-menu` dropdown with 4 items: Dark Mode, Sketchy, Grid (toggles) + Fit to Content

### site/style.css (+56 lines)
- Frosted glass dropdown: `position: absolute; right: 0; top: 100%; z-index: 50`
- `.sm-item` full-width buttons with `.sm-toggle` indicator dots
- Toggle dot: accent color + glow when active (`.on`)

### site/playground.js (+86 lines, -14 lines)
- `updateSettingsToggles()` syncs indicator dot states
- Toggle handlers: dark-mode, sketchy, grid
- Fit to Content: scans all `@id` node bounds, computes bounding box, sets zoom+pan to fit
- Outside-click dismiss