### PR TITLE
feat(site): add Zen mode toggle + responsive polish

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -112,6 +112,10 @@
         <button class="sm-item" data-setting="export-svg" id="sm-export-svg">
           <span class="sm-label">📄 Download SVG</span>
         </button>
+        <div class="sm-sep"></div>
+        <button class="sm-item" data-setting="zen">
+          <span class="sm-label">🧘 Zen Mode</span><span class="sm-toggle" id="sm-zen"></span>
+        </button>
       </div>
       <div id="playground-container" class="playground-split">
         <div class="playground-editor">

--- a/site/playground.js
+++ b/site/playground.js
@@ -181,6 +181,7 @@ let panDragging = false;
 let zoomLevel = 1.0;
 let gridEnabled = false;
 const GRID_SPACING = 20;
+let zenMode = false;
 const ZOOM_MIN = 0.1, ZOOM_MAX = 5;
 let isPanning = false;
 
@@ -305,6 +306,10 @@ function updateFab(canvas) {
 
   const selectedId = fdCanvas.get_selected_id();
   if (!selectedId) { fab.classList.remove('visible'); return; }
+
+  // Hide FAB when props panel is visible
+  const propsPanel = document.getElementById('props-panel');
+  if (propsPanel?.classList.contains('visible')) { fab.classList.remove('visible'); return; }
 
   try {
     const boundsJson = fdCanvas.get_node_bounds(selectedId);
@@ -554,7 +559,16 @@ function setupContextMenu(editor) {
     if (!menu.contains(e.target)) closeContextMenu();
   });
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') closeContextMenu();
+    if (e.key === 'Escape') {
+      closeContextMenu();
+      // Exit Zen mode on Escape
+      if (zenMode) {
+        zenMode = false;
+        document.querySelector('.hero-playground')?.classList.remove('zen-mode');
+        resizeCanvas();
+        renderCanvas();
+      }
+    }
   });
   canvas.addEventListener('pointerdown', closeContextMenu);
 }
@@ -1200,6 +1214,7 @@ async function initPlayground() {
       document.getElementById('sm-dark')?.classList.toggle('on', isDark);
       document.getElementById('sm-sketchy')?.classList.toggle('on', isSketchy);
       document.getElementById('sm-grid')?.classList.toggle('on', gridEnabled);
+      document.getElementById('sm-zen')?.classList.toggle('on', zenMode);
     }
 
     settingsBtn?.addEventListener('click', (e) => {
@@ -1224,6 +1239,15 @@ async function initPlayground() {
           case 'grid':
             gridEnabled = !gridEnabled;
             break;
+          case 'zen': {
+            zenMode = !zenMode;
+            document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
+            settingsMenu?.classList.remove('visible');
+            // Trigger resize after layout change
+            setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
+            updateSettingsToggles();
+            return;
+          }
           case 'fit': {
             // Fit to content: scan all nodes, compute bounding box, set zoom+pan
             if (fdCanvas) {

--- a/site/style.css
+++ b/site/style.css
@@ -1374,6 +1374,13 @@ code {
   transform: translateY(0);
 }
 
+/* ─── Zen Mode ─── */
+.zen-mode .playground-toolbar { display: none !important; }
+.zen-mode #settings-menu { display: none !important; }
+.zen-mode .playground-editor { display: none !important; }
+.zen-mode .playground-split { grid-template-columns: 1fr; }
+.zen-mode .playground-canvas { min-height: 500px; }
+
 /* ─── Responsive ─── */
 @media (max-width: 768px) {
   .nav-links {
@@ -1413,6 +1420,10 @@ code {
   .hero-sub { font-size: 1rem; }
 
   .playground-label { display: none; }
+
+  #layers-panel, #props-panel { display: none !important; }
+  #floating-toolbar { left: 8px; }
+  #minimap-container { display: none; }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary

Add Zen mode toggle and responsive polish to the playground canvas.

## Changes

### site/index.html (+4 lines)
- 🧘 Zen Mode toggle with indicator dot in settings menu

### site/style.css (+10 lines)
- `.zen-mode`: hides editor, toolbar, settings menu; canvas full-width, min-height 500px
- Responsive `@media (≤768px)`: hide layers/props panels, minimap; adjust toolbar left

### site/playground.js (+26 lines)
- `zenMode` state variable
- Settings toggle: adds/removes `.zen-mode` class on `.hero-playground`, triggers `resizeCanvas()`
- Escape exits Zen mode
- FAB hidden when props panel is visible (prevents overlap)
- `updateSettingsToggles()` includes zen indicator dot