### PR TITLE
fix(ci): add CF Pages project creation step before deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,9 +39,17 @@ jobs:
       - name: Build WASM
         run: wasm-pack build crates/fd-wasm --target web --out-dir ../../site/wasm
 
+      - name: Create CF Pages project (idempotent)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create fast-draft --production-branch=main
+        continue-on-error: true  # OK if project already exists
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=fast-draft
+          command: pages deploy site --project-name=fast-draft --commit-dirty=true


### PR DESCRIPTION
## Fix

The CF Pages deploy was failing with `Project not found [code: 8000007]` because wrangler doesn't auto-create Pages projects.

**Changes:**
- Added `wrangler pages project create` step before deploy (idempotent via `continue-on-error: true`)
- Added `--commit-dirty=true` flag to suppress git warning

**Site is DOWN** — merging urgently to restore service.