### PR TITLE
docs(ci): Cloudflare Pages migration CHANGELOG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.80 — Migrate to Cloudflare Pages (R6.5)
+
+- **INFRA (R6.5)**: Migrated site hosting from GitHub Pages to Cloudflare Pages — 330+ edge PoPs (was ~10 Fastly), HTTP/3+QUIC, custom response headers, unlimited bandwidth; hybrid deploy: GitHub Actions builds WASM → `wrangler-action@v3` pushes to CF Pages
+- **PERF**: Added `site/_headers` — WASM binary cached for 1 year (`Cache-Control: immutable`); security headers (`X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`) on all responses
+- **CLEANUP**: Removed `site/CNAME` (not needed for CF Pages custom domain binding)
+- **DOCS**: Updated `GEMINI.md` Tier 2 table, `REQUIREMENTS.md` R6.5
+
 ### v0.10.79 — Cross-Framework Property Aliases (R4.16)
 
 - **FEATURE (R4.16)**: `border:` accepted as alias for `stroke:` — CSS/Tailwind's most common expectation for outline/border styling; emitter outputs canonical `stroke:`


### PR DESCRIPTION
## Summary

Adds CHANGELOG entry (v0.10.80) documenting the Cloudflare Pages migration.

The infrastructure changes (workflow, headers, CNAME deletion, GEMINI.md) were already committed to `main`. This PR adds the missing CHANGELOG entry.

## Changes

- `docs/CHANGELOG.md` — new v0.10.80 entry documenting:
  - Migration from GitHub Pages to Cloudflare Pages (330+ edge PoPs)
  - `site/_headers` for WASM caching (1yr immutable) + security headers
  - Removed `site/CNAME`
  - Updated docs (GEMINI.md, REQUIREMENTS.md R6.5)

## Verification

- `cargo check --workspace` ✅
- `cargo test --workspace` ✅
- All 370 tests pass