### PR TITLE
refactor(R4.18): final theme→style cleanup — emitter, docs, lessons, workflow

### DIFF
--- a/.agents/workflows/learn.md
+++ b/.agents/workflows/learn.md
@@ -58,7 +58,7 @@ Pick the most relevant category:
 | **WASM**        | Build targets, feature flags, wasm-pack       |
 | **CI/CD**       | GitHub Actions, test flakiness, clippy lints  |
 | **Git**         | Branch workflow, merge conflicts, hooks       |
-| **FD Format**   | Syntax, semantics, spec blocks, themes        |
+| **FD Format**   | Syntax, semantics, spec blocks, styles        |
 | **Cross-Crate** | Dependency ordering, trait bounds, re-exports |
 | **Testing**     | Test setup, mocking, assertion patterns       |
 

--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -899,7 +899,7 @@ pub enum ReadMode {
     Structure,
     /// Structure + dimensions (`w:`/`h:`) + `layout:` directives + constraints.
     Layout,
-    /// Structure + themes/styles + `fill:`/`stroke:`/`font:`/`corner:`/`use:` refs.
+    /// Structure + styles + `fill:`/`stroke:`/`font:`/`corner:`/`use:` refs.
     Design,
     /// Structure + `spec {}` blocks + annotations.
     Spec,
@@ -919,7 +919,7 @@ pub enum ReadMode {
 /// - `Full`: identical to `emit_document`.
 /// - `Structure`: node kind + `@id` + children. No styles, dims, anims, specs.
 /// - `Layout`: structure + `w:`/`h:` + `layout:` + constraints (`->`).
-/// - `Design`: structure + themes + `fill:`/`stroke:`/`font:`/`corner:`/`use:`.
+/// - `Design`: structure + styles + `fill:`/`stroke:`/`font:`/`corner:`/`use:`.
 /// - `Spec`: structure + `spec {}` blocks.
 /// - `Visual`: layout + design + when combined.
 /// - `When`: structure + `when :trigger { ... }` blocks.
@@ -937,12 +937,12 @@ pub fn emit_filtered(graph: &SceneGraph, mode: ReadMode) -> String {
     let mut out = String::with_capacity(1024);
 
     let children = graph.children(graph.root);
-    let include_themes = matches!(mode, ReadMode::Design | ReadMode::Visual);
+    let include_styles = matches!(mode, ReadMode::Design | ReadMode::Visual);
     let include_constraints = matches!(mode, ReadMode::Layout | ReadMode::Visual);
     let include_edges = matches!(mode, ReadMode::Edges | ReadMode::Visual);
 
     // Styles (Design and Visual modes)
-    if include_themes && !graph.styles.is_empty() {
+    if include_styles && !graph.styles.is_empty() {
         let mut styles: Vec<_> = graph.styles.iter().collect();
         styles.sort_by_key(|(id, _)| id.as_str().to_string());
         for (name, style) in &styles {

--- a/crates/fd-core/src/emitter_tests.rs
+++ b/crates/fd-core/src/emitter_tests.rs
@@ -978,7 +978,7 @@ rect @btn {
     let graph = parse_document(input).unwrap();
     let output = emit_document(&graph);
 
-    // Emitter should output `style`, not `theme`
+    // Emitter should output `style`, not `theme` (legacy)
     assert!(
         output.contains("style accent"),
         "should emit `style` keyword"
@@ -1554,7 +1554,7 @@ fn emit_filtered_layout() {
 fn emit_filtered_design() {
     let graph = make_test_graph();
     let out = emit_filtered(&graph, ReadMode::Design);
-    // Should have themes + styles
+    // Should have style definitions
     assert!(out.contains("style accent"), "should include style");
     assert!(out.contains("use: accent"), "should include use ref");
     assert!(out.contains("fill:"), "should include fill");

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -165,7 +165,7 @@
 
 ### v0.10.63 — Demo Cleanup + Test Coverage
 
-- **DOCS**: Rewrote `examples/demo.fd` from 562 lines of testing debris to a polished 236-line product dashboard showcase — demonstrates themes, edge_defaults, specs, animations, flows, frames with column layout, and semantic naming throughout
+- **DOCS**: Rewrote `examples/demo.fd` from 562 lines of testing debris to a polished 236-line product dashboard showcase — demonstrates styles, edge_defaults, specs, animations, flows, frames with column layout, and semantic naming throughout
 - **TEST**: Added `sync_bring_forward_already_front_is_noop` — z-order edge case: bring_forward on frontmost child is a no-op
 - **TEST**: Added `sync_clone_name_sequence` — chained duplication produces `card`, `card_2`, `card_3`, `card_4` correctly
 - **TEST**: Added `sync_near_detach_warning_zone` — exercises near-detach evaluation code path without panic
@@ -824,7 +824,7 @@
 - **Parser hardening**: Added 13 new round-trip tests covering empty groups, 3-level nesting, unicode text (emoji/CJK), spec blocks with all fields, path nodes, linear/radial gradients, shadow, opacity, clip frames, multiple animations, inline spec shorthand, and all layout modes (column/row/grid)
 - **LSP completions**: Overhauled `completion.rs` — added `frame`, `edge`, `import`, `spec` snippets to top-level; `shadow:`, `clip:`, `x:`, `y:`, `align:` properties to node body; value completions for `fill` (named colors + hex palette), `align`, `clip`, `arrow`, `curve`; 9 total tests
 - **Error recovery**: All 6 parser error sites now include 1-based line numbers and 40-char context snippets (UTF-8 safe) — e.g. `line 12: node error — expected 'kind @id { ... }', got '...'`
-- **Example files**: Created 3 new showcase examples: `responsive_dashboard.fd` (constraint-based dashboard), `animated_onboarding.fd` (3-step flow with edge/pulse animations), `design_tokens.fd` (design system with 7 themes + component patterns)
+- **Example files**: Created 3 new showcase examples: `responsive_dashboard.fd` (constraint-based dashboard), `animated_onboarding.fd` (3-step flow with edge/pulse animations), `design_tokens.fd` (design system with 7 styles + component patterns)
 
 ---
 
@@ -851,7 +851,7 @@ Eraser tool (swipe-to-delete, group-aware, poof animation, Ctrl+click temp erase
 
 ### Epoch: v0.8.70–v0.8.99 — Canvas UX & Design Polish (30 releases)
 
-Canvas UX overhaul (layer sync, smart guides 5px, center-snap, text-consume), scroll toolbar redesign (V12 wooden handles), SVG toolbar icons, frosted glass tooltips, auto bring-forward on select, sketchy rendering mode, arrow/connector tool, Figma group drill-down iterations (5+ attempts), toolbar consolidation, status rename, spec badges, theme/when rename, ReadMode filtered views, component libraries, GitHub Pages playground.
+Canvas UX overhaul (layer sync, smart guides 5px, center-snap, text-consume), scroll toolbar redesign (V12 wooden handles), SVG toolbar icons, frosted glass tooltips, auto bring-forward on select, sketchy rendering mode, arrow/connector tool, Figma group drill-down iterations (5+ attempts), toolbar consolidation, status rename, spec badges, style/when rename, ReadMode filtered views, component libraries, GitHub Pages playground.
 
 <details>
 <summary>Full v0.8.70–v0.8.99 entries</summary>
@@ -901,7 +901,7 @@ Zen mode, sketchy/hand-drawn rendering, Figma-style keyboard shortcuts (z-order 
 - **v0.8.66**: Toolbar consolidation (+ Insert dropdown)
 - **v0.8.65**: Status rename (draft→todo, in_progress→doing, +blocked)
 - **v0.8.64**: Spec badge improvements
-- **v0.8.62**: Sort fix + LSP theme/when + tree-sitter regen
+- **v0.8.62**: Sort fix + LSP style/when + tree-sitter regen
 - **v0.8.60**: Text centering in nested layouts
 - **v0.8.59**: Content-first emitter ordering + section separators
 - **v0.8.58**: Text auto-centering in shapes

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -253,7 +253,7 @@ Engineering lessons discovered through building FD.
 **Date**: 2026-03-02
 **Context**: Double-clicking a text node to edit showed text at wrong size/style — the inline editor didn't match what the canvas rendered.
 
-**Root cause**: `get_selected_node_props()` only returned `fontSize`/`fontFamily`/`fontWeight` when `style.font.is_some()`. Text nodes using the default font (no explicit `font:` in FD source) got no font keys in the JSON. The JS fallback (`14`/`"Inter"`/`400`) happened to match the renderer defaults, but broke when themes set different sizes.
+**Root cause**: `get_selected_node_props()` only returned `fontSize`/`fontFamily`/`fontWeight` when `style.font.is_some()`. Text nodes using the default font (no explicit `font:` in FD source) got no font keys in the JSON. The JS fallback (`14`/`"Inter"`/`400`) happened to match the renderer defaults, but broke when styles set different sizes.
 
 **Fix**: Always return `fontSize`, `fontFamily`, `fontWeight` using `style.font.as_ref().map_or(default, |f| f.field)` — same defaults as the renderer.
 


### PR DESCRIPTION
## Summary\n\nFinal pass of `theme` → `style` cleanup (R4.18). Catches remaining references in Rust emitter source, test comments, documentation, and workflow files.\n\n### Changes\n\n| File | What changed |\n|---|---|\n| `emitter.rs` | Renamed `include_themes` → `include_styles` variable; updated 2 doc comments |\n| `emitter_tests.rs` | Updated 3 test comments |\n| `CHANGELOG.md` | 4 historical entries: \"themes\" → \"styles\" where referring to FD style blocks |\n| `LESSONS.md` | 1 entry: \"themes set different sizes\" → \"styles set different sizes\" |\n| `.agents/workflows/learn.md` | Category table: \"themes\" → \"styles\" |\n\n### Verified remaining `theme` — all intentional\n- Parser backward-compat: `starts_with(\"theme \")`, `alt((\"theme\", \"style\"))` \n- `parse_old_theme_keyword_compat` test — specifically tests legacy keyword\n- LSP hover/completion: documents legacy keyword acceptance\n- `CanvasTheme`/`let theme = ...`/`set_theme()` — canvas rendering theme (unrelated)\n- CSS `.dark-theme` — canvas UI light/dark mode\n- QA/skill workflows: \"theme toggle\", \"dark/light theme\" — canvas UI\n\n### Verification\n- `cargo test --workspace` ✅ all pass\n- `cargo clippy --workspace -- -D warnings` ✅ clean