### PR TITLE
docs(workflows): add live site deploy verification to /e2e, /yolo, /smoke

### DIFF
--- a/.agents/workflows/e2e.md
+++ b/.agents/workflows/e2e.md
@@ -79,6 +79,42 @@ Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop.
 
 ---
 
+## Tier: Site Deploy Verification
+
+> Run **after merge** to confirm the deploy landed on [fast-draft.com](https://fast-draft.com).
+> Requires the `pages.yml` workflow to have completed successfully.
+> **One browser subagent call — copy the task below verbatim.**
+
+### Pre-check
+
+1. **Verify the deploy workflow passed:**
+
+   ```bash
+   gh run list --workflow=pages.yml --limit 1 --json status,conclusion
+   ```
+
+   If `conclusion` is not `success`, do NOT proceed — fix the deploy first.
+
+### Browser subagent task:
+
+```
+Navigate to https://fast-draft.com and verify the site is live after deploy:
+
+1. SITE LOADS: Page title contains "Fast Draft", hero section visible with "Design as Code".
+2. PLAYGROUND VISIBLE: Live Playground section with code editor and canvas area visible.
+3. WASM LOADS: Canvas renders shapes (not blank/black). Wait up to 5s for WASM init.
+
+Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop.
+```
+
+### Reporting:
+
+```
+Site Deploy: ✅ 3/3 — site loads, playground visible, WASM renders. Screenshot attached.
+```
+
+---
+
 ## Tier: Full
 
 > Run for major feature PRs or pre-release. Includes all phases below.

--- a/.agents/workflows/smoke.md
+++ b/.agents/workflows/smoke.md
@@ -32,7 +32,15 @@ description: Quick sanity check — run before committing or as a lightweight CI
    cargo fmt --all -- --check
    ```
 
-5. **Report** results to user. If all pass, it's safe to `/yolo`.
+5. **Live site health check** (if on `main` or post-merge):
+
+   ```bash
+   curl -sL -o /dev/null -w '%{http_code}' https://fast-draft.com
+   ```
+
+   Should return `200`. If not, check `gh run list --workflow=pages.yml --limit 1`.
+
+6. **Report** results to user. If all pass, it's safe to `/yolo`.
 
 ---
 

--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -150,7 +150,20 @@ git checkout -b feat/<descriptive-name>
     git pull origin main
     ```
 
-18. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
+18. **Verify site deploy** (if `site/`, `crates/fd-wasm/`, or `crates/fd-core/` changed):
+
+    Wait for the `pages.yml` deploy workflow to complete:
+
+    ```bash
+    sleep 30 && gh run list --workflow=pages.yml --limit 1 --json status,conclusion
+    ```
+
+    If `conclusion` is `success`, run the `/e2e` **Site Deploy Verification** tier
+    to confirm https://fast-draft.com is serving the updated content.
+
+    > **Skip** if the change is docs-only, CI config, or VS Code extension-only.
+
+19. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
 
     > ⚠️ **MANDATORY**: Read `.env` for `VSCE_PAT`, `VSX_PAT`, and `GEMINI_API_KEY` BEFORE publishing.
     > Never rely on interactive prompts — always pass tokens via flags.
@@ -180,7 +193,7 @@ git checkout -b feat/<descriptive-name>
     > Skip publish if the change is local-only or version wasn't bumped.
     > **NEVER** publish to only one registry — both Marketplace AND Open VSX are required.
 
-19. Report PR URL, merge status, and publish results to user.
+20. Report PR URL, merge status, deploy verification, and publish results to user.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds live site deploy verification to 3 workflows:

- **`/e2e`**: New "Site Deploy Verification" tier — browser subagent checks `fast-draft.com` loads, playground visible, WASM renders
- **`/yolo`**: Step 18 — post-merge deploy check with `gh run list` + `/e2e` Site Deploy tier
- **`/smoke`**: Step 5 — lightweight `curl` health check returning HTTP 200

No code changes — docs only.