### PR TITLE
refactor: update remaining theme→style refs in examples, TypeScript, LSP, tree-sitter

### DIFF
--- a/crates/fd-lsp/src/completion.rs
+++ b/crates/fd-lsp/src/completion.rs
@@ -91,9 +91,9 @@ fn top_level_completions() -> Vec<CompletionItem> {
             "frame @${1:name} {\n  w: ${2:300} h: ${3:200}\n  $0\n}",
         ),
         (
-            "theme",
-            "Reusable theme definition (legacy: style)",
-            "theme ${1:name} {\n  fill: #${2:6C5CE7}\n}",
+            "style",
+            "Reusable style definition (legacy: theme)",
+            "style ${1:name} {\n  fill: #${2:6C5CE7}\n}",
         ),
         (
             "edge",
@@ -333,10 +333,7 @@ mod tests {
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"rect"));
         assert!(labels.contains(&"group"));
-        assert!(
-            labels.contains(&"theme"),
-            "should suggest `theme` not `style`"
-        );
+        assert!(labels.contains(&"style"), "should suggest `style` keyword");
     }
 
     #[test]

--- a/crates/fd-lsp/src/hover.rs
+++ b/crates/fd-lsp/src/hover.rs
@@ -122,7 +122,7 @@ fn hover_keyword(word: &str) -> Option<Hover> {
             "**image** — Embedded image node.\n\nProperties: `src:` `w:` `h:` `fit:` (`cover`|`contain`|`fill`|`none`)"
         }
         "style" | "theme" => {
-            "**theme** — Reusable style definition.\n\nDefine once, apply to nodes with `use: theme_name`.\n(Legacy keyword `style` also accepted.)"
+            "**style** — Reusable style definition.\n\nDefine once, apply to nodes with `use: style_name`.\n(Legacy keyword `theme` also accepted.)"
         }
         // Properties
         "w" | "width" => "**w:** — Width of the element in pixels.",
@@ -212,9 +212,9 @@ mod tests {
     }
 
     #[test]
