### PR TITLE
refactor(R4.18): complete theme→style keyword cleanup across all files

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,7 @@ The document is a **DAG** (Directed Acyclic Graph) stored as `petgraph::StableDi
 | ---------- | ------------------------------ | ------------------------------------- |
 | `graph`    | `StableDiGraph<SceneNode, ()>` | Parent→child containment edges        |
 | `root`     | `NodeIndex`                    | The invisible root node               |
-| `styles`   | `HashMap<NodeId, Style>`       | Named `theme` block definitions       |
+| `styles`   | `HashMap<NodeId, Style>`       | Named `style` block definitions       |
 | `id_index` | `HashMap<NodeId, NodeIndex>`   | Fast `@id` → index lookup             |
 | `edges`    | `Vec<Edge>`                    | Visual connections between nodes      |
 | `imports`  | `Vec<Import>`                  | `import "file.fd" as ns` declarations |
@@ -92,7 +92,7 @@ A single element in the scene graph.
 | `id`          | `NodeId`                      | Interned string ID (e.g. `@login_form`)                        |
 | `kind`        | `NodeKind`                    | Root, Generic, Group, Frame, Rect, Ellipse, Path, Text         |
 | `style`       | `Style`                       | Inline fill, stroke, font, corner, opacity, shadow, text-align |
-| `use_styles`  | `SmallVec<[NodeId; 2]>`       | Named theme references (`use: base_text`)                      |
+| `use_styles`  | `SmallVec<[NodeId; 2]>`       | Named style references (`use: base_text`)                      |
 | `constraints` | `SmallVec<[Constraint; 2]>`   | CenterIn, Offset, FillParent, Position                         |
 | `animations`  | `SmallVec<[AnimKeyframe; 2]>` | `:hover`, `:press`, `:enter` animations                        |
 | `annotations` | `Vec<Annotation>`             | `spec { ... }` metadata                                        |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.82 — Complete `theme` → `style` Keyword Cleanup (R4.18)
+
+- **CLEANUP (R4.18)**: Replaced all remaining `theme` keywords with `style` across the entire codebase — playground examples in `site/playground.js` (3 example strings, 6 occurrences), 3 library `.fd` files (`wireframe`, `flowchart`, `ui-kit`), 9 benchmark `.fd` files, 3 design doc `.fd` files, 3 example `.fd` files; also updated `# ─── Themes ───` section headers to `# ─── Styles ───` in all 13 affected files
+- **DOCS (R4.18)**: Updated `LIBRARIES.md` (code examples + convention table), `ARCHITECTURE.md` (SceneGraph/SceneNode field descriptions), `REQUIREMENTS.md` (R1.4, R1.17, R4.21 wording) to reflect `style` as the primary keyword with `theme` as legacy alias
+
 ### v0.10.81 — Simplify "Under the Hood" Section
 
 - **SITE**: Removed redundant ASCII architecture diagram — crate cards already conveyed the same info; eliminates responsive breakage on narrow screens

--- a/docs/LIBRARIES.md
+++ b/docs/LIBRARIES.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-FD libraries are `.fd` files that export **themes** (reusable styles) and **components** (named groups) for use in other `.fd` files via the `import` statement.
+FD libraries are `.fd` files that export **styles** (reusable property bundles) and **components** (named groups) for use in other `.fd` files via the `import` statement.
 
 ```
 import "libraries/ui-kit.fd" as ui
@@ -34,9 +34,9 @@ Libraries are:
 # Description of what this library provides.
 # Usage: import "libraries/my-lib.fd" as my
 
-# ─── Themes ───
+# ─── Styles ───
 
-theme my_accent {
+style my_accent {
   fill: #FF6B6B
   corner: 8
 }
@@ -66,7 +66,7 @@ Put your `.fd` file in the workspace `libraries/` directory. The Library Panel i
 ```
 import "libraries/my-lib.fd" as my
 
-# Reference themes and components with the namespace prefix
+# Reference styles and components with the namespace prefix
 rect @hero {
   w: 400 h: 200
   use: my.my_accent
@@ -79,7 +79,7 @@ rect @hero {
 | ------------------ | ---------------------------------------------------------------------- |
 | **Header comment** | Start with `# @library "Name"` for panel discovery                     |
 | **Semantic IDs**   | Use descriptive names: `@btn_primary`, `@nav_sidebar`                  |
-| **Themes first**   | Define themes before components that use them                          |
+| **Styles first**   | Define styles before components that use them                          |
 | **Grouped**        | Related components should share section comments (`# ─── Buttons ───`) |
 | **Self-contained** | Each component should work standalone (include all needed styles)      |
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -11,7 +11,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.1** _(done)_: Token-efficient text DSL — ~5× fewer tokens than SVG for equivalent content
 - **R1.2** _(done)_: Graph-based document model (DAG) — nodes reference by `@id`, not coordinates
 - **R1.3** _(done)_: Constraint-based layout (`center_in`, `offset`, `fill_parent`) — no absolute coordinates until render time
-- **R1.4** _(done)_: Reusable themes via `theme` blocks and `use:` references (parser also accepts legacy `style` keyword)
+- **R1.4** _(done)_: Reusable styles via `style` blocks and `use:` references (parser also accepts legacy `theme` keyword)
 - **R1.5** _(done)_: Animation declarations with triggers (`:hover`, `:press`, `:enter`) and easing → [spec](specs/animation-system.md)
 - **R1.6** _(done)_: Git-friendly plain text — line-oriented diffs work well
 - **R1.7** _(done)_: Comments via `#` prefix
@@ -24,7 +24,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R1.14** _(done)_: Namespaced imports — `import "path.fd" as ns` for cross-file style/node reuse with `ns.style_name` references
 - **R1.15** _(done)_: Background shorthand — `bg: #FFF corner=12 shadow=(0,4,20,#0002)` for combined fill, corner, and shadow in one line
 - **R1.16** _(done)_: Comment preservation — `# text` lines attached to the following node survive all parse/emit round-trips and format passes
-- **R1.17** _(done)_: Text alignment — `align: left|center|right [top|middle|bottom]` property; defaults to `center middle`; reusable via `theme` blocks and `use:` inheritance
+- **R1.17** _(done)_: Text alignment — `align: left|center|right [top|middle|bottom]` property; defaults to `center middle`; reusable via `style` blocks and `use:` inheritance
 - **R1.18** _(done)_: Mermaid import — parse Mermaid diagram syntax (`flowchart`, `sequenceDiagram`, `stateDiagram`) into equivalent FD nodes + edges; `parse_mermaid()` in fd-core + `import_mermaid()` WASM API
 - **R1.19** _(done)_: Edge label offset — `label_offset: <x> <y>` property on edges for draggable text labels; parse/emit roundtrip support
 - **R1.20** _(done)_: Edge anchors — `EdgeAnchor` enum (`@node_id` or `x y` coords) for flexible edge endpoints; `text_child: Option<NodeId>` for styled text labels; `create_edge_at()` WASM API; edge-to-edge validation
@@ -138,7 +138,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 - **R4.21** _(planned)_: **Comprehensibility Score** — compute a 0–100 score measuring how easily AI agents can understand an FD document. Metrics:
   - **Semantic naming ratio**: % of non-anonymous `@id`s (target: >80%)
   - **Inline doc-comment density**: % of nodes with `[auto]` or manual `#` comments
-  - **Theme reuse ratio**: % of styled nodes using `use:` references vs inline styles
+  - **Style reuse ratio**: % of styled nodes using `use:` references vs inline styles
   - **Edge default coverage**: % of edges whose props match `edge_defaults {}`
   - **Read token cost**: total tokens in `ReadMode::Full` vs optimal `ReadMode::Structure`
   - Display as a badge in the Canvas toolbar (e.g. `AI: 72/100`) and in `fd-lsp --score`

--- a/docs/design/02_bidi_sync.fd
+++ b/docs/design/02_bidi_sync.fd
@@ -1,26 +1,26 @@
-# ─── Themes ───
+# ─── Styles ───
 
-theme box_green {
+style box_green {
   fill: #10B981  # teal
   corner: 16
 }
 
-theme box_orange {
+style box_orange {
   fill: #F59E0B  # orange
   corner: 16
 }
 
-theme box_primary {
+style box_primary {
   fill: #6C5CE7  # blue
   corner: 16
 }
 
-theme desc {
+style desc {
   fill: #6B7280  # blue
   font: "Inter" regular 12
 }
 
-theme label {
+style label {
   fill: #1A1A2E  # blue
   font: "Inter" semibold 14
 }

--- a/docs/design/04_architecture.fd
+++ b/docs/design/04_architecture.fd
@@ -1,16 +1,16 @@
-# ─── Themes ───
+# ─── Styles ───
 
-theme crate_box {
+style crate_box {
   fill: #1A1A2E  # blue
   corner: 16
 }
 
-theme module_chip {
+style module_chip {
   fill: #2D2D4E  # blue
   corner: 8
 }
 
-theme platform_box {
+style platform_box {
   fill: #FFFFFF  # white
   corner: 12
 }

--- a/docs/design/05_edge_system.fd
+++ b/docs/design/05_edge_system.fd
@@ -1,16 +1,16 @@
-# ─── Themes ───
+# ─── Styles ───
 
-theme desc_text {
+style desc_text {
   fill: #6B7280  # blue
   font: "Inter" regular 12
 }
 
-theme screen {
+style screen {
   fill: #FFFFFF  # white
   corner: 14
 }
 
-theme screen_label {
+style screen_label {
   fill: #1A1A2E  # blue
   font: "Inter" bold 16
 }

--- a/examples/animated_onboarding.fd
+++ b/examples/animated_onboarding.fd
@@ -1,4 +1,4 @@
-# ─── Themes ───
+# ─── Styles ───
 
 style cta {
   fill: #6C5CE7  # blue

--- a/examples/benchmarks/api_flowchart.fd
+++ b/examples/benchmarks/api_flowchart.fd
@@ -1,26 +1,26 @@
-# ─── Themes ───
+# ─── Styles ───
 
-theme decision_box {
+style decision_box {
   fill: #FEF3C7  # yellow
   corner: 4
 }
 
-theme error_box {
+style error_box {
   fill: #FEE2E2  # red
   corner: 8
 }
 
-theme io_box {
+style io_box {
   fill: #F3E8FF  # purple
   corner: 12
 }
 
-theme process_box {
+style process_box {
   fill: #EFF6FF  # blue
   corner: 8
 }
 
-theme success_box {
+style success_box {
   fill: #D1FAE5  # green
   corner: 8
 }

--- a/examples/benchmarks/dashboard_card.fd
+++ b/examples/benchmarks/dashboard_card.fd
@@ -1,8 +1,8 @@
-theme accent {
+style accent {
   fill: #6C5CE7
 }
 
-theme subtle {
+style subtle {
   fill: #F0F0F5
   corner: 8
 }

--- a/examples/benchmarks/data_dashboard.fd
+++ b/examples/benchmarks/data_dashboard.fd
@@ -1,32 +1,32 @@
 # Data Dashboard — Data Analyst use case
 # Demonstrates: grid layout, nested groups, style tokens, KPI cards
 
-theme kpi_card {
+style kpi_card {
   fill: #FFFFFF
   corner: 12
 }
 
-theme chart_area {
+style chart_area {
   fill: #F8FAFC
   corner: 8
 }
 
-theme metric_value {
+style metric_value {
   font: "Inter" bold 28
   fill: #0F172A
 }
 
-theme metric_label {
+style metric_label {
   font: "Inter" medium 12
   fill: #64748B
 }
 
-theme metric_delta_up {
+style metric_delta_up {
   font: "Inter" semibold 13
   fill: #10B981
 }
 
-theme metric_delta_down {
+style metric_delta_down {
   font: "Inter" semibold 13
   fill: #EF4444
 }

--- a/examples/benchmarks/design_system.fd
+++ b/examples/benchmarks/design_system.fd
@@ -4,33 +4,33 @@
 import "tokens.fd" as tokens
 
 # Typography scale — uses named colors for quick scanning
-theme display {
+style display {
   font: "Inter" bold 48
   fill: slate
 }
 
-theme heading {
+style heading {
   font: "Inter" semibold 24
   fill: slate
 }
 
-theme body {
+style body {
   font: "Inter" regular 16
   fill: gray
 }
 
-theme caption {
+style caption {
   font: "Inter" medium 12
   fill: gray
 }
 
 # Shared component styles
-theme swatch_card {
+style swatch_card {
   fill: white
   corner: 12
 }
 
-theme section_label {
+style section_label {
   font: "Inter" semibold 11
   fill: gray
   opacity: 0.6

--- a/examples/benchmarks/kanban_board.fd
+++ b/examples/benchmarks/kanban_board.fd
@@ -1,27 +1,27 @@
 # Kanban Board — Project Manager use case
 # Demonstrates: row/column layouts, semantic IDs, named colors, style reuse
 
-theme card {
+style card {
   fill: #FFFFFF
   corner: 8
 }
 
-theme column_bg {
+style column_bg {
   fill: #F4F5F7
   corner: 12
 }
 
-theme tag_urgent {
+style tag_urgent {
   fill: #FEE2E2
   corner: 4
 }
 
-theme tag_feature {
+style tag_feature {
   fill: #DBEAFE
   corner: 4
 }
 
-theme tag_bug {
+style tag_bug {
   fill: #FEF3C7
   corner: 4
 }

--- a/examples/benchmarks/login_form.fd
+++ b/examples/benchmarks/login_form.fd
@@ -1,22 +1,22 @@
 # Login Form — Product Designer use case
 # Demonstrates: nested groups, style reuse, spec annotations, animations
 
-theme card_bg {
+style card_bg {
   fill: #FFFFFF
   corner: 16
 }
 
-theme input_field {
+style input_field {
   fill: #F8F9FA
   corner: 8
 }
 
-theme primary_btn {
+style primary_btn {
   fill: #6C5CE7
   corner: 10
 }
 
-theme secondary_btn {
+style secondary_btn {
   fill: #F0F0F5
   corner: 10
 }

--- a/examples/benchmarks/mobile_onboarding.fd
+++ b/examples/benchmarks/mobile_onboarding.fd
@@ -1,27 +1,27 @@
 # Mobile Onboarding — Mobile Designer use case
 # Demonstrates: frames with clip, column layouts, animations, style reuse
 
-theme phone_frame {
+style phone_frame {
   fill: #1A1A2E
   corner: 40
 }
 
-theme screen_bg {
+style screen_bg {
   fill: #FFFFFF
   corner: 32
 }
 
-theme dot_active {
+style dot_active {
   fill: #6C5CE7
   corner: 6
 }
 
-theme dot_inactive {
+style dot_inactive {
   fill: #D1D5DB
   corner: 6
 }
 
-theme cta_primary {
+style cta_primary {
   fill: #6C5CE7
   corner: 12
 }

--- a/examples/benchmarks/network_topology.fd
+++ b/examples/benchmarks/network_topology.fd
@@ -1,21 +1,21 @@
-# ─── Themes ───
+# ─── Styles ───
 
-theme cache_box {
+style cache_box {
   fill: #D1FAE5  # green
   corner: 8
 }
 
-theme db_box {
+style db_box {
   fill: #FEF3C7  # yellow
   corner: 8
 }
 
-theme ext_box {
+style ext_box {
   fill: #F3E8FF  # purple
   corner: 8
 }
 
-theme server_box {
+style server_box {
   fill: #EFF6FF  # blue
   corner: 8
 }

--- a/examples/benchmarks/org_chart.fd
+++ b/examples/benchmarks/org_chart.fd
@@ -1,12 +1,12 @@
 # Org Chart — HR / Manager use case
 # Demonstrates: edges, nested groups, ellipse avatars, named colors
 
-theme person_card {
+style person_card {
   fill: #FFFFFF
   corner: 12
 }
 
-theme role_badge {
+style role_badge {
   corner: 4
 }
 

--- a/examples/benchmarks/pricing_table.fd
+++ b/examples/benchmarks/pricing_table.fd
@@ -1,27 +1,27 @@
 # Pricing Table — Marketing use case
 # Demonstrates: row layout, style reuse, highlighted tier, animations
 
-theme tier_card {
+style tier_card {
   fill: #FFFFFF
   corner: 16
 }
 
-theme tier_highlighted {
+style tier_highlighted {
   fill: #6C5CE7
   corner: 16
 }
 
-theme feature_text {
+style feature_text {
   font: "Inter" regular 14
   fill: #4B5563
 }
 
-theme price_text {
+style price_text {
   font: "Inter" bold 40
   fill: #111827
 }
 
-theme tier_name {
+style tier_name {
   font: "Inter" semibold 20
   fill: #111827
 }

--- a/examples/dark_theme.fd
+++ b/examples/dark_theme.fd
@@ -1,4 +1,4 @@
-# ─── Themes ───
+# ─── Styles ───
 
 style dark_accent {
   fill: #A29BFE  # blue

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -1,4 +1,4 @@
-# ─── Themes ───
+# ─── Styles ───
 
 style accent_text {
   fill: #FFFFFF  # white

--- a/examples/userflow_onboarding.fd
+++ b/examples/userflow_onboarding.fd
@@ -1,6 +1,6 @@
 import "../../examples/design_system.fd" as ds
 
-# ─── Themes ───
+# ─── Styles ───
 
 style flow_edge {
 }

--- a/examples/wireframe_login.fd
+++ b/examples/wireframe_login.fd
@@ -1,4 +1,4 @@
-# ─── Themes ───
+# ─── Styles ───
 
 style bg_surface {
   fill: #FFFFFF  # white

--- a/libraries/flowchart.fd
+++ b/libraries/flowchart.fd
@@ -2,31 +2,31 @@
 # Flowchart components — process, decision, start/end, connectors.
 # Usage: import "libraries/flowchart.fd" as flow
 
-# ─── Themes ───
+# ─── Styles ───
 
-theme flow_process {
+style flow_process {
   fill: #FFFFFF
   stroke: #2D3436 2
   corner: 8
 }
 
-theme flow_decision {
+style flow_decision {
   fill: #FFF3E0
   stroke: #E17055 2
 }
 
-theme flow_start_end {
+style flow_start_end {
   fill: #E8F5E9
   stroke: #00B894 2
   corner: 24
 }
 
-theme flow_label {
+style flow_label {
   fill: #2D3436
   font: "Inter" 500 13
 }
 
-theme flow_sublabel {
+style flow_sublabel {
   fill: #636E72
   font: "Inter" 400 11
 }

--- a/libraries/ui-kit.fd
+++ b/libraries/ui-kit.fd
@@ -2,54 +2,54 @@
 # Reusable UI components — buttons, inputs, cards, badges, avatars.
 # Usage: import "libraries/ui-kit.fd" as ui
 
-# ─── Themes ───
+# ─── Styles ───
 
-theme primary {
+style primary {
   fill: #6C5CE7
   corner: 8
 }
 
-theme primary_hover {
+style primary_hover {
   fill: #5A4BD1
   corner: 8
 }
 
-theme secondary {
+style secondary {
   fill: #DFE6E9
   corner: 8
 }
 
-theme danger {
+style danger {
   fill: #E17055
   corner: 8
 }
 
-theme success {
+style success {
   fill: #00B894
   corner: 8
 }
 
-theme input_style {
+style input_style {
   stroke: #DDDDDD 1
   corner: 8
 }
 
-theme label_text {
+style label_text {
   fill: #2D3436
   font: "Inter" 500 14
 }
 
-theme hint_text {
+style hint_text {
   fill: #999999
   font: "Inter" 400 13
 }
 
-theme heading {
+style heading {
   fill: #1A1A2E
   font: "Inter" 700 24
 }
 
-theme subheading {
+style subheading {
   fill: #2D3436
   font: "Inter" 600 16
 }

--- a/libraries/wireframe.fd
+++ b/libraries/wireframe.fd
@@ -2,34 +2,34 @@
 # Wireframe components — navbar, sidebar, content, footer, placeholders.
 # Usage: import "libraries/wireframe.fd" as wire
 
-# ─── Themes ───
+# ─── Styles ───
 
-theme wire_bg {
+style wire_bg {
   fill: #FAFAFA
   corner: 0
 }
 
-theme wire_panel {
+style wire_panel {
   fill: #FFFFFF
   stroke: #E0E0E0 1
 }
 
-theme wire_accent {
+style wire_accent {
   fill: #6C5CE7
   corner: 4
 }
 
-theme wire_heading {
+style wire_heading {
   fill: #2D3436
   font: "Inter" 700 16
 }
 
-theme wire_text {
+style wire_text {
   fill: #636E72
   font: "Inter" 400 13
 }
 
-theme wire_muted {
+style wire_muted {
   fill: #B2BEC3
   font: "Inter" 400 12
 }

--- a/site/playground.js
+++ b/site/playground.js
@@ -3,7 +3,7 @@
 const EXAMPLES = {
   card: `# A card with a button that reacts on hover
 
-theme accent {
+style accent {
   fill: #6C5CE7
 }
 
@@ -33,12 +33,12 @@ group @card {
 
   login: `# Login form with spec annotations
 
-theme accent {
+style accent {
   fill: #6C5CE7
   corner: 10
 }
 
-theme base_text {
+style base_text {
   fill: #333333
   font: "Inter" regular 14
 }
@@ -98,9 +98,9 @@ group @login_form {
 
   welcome: `# Welcome to Fast Draft!
 
-theme accent { fill: #6C5CE7 }
-theme soft { fill: #DFE6E9; corner: 12 }
-theme label_style { font: "Inter" 500 14; fill: #2D3436 }
+style accent { fill: #6C5CE7 }
+style soft { fill: #DFE6E9; corner: 12 }
+style label_style { font: "Inter" 500 14; fill: #2D3436 }
 
 text @welcome_title "Welcome to Fast Draft" {
   x: 180  y: 40


### PR DESCRIPTION
## Summary\n\nCompletes the `theme` → `style` keyword migration (R4.18) that was started in v0.10.69 but left many files using the old keyword.\n\n### Changes\n\n**Playground (live site impact)**\n- Updated all 3 example strings in `site/playground.js` (6 `theme` → `style` replacements)\n\n**`.fd` files (15 files)**\n- Libraries: `wireframe.fd`, `flowchart.fd`, `ui-kit.fd`\n- Benchmarks: all 9 benchmark files\n- Design docs: `02_bidi_sync.fd`, `04_architecture.fd`, `05_edge_system.fd`\n- Examples: `demo.fd`, `wireframe_login.fd`, `dark_theme.fd`, `animated_onboarding.fd`, `userflow_onboarding.fd`\n\n**Section headers (13 files)**\n- `# ─── Themes ───` → `# ─── Styles ───`\n\n**Documentation (3 files)**\n- `LIBRARIES.md`: code examples, convention table\n- `ARCHITECTURE.md`: SceneGraph/SceneNode field descriptions\n- `REQUIREMENTS.md`: R1.4, R1.17, R4.21 wording\n\n### Not changed (intentional)\n- Rust parser backward-compat: `alt((\"theme\", \"style\"))` — accepts both keywords\n- TypeScript regex: `/^(theme|style)\\s+/` — for file compatibility\n- CSS class names: `dark-theme`, `set_theme()` — unrelated (canvas UI light/dark mode)\n\n### Verification\n- `cargo clippy --workspace -- -D warnings` ✅\n- `cargo test --workspace` ✅\n- `grep -rn '^theme ' examples/ libraries/ docs/design/` → 0 matches ✅