-    fn hover_on_theme_keyword() {
-        let result = hover_keyword("theme");
-        assert!(result.is_some(), "should have hover info for `theme`");
+    fn hover_on_style_keyword() {
+        let result = hover_keyword("style");
+        assert!(result.is_some(), "should have hover info for `style`");
     }
 
     #[test]

--- a/examples/animated_onboarding.fd
+++ b/examples/animated_onboarding.fd
@@ -1,26 +1,26 @@
 # ─── Themes ───
 
-theme cta {
+style cta {
   fill: #6C5CE7  # blue
   corner: 12
 }
 
-theme cta_text {
+style cta_text {
   fill: #FFFFFF  # white
   font: "Inter" semibold 16
 }
 
-theme step_bg {
+style step_bg {
   fill: #FFFFFF  # white
   corner: 16
 }
 
-theme step_body {
+style step_body {
   fill: #6B7280  # blue
   font: "Inter" regular 16
 }
 
-theme step_title {
+style step_title {
   fill: #1F2937  # blue
   font: "Inter" bold 24
 }

--- a/examples/checkout_flow.fd
+++ b/examples/checkout_flow.fd
@@ -3,8 +3,8 @@
 
 spec "E-commerce checkout flow — MVP scope"
 
-theme label { font: "Inter" 14; fill: #333 }
-theme muted { font: "Inter" 12; fill: #999 }
+style label { font: "Inter" 14; fill: #333 }
+style muted { font: "Inter" 12; fill: #999 }
 
 # ─── Checkout page ───────────────────────────────────────────────────────
 

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -1,24 +1,24 @@
 # ─── Themes ───
 
-theme dark_accent {
+style dark_accent {
   fill: #A29BFE  # blue
 }
 
-theme dark_bg {
+style dark_bg {
   fill: #1A1A2E  # blue
 }
 
-theme dark_card {
+style dark_card {
   fill: #2D2D44  # blue
   corner: 12
 }
 
-theme dark_muted {
+style dark_muted {
   fill: #6B7280  # blue
   font: "Inter" regular 12
 }
 
-theme dark_text {
+style dark_text {
   fill: #E0E0E0  # white
   font: "Inter" regular 14
 }

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -1,36 +1,36 @@
 # ─── Themes ───
 
-theme accent_text {
+style accent_text {
   fill: #FFFFFF  # white
   font: "Inter" semibold 14
 }
 
-theme body {
+style body {
   fill: #6B7280  # blue
   font: "Inter" regular 14
 }
 
-theme brand {
+style brand {
   fill: #6C5CE7  # blue
   corner: 12
 }
 
-theme card {
+style card {
   fill: #FFFFFF  # white
   corner: 14
 }
 
-theme heading {
+style heading {
   fill: #1A1A2E  # blue
   font: "Inter" bold 22
 }
 
-theme metric {
+style metric {
   fill: #6C5CE7  # blue
   font: "Inter" bold 32
 }
 
-theme subheading {
+style subheading {
   fill: #111827  # blue
   font: "Inter" semibold 16
 }

--- a/examples/design_tokens.fd
+++ b/examples/design_tokens.fd
@@ -1,61 +1,61 @@
 # Design tokens / design system file
-# Demonstrates theme reuse and component patterns
+# Demonstrates style reuse and component patterns
 
 # ─── Color Tokens ───
 
-theme primary {
+style primary {
   fill: #6C5CE7
 }
 
-theme primary_hover {
+style primary_hover {
   fill: #5A4BD1
 }
 
-theme secondary {
+style secondary {
   fill: #A29BFE
 }
 
-theme surface {
+style surface {
   fill: #FFFFFF
   corner: 12
 }
 
-theme surface_elevated {
+style surface_elevated {
   fill: #FFFFFF
   corner: 16
 }
 
-theme danger {
+style danger {
   fill: #EF4444
 }
 
-theme success {
+style success {
   fill: #22C55E
 }
 
 # ─── Typography Tokens ───
 
-theme h1 {
+style h1 {
   font: "Inter" bold 32
   fill: #111827
 }
 
-theme h2 {
+style h2 {
   font: "Inter" semibold 24
   fill: #1F2937
 }
 
-theme h3 {
+style h3 {
   font: "Inter" semibold 18
   fill: #374151
 }
 
-theme body {
+style body {
   font: "Inter" regular 16
   fill: #4B5563
 }
 
-theme caption {
+style caption {
   font: "Inter" regular 12
   fill: #9CA3AF
 }

--- a/examples/grid_gallery.fd
+++ b/examples/grid_gallery.fd
@@ -1,7 +1,7 @@
 # FD v1
 # Photo gallery — grid layout showcase with hover interactions
 
-theme card_text {
+style card_text {
   fill: #FFFFFF
   font: "Inter" 400 14
 }

--- a/examples/landing_page.fd
+++ b/examples/landing_page.fd
@@ -1,17 +1,17 @@
 # FD v1
 # SaaS landing page — hero section with CTA, features, and social proof
 
-theme heading {
+style heading {
   fill: #1A1A2E
   font: "Inter" 700 32
 }
 
-theme body {
+style body {
   fill: #6B7280
   font: "Inter" 400 16
 }
 
-theme card {
+style card {
   fill: #FFFFFF
   corner: 16
 }

--- a/examples/mobile_app.fd
+++ b/examples/mobile_app.fd
@@ -1,17 +1,17 @@
 # FD v1
 # Social media app — Instagram-style mobile UI
 
-theme body {
+style body {
   fill: #333333
   font: "Inter" 400 14
 }
 
-theme bold {
+style bold {
   fill: #1A1A2E
   font: "Inter" 600 16
 }
 
-theme caption {
+style caption {
   fill: #999999
   font: "Inter" 400 12
 }

--- a/examples/onboarding.fd
+++ b/examples/onboarding.fd
@@ -1,9 +1,9 @@
-theme step_desc {
+style step_desc {
   fill: #6B7280  # blue
   font: "Inter" regular 16
 }
 
-theme step_title {
+style step_title {
   fill: #1A1A2E  # blue
   font: "Inter" bold 28
 }

--- a/examples/pricing_page.fd
+++ b/examples/pricing_page.fd
@@ -1,23 +1,23 @@
-theme check {
+style check {
   fill: #00B894  # teal
 }
 
-theme feature {
+style feature {
   fill: #333333  # gray
   font: "Inter" regular 14
 }
 
-theme heading {
+style heading {
   fill: #1A1A2E  # blue
   font: "Inter" bold 32
 }
 
-theme price {
+style price {
   fill: #1A1A2E  # blue
   font: "Inter" extrabold 48
 }
 
-theme subhead {
+style subhead {
   fill: #6B7280  # blue
   font: "Inter" regular 16
 }

--- a/examples/responsive_dashboard.fd
+++ b/examples/responsive_dashboard.fd
@@ -1,25 +1,25 @@
-# Dashboard layout using constraints and themes
+# Dashboard layout using constraints and styles
 # Demonstrates responsive patterns with column/row/grid
 
 import "tokens.fd" as tokens
 
-theme card_bg {
+style card_bg {
   fill: #FFFFFF
   corner: 12
   opacity: 0.95
 }
 
-theme label {
+style label {
   font: "Inter" regular 14
   fill: #6B7280
 }
 
-theme heading {
+style heading {
   font: "Inter" bold 20
   fill: #111827
 }
 
-theme metric_value {
+style metric_value {
   font: "Inter" semibold 32
   fill: #6C5CE7
 }

--- a/examples/userflow_onboarding.fd
+++ b/examples/userflow_onboarding.fd
@@ -2,15 +2,15 @@ import "../../examples/design_system.fd" as ds
 
 # ─── Themes ───
 
-theme flow_edge {
+style flow_edge {
 }
 
-theme screen {
+style screen {
   fill: #FFFFFF  # white
   corner: 16
 }
 
-theme screen_title {
+style screen_title {
   fill: #1A1A2E  # blue
   font: "Inter" bold 20
 }

--- a/examples/welcome.fd
+++ b/examples/welcome.fd
@@ -1,9 +1,9 @@
 # Welcome to Fast Draft!
 # Click any shape to select it. Try moving, resizing, and editing.
 
-theme accent { fill: #6C5CE7 }
-theme soft { fill: #DFE6E9; corner: 12 }
-theme label_style { font: "Inter" 500 14; fill: #2D3436 }
+style accent { fill: #6C5CE7 }
+style soft { fill: #DFE6E9; corner: 12 }
+style label_style { font: "Inter" 500 14; fill: #2D3436 }
 
 # ── Title ──
 text @welcome_title "Welcome to Fast Draft ✨" {

--- a/examples/wireframe_login.fd
+++ b/examples/wireframe_login.fd
@@ -1,16 +1,16 @@
 # ─── Themes ───
 
-theme bg_surface {
+style bg_surface {
   fill: #FFFFFF  # white
   corner: 12
 }
 
-theme input_style {
+style input_style {
   fill: #F8F9FA  # white
   corner: 8
 }
 
-theme label_style {
+style label_style {
   fill: #1A1A2E  # blue
   font: "Inter" medium 14
 }

--- a/fd-vscode/src/ai-refactor.ts
+++ b/fd-vscode/src/ai-refactor.ts
@@ -4,7 +4,7 @@
  * Invoked via Canvas toolbar "Refactor" button or command palette.
  * Runs all cleanup passes in sequence:
  *   1. Rename anonymous IDs → semantic names (Renamify)
- *   2. Hoist repeated inline styles → shared theme blocks
+ *   2. Hoist repeated inline styles → shared style blocks
  *   3. Round coordinates to 1dp precision (already handled by emitter)
  */
 
@@ -13,7 +13,7 @@ import { callRenamifyAi, applyGlobalRenames, RenamifyResult, RenameProposal } fr
 export interface RefactorResult {
     /** Number of nodes renamed by Renamify. */
     renamed: number;
-    /** Number of theme blocks hoisted from inline styles. */
+    /** Number of style blocks hoisted from inline styles. */
     stylesHoisted: number;
     /** The final refactored FD text. */
     fdText: string;
@@ -57,10 +57,10 @@ export async function runRefactor(
         try {
             const before = text;
             text = wasmFormatFn(text);
-            // Count hoisted themes by diffing theme blocks
-            const themesBefore = (before.match(/^theme\s+/gm) || []).length;
-            const themesAfter = (text.match(/^theme\s+/gm) || []).length;
-            stylesHoisted = Math.max(0, themesAfter - themesBefore);
+            // Count hoisted styles by diffing style blocks
+            const stylesBefore = (before.match(/^style\s+/gm) || []).length;
+            const stylesAfter = (text.match(/^style\s+/gm) || []).length;
+            stylesHoisted = Math.max(0, stylesAfter - stylesBefore);
         } catch (err: unknown) {
             const msg = err instanceof Error ? err.message : String(err);
             warnings.push(`Style hoisting failed: ${msg}`);
@@ -87,7 +87,7 @@ export function summarizeRefactor(result: RefactorResult): string {
         parts.push(`${result.renamed} node(s) renamed`);
     }
     if (result.stylesHoisted > 0) {
-        parts.push(`${result.stylesHoisted} theme(s) hoisted`);
+        parts.push(`${result.stylesHoisted} style(s) hoisted`);
     }
     if (parts.length === 0) {
         return "No changes needed — document is already clean.";

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -649,7 +649,7 @@ interface LibraryFile {
 
 /**
  * Scan workspace `libraries/` directories for .fd files.
- * Parse each file to extract reusable components (themes, groups, nodes).
+ * Parse each file to extract reusable components (styles, groups, nodes).
  */
 async function scanLibraryFiles(): Promise<LibraryFile[]> {
   const results: LibraryFile[] = [];
@@ -678,7 +678,7 @@ async function scanLibraryFiles(): Promise<LibraryFile[]> {
 
 /**
  * Parse a library .fd file to extract component definitions.
- * Extracts themes and top-level nodes (group, rect, ellipse, etc.) with their full code.
+ * Extracts styles and top-level nodes (group, rect, ellipse, etc.) with their full code.
  */
 function parseLibraryComponents(text: string): LibraryComponent[] {
   const components: LibraryComponent[] = [];
@@ -694,9 +694,9 @@ function parseLibraryComponents(text: string): LibraryComponent[] {
       continue;
     }
 
-    // Theme definition: theme name { ... }
-    const themeMatch = trimmed.match(/^theme\s+(\w+)\s*\{/);
-    if (themeMatch) {
+    // Style definition: style name { ... } (also accepts legacy `theme`)
+    const styleMatch = trimmed.match(/^(?:style|theme)\s+(\w+)\s*\{/);
+    if (styleMatch) {
       const startLine = i;
       let depth = 1;
       i++;
@@ -706,7 +706,7 @@ function parseLibraryComponents(text: string): LibraryComponent[] {
         i++;
       }
       const code = lines.slice(startLine, i).join("\n");
-      components.push({ name: themeMatch[1], kind: "theme", code });
+      components.push({ name: styleMatch[1], kind: "style", code });
       continue;
     }
 

--- a/fd-vscode/src/fd-parse.test.ts
+++ b/fd-vscode/src/fd-parse.test.ts
@@ -178,10 +178,10 @@ describe("computeSpecHideLines", () => {
     expect(computeSpecHideLines([])).toEqual([]);
   });
 
-  it("hides theme blocks entirely", () => {
-    const lines = ["theme heading {", "  fill: #333", "  font: Inter 700 32", "}"];
+  it("hides style blocks entirely", () => {
+    const lines = ["style heading {", "  fill: #333", "  font: Inter 700 32", "}"];
     const hidden = computeSpecHideLines(lines);
-    // All 4 lines should be hidden (theme block + closing brace of theme)
+    // All 4 lines should be hidden (style block + closing brace)
     expect(hidden).toEqual([0, 1, 2, 3]);
   });
 
@@ -292,7 +292,7 @@ describe("computeSpecFoldRanges", () => {
   });
 
   it("returns one range for a single contiguous hidden block", () => {
-    const lines = ["theme heading {", "  fill: #333", "  font: Inter 700 32", "}"];
+    const lines = ["style heading {", "  fill: #333", "  font: Inter 700 32", "}"];
     const ranges = computeSpecFoldRanges(lines);
     expect(ranges).toEqual([{ start: 0, end: 3 }]);
   });
@@ -313,7 +313,7 @@ describe("computeSpecFoldRanges", () => {
 
   it("returns multiple ranges when hidden blocks are separated by kept lines", () => {
     const lines = [
-      "theme body {",      // 0 - hidden
+      "style body {",      // 0 - hidden
       "  fill: #333",      // 1 - hidden
       "}",                 // 2 - hidden
       "",                  // 3 - blank (kept)
@@ -519,8 +519,8 @@ describe("parseDocumentSymbols", () => {
     expect(result[0].children[0].endLine).toBe(3);
   });
 
-  it("parses theme definition", () => {
-    const lines = ["theme card_text {", "  font: Inter 14", "  fill: #FFF", "}"];
+  it("parses style definition", () => {
+    const lines = ["style card_text {", "  font: Inter 14", "  fill: #FFF", "}"];
     const result = parseDocumentSymbols(lines);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("card_text");
@@ -556,7 +556,7 @@ describe("parseDocumentSymbols", () => {
 
   it("handles multiple top-level symbols", () => {
     const lines = [
-      "theme heading {",
+      "style heading {",
       "  fill: #333",
       "}",
       "rect @hero {",
@@ -655,8 +655,8 @@ describe("findSymbolAtLine", () => {
     expect(findSymbolAtLine([], 0)).toBeUndefined();
   });
 
-  it("handles theme blocks (non-@ symbols)", () => {
-    const styleLines = ["theme heading {", "  fill: #333", "}"];
+  it("handles style blocks (non-@ symbols)", () => {
+    const styleLines = ["style heading {", "  fill: #333", "}"];
     const styleSymbols = parseDocumentSymbols(styleLines);
     const sym = findSymbolAtLine(styleSymbols, 1);
     expect(sym).toBeDefined();
@@ -697,8 +697,8 @@ describe("transformSpecViewLine", () => {
     expect(transformSpecViewLine("    text @label \"Hi\" {")).toBe('    @label "Hi" {');
   });
 
-  it("does not transform theme lines", () => {
-    expect(transformSpecViewLine("theme heading {")).toBe("theme heading {");
+  it("does not transform style lines", () => {
+    expect(transformSpecViewLine("style heading {")).toBe("style heading {");
   });
 
   it("does not transform edge lines", () => {

--- a/tree-sitter-fd/grammar.js
+++ b/tree-sitter-fd/grammar.js
@@ -55,10 +55,10 @@ module.exports = grammar({
         spec_keyword: (_$) =>
             choice("accept", "status", "priority", "tag"),
 
-        // ─── Style/Theme Block ──────────────────────────────────
+        // ─── Style Block (legacy: theme) ───────────────────────
         style_block: ($) =>
             seq(
-                choice("theme", "style"),
+                choice("style", "theme"),
                 field("name", $.identifier),
                 "{",
                 repeat($.property),


### PR DESCRIPTION
## Summary

Round 2 of the `theme` → `style` keyword rename — updates all remaining references outside of Rust core (which was done in PR #436).

## Changes

- **`.fd` examples** (15 files): all `theme` keywords → `style`
- **ai-refactor.ts**: regex patterns match `style` blocks, user-facing messages updated
- **extension.ts**: library component parser accepts `style|theme`, outputs `style` kind
- **fd-parse.test.ts**: 7 test input strings updated
- **LSP completion.rs**: snippet label/body uses `style` keyword
- **LSP hover.rs**: hover text shows `style` as primary, `theme` as legacy
- **tree-sitter grammar.js**: `choice("style", "theme")` order swapped

## Not Changed (Intentionally)
- `.dark-theme` CSS class — UI dark mode, not FD keyword
- `CanvasTheme`/`set_theme()` — canvas background rendering
- CHANGELOG historical entries — changing history bad practice
- Parser backward-compat `"theme"` match arms — must keep

## Verification
- `cargo check/clippy/test` ✅ (203 tests)
- `pnpm test` ✅ (241 tests)
- `cargo fmt` ✅