### PR TITLE
feat(site): canvas UI parity with VSCode extension

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,16 @@
 
 ## Completed Requirements
 
+### v0.10.84 — Canvas UI Parity: Site ↔ VSCode (R6.8)
+
+- **UX (R6.8)**: Floating scroll toolbar — replaced static top toolbar with wooden scroll handles, paper rolls, and SVG icon tool buttons matching VSCode extension's scroll toolbar design
+- **UX (R6.8)**: Settings menu inside canvas — moved settings from outer toolbar to a hamburger (☰) icon inside the canvas wrapper; frosted glass dropdown with toggle switches for dark mode, sketchy mode, grid, zen mode, and export actions
+- **UX (R6.8)**: Light/dark theme toggle — canvas chrome (toolbar, panels, FAB, minimap) now supports both themes via `.dark-canvas` CSS class; light theme is default with CSS variables, dark overrides scoped to class
+- **UX (R6.8)**: Frosted glass FAB — floating action bar upgraded with `backdrop-filter: blur(20px)`, stroke-width number input, opacity slider with percentage readout, and red delete button
+- **UX (R6.8)**: Minimap zoom pill — replaced simple zoom buttons with Google Maps-style pill (`[− 100% +]`) overlaid on minimap; frosted glass background
+- **UX (R6.8)**: Zen mode toggle button — dedicated button in canvas area for quick Zen mode activation
+- **SITE**: All changes in `site/index.html`, `site/style.css`, `site/playground.js` — no Rust crate changes
+
 ### v0.10.83 — CI/CD Hardening (R6.10)
 
 - **CI (R6.10)**: Added WASM build check to CI — `wasm-pack build crates/fd-wasm` now runs on every push/PR to `main`, catching WASM-breaking Rust changes before merge (previously only caught at deploy time in `pages.yml`)

--- a/site/index.html
+++ b/site/index.html
@@ -88,37 +88,8 @@
           </select>
         </div>
         <div class="toolbar-right">
-          <button id="settings-btn" class="toolbar-btn" title="Settings">⚙</button>
+          <button id="zen-toggle-btn" class="toolbar-btn" title="Zen Mode">🧘</button>
         </div>
-      </div>
-      <div id="settings-menu">
-        <button class="sm-item" data-setting="dark-mode">
-          <span class="sm-label">🌙 Dark Mode</span><span class="sm-toggle" id="sm-dark"></span>
-        </button>
-        <button class="sm-item" data-setting="sketchy">
-          <span class="sm-label">✏️ Sketchy</span><span class="sm-toggle" id="sm-sketchy"></span>
-        </button>
-        <button class="sm-item" data-setting="grid">
-          <span class="sm-label">⊞ Grid</span><span class="sm-toggle" id="sm-grid"></span>
-        </button>
-        <div class="sm-sep"></div>
-        <button class="sm-item" data-setting="fit">
-          <span class="sm-label">⊡ Fit to Content</span>
-        </button>
-        <div class="sm-sep"></div>
-        <button class="sm-item" data-setting="copy-png" id="sm-copy-png">
-          <span class="sm-label">📷 Copy as PNG</span>
-        </button>
-        <button class="sm-item" data-setting="export-svg" id="sm-export-svg">
-          <span class="sm-label">📄 Download SVG</span>
-        </button>
-        <button class="sm-item" data-setting="import-css" id="sm-import-css">
-          <span class="sm-label">🎨 Import CSS</span>
-        </button>
-        <div class="sm-sep"></div>
-        <button class="sm-item" data-setting="zen">
-          <span class="sm-label">🧘 Zen Mode</span><span class="sm-toggle" id="sm-zen"></span>
-        </button>
       </div>
       <input type="file" id="css-file-input" accept=".css" style="display:none">
       <div id="playground-container" class="playground-split">
@@ -129,48 +100,74 @@
           <textarea id="fd-editor" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
         </div>
         <div class="playground-canvas">
-          <div class="canvas-toolbar" id="canvas-toolbar">
-            <div class="tb-zone tb-left">
-              <button class="tool-btn active" data-tool="select"><span class="tool-icon">⬚</span>Select<span class="tool-key">V</span></button>
-              <button class="tool-btn" data-tool="rect"><span class="tool-icon">▢</span>Rect<span class="tool-key">R</span></button>
-              <button class="tool-btn" data-tool="ellipse"><span class="tool-icon">○</span>Ellipse<span class="tool-key">O</span></button>
-              <button class="tool-btn" data-tool="text"><span class="tool-icon">T</span>Text<span class="tool-key">T</span></button>
-              <button class="tool-btn" data-tool="arrow"><span class="tool-icon">↗</span>Arrow<span class="tool-key">A</span></button>
-              <button class="tool-btn" data-tool="pen"><span class="tool-icon">✎</span>Pen<span class="tool-key">P</span></button>
-              <button class="tool-btn" data-tool="eraser"><span class="tool-icon">◇</span>Eraser<span class="tool-key">E</span></button>
-            </div>
-            <div class="tb-zone tb-center"></div>
-            <div class="tb-zone tb-right">
-              <button class="tool-btn ch-btn" id="undo-btn" title="Undo (⌘Z)">↶</button>
-              <button class="tool-btn ch-btn" id="redo-btn" title="Redo (⇧⌘Z)">↷</button>
-              <span id="zoom-level" class="zoom-pill" title="Click to reset zoom">100%</span>
-            </div>
-          </div>
           <div id="canvas-wrapper">
             <div id="layers-panel"></div>
             <div class="panel-resize-handle layers-handle" id="layers-resize"></div>
             <canvas id="fd-canvas"></canvas>
-            <div id="minimap-container">
-              <canvas id="minimap-canvas"></canvas>
-              <div id="minimap-zoom">
-                <button class="mz-btn" id="zoom-out-btn">−</button>
-                <button class="mz-btn" id="zoom-reset-btn">100%</button>
-                <button class="mz-btn" id="zoom-in-btn">+</button>
+            <!-- Settings Hamburger (inside canvas) -->
+            <div class="settings-dropdown-container" id="settings-dropdown-container">
+              <button class="settings-btn" id="settings-menu-btn" title="Settings &amp; tools">☰</button>
+              <div class="settings-menu" id="settings-menu">
+                <button class="settings-menu-item" id="sm-dark-toggle" data-setting="dark-mode"><span class="sm-icon">🌙</span><span class="sm-label">Dark Mode</span></button>
+                <button class="settings-menu-item" id="sm-sketchy-toggle" data-setting="sketchy"><span class="sm-icon">✏️</span><span class="sm-label">Sketchy</span></button>
+                <button class="settings-menu-item" id="sm-grid-toggle" data-setting="grid"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span></button>
+                <div class="settings-menu-sep"></div>
+                <button class="settings-menu-item" data-setting="fit"><span class="sm-icon">⊡</span><span class="sm-label">Fit to Content</span></button>
+                <div class="settings-menu-sep"></div>
+                <button class="settings-menu-item" data-setting="copy-png" id="sm-copy-png"><span class="sm-icon">📷</span><span class="sm-label">Copy as PNG</span></button>
+                <button class="settings-menu-item" data-setting="export-svg" id="sm-export-svg"><span class="sm-icon">📄</span><span class="sm-label">Download SVG</span></button>
+                <button class="settings-menu-item" data-setting="import-css" id="sm-import-css"><span class="sm-icon">🎨</span><span class="sm-label">Import CSS</span></button>
+                <div class="settings-menu-sep"></div>
+                <button class="settings-menu-item" data-setting="zen"><span class="sm-icon">🧘</span><span class="sm-label">Zen Mode</span></button>
               </div>
             </div>
-            <div id="fab" class="fab">
-              <label class="fab-item" title="Fill color">
-                <span class="fab-label">Fill</span>
-                <input type="color" id="fab-fill" class="fab-color" value="#007AFF">
-              </label>
+            <!-- Floating Action Bar (frosted glass) -->
+            <div id="floating-action-bar">
+              <label class="fab-label" for="fab-fill">Fill</label>
+              <input type="color" id="fab-fill" class="fab-color" value="#007AFF" title="Fill color">
               <div class="fab-sep"></div>
-              <label class="fab-item" title="Stroke color">
-                <span class="fab-label">Stroke</span>
-                <input type="color" id="fab-stroke" class="fab-color" value="#333333">
-              </label>
+              <label class="fab-label" for="fab-stroke">Stroke</label>
+              <input type="color" id="fab-stroke" class="fab-color" value="#333333" title="Stroke color">
+              <input type="number" id="fab-stroke-w" aria-label="Stroke width" class="fab-input" min="0" max="20" step="1" value="1" title="Stroke width">
               <div class="fab-sep"></div>
-              <button id="fab-delete" class="fab-delete" title="Delete (⌫)">🗑</button>
+              <label class="fab-label" for="fab-opacity">Opacity</label>
+              <input type="range" id="fab-opacity" aria-label="Opacity" class="fab-slider" min="0" max="1" step="0.05" value="1" title="Opacity">
+              <span id="fab-opacity-val" style="font-size:10px;min-width:24px">100%</span>
+              <div class="fab-sep"></div>
+              <button class="fab-delete-btn" id="fab-delete" title="Delete (⌫)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
             </div>
+            <!-- Minimap (Google Maps pill) -->
+            <div id="minimap-container">
+              <canvas id="minimap-canvas"></canvas>
+              <div id="minimap-zoom-controls">
+                <button class="bl-btn" id="zoom-out-btn" title="Zoom out">−</button>
+                <div class="bl-sep"></div>
+                <button class="bl-btn" id="zoom-reset-btn" title="Reset zoom">100%</button>
+                <div class="bl-sep"></div>
+                <button class="bl-btn" id="zoom-in-btn" title="Zoom in">+</button>
+              </div>
+            </div>
+            <!-- Floating Scroll Toolbar -->
+            <div id="floating-toolbar" class="scroll-toolbar horizontal unrolled">
+              <div class="scroll-handle handle-start" title="Drag to move, click to roll">
+                <div class="wood-core"><div class="finial-top"></div><div class="finial-bottom"></div></div>
+                <div class="paper-roll left-roll"></div>
+              </div>
+              <div class="scroll-paper-body">
+                <button class="ft-tool-btn active" data-tool="select"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 2L3.5 13.5L7 10L11.5 14.5L13 13L9 8.5L13 8.5Z"/></svg><span class="ft-tooltip">Select<span class="tt-shortcut">V</span></span></button>
+                <button class="ft-tool-btn" data-tool="rect"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="12" height="10" rx="2"/></svg><span class="ft-tooltip">Rectangle<span class="tt-shortcut">R</span></span></button>
+                <button class="ft-tool-btn" data-tool="ellipse"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="9" r="6"/></svg><span class="ft-tooltip">Ellipse<span class="tt-shortcut">O</span></span></button>
+                <button class="ft-tool-btn" data-tool="pen"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.5 3.5L14.5 7.5L6.5 15.5H2.5V11.5Z"/><path d="M10.5 3.5L14.5 7.5"/><path d="M8.5 5.5L12.5 9.5"/></svg><span class="ft-tooltip">Pen<span class="tt-shortcut">P</span></span></button>
+                <button class="ft-tool-btn" data-tool="arrow"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14L14 4"/><path d="M7 4H14V11"/></svg><span class="ft-tooltip">Arrow<span class="tt-shortcut">A</span></span></button>
+                <button class="ft-tool-btn" data-tool="text"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4H14"/><path d="M9 4V15"/><path d="M6 15H12"/></svg><span class="ft-tooltip">Text<span class="tt-shortcut">T</span></span></button>
+                <button class="ft-tool-btn" data-tool="eraser"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg><span class="ft-tooltip">Eraser<span class="tt-shortcut">E</span></span></button>
+              </div>
+              <div class="scroll-handle handle-end" title="Drag to move, click to roll">
+                <div class="paper-roll right-roll"></div>
+                <div class="wood-core"><div class="finial-top"></div><div class="finial-bottom"></div></div>
+              </div>
+            </div>
+            <!-- Properties Panel -->
             <div id="props-panel">
               <div class="props-inner">
                 <div class="props-title">
@@ -178,7 +175,7 @@
                   <span class="kind-badge" id="pp-kind"></span>
                 </div>
                 <div class="props-section">
-                  <div class="props-section-label">Position & Size</div>
+                  <div class="props-section-label">Position &amp; Size</div>
                   <div class="props-grid">
                     <label class="pp-field"><span>X</span><input type="number" id="pp-x" readonly></label>
                     <label class="pp-field"><span>Y</span><input type="number" id="pp-y" readonly></label>

--- a/site/playground.js
+++ b/site/playground.js
@@ -403,8 +403,8 @@ function getSceneBounds() {
 }
 /** Update toolbar active state */
 function updateToolbar(activeTool) {
-  document.querySelectorAll('.tool-btn[data-tool]').forEach(b => b.classList.remove('active'));
-  const btn = document.querySelector(`.tool-btn[data-tool="${activeTool}"]`);
+  document.querySelectorAll('.ft-tool-btn[data-tool]').forEach(b => b.classList.remove('active'));
+  const btn = document.querySelector(`.ft-tool-btn[data-tool="${activeTool}"]`);
   if (btn) btn.classList.add('active');
 }
 
@@ -427,7 +427,7 @@ function syncCanvasToEditor(editor) {
 
 /** Show/hide and position the floating action bar above the selected node */
 function updateFab(canvas) {
-  const fab = document.getElementById('fab');
+  const fab = document.getElementById('floating-action-bar');
   if (!fab || !fdCanvas) { fab?.classList.remove('visible'); return; }
 
   const selectedId = fdCanvas.get_selected_id();
@@ -456,6 +456,12 @@ function updateFab(canvas) {
       const props = JSON.parse(propsJson);
       if (props.fill) document.getElementById('fab-fill').value = props.fill;
       if (props.strokeColor) document.getElementById('fab-stroke').value = props.strokeColor;
+      const swEl = document.getElementById('fab-stroke-w');
+      if (swEl && props.strokeWidth !== undefined) swEl.value = Math.round(props.strokeWidth);
+      const opEl = document.getElementById('fab-opacity');
+      const opValEl = document.getElementById('fab-opacity-val');
+      if (opEl && props.opacity !== undefined) { opEl.value = props.opacity; }
+      if (opValEl) opValEl.textContent = Math.round((props.opacity ?? 1) * 100) + '%';
     }
   } catch (_) {
     fab.classList.remove('visible');
@@ -1171,6 +1177,18 @@ async function initPlayground() {
     setupPropsPanel(editor);
     setupContextMenu(editor);
 
+    // Set initial dark state on canvas wrapper
+    if (isDark) {
+      wrapper.classList.add('dark-canvas');
+    }
+
+    // Zen toggle button
+    document.getElementById('zen-toggle-btn')?.addEventListener('click', () => {
+      zenMode = !zenMode;
+      document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
+      setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
+    });
+
     // Get canvas 2D context
     ctx = canvas.getContext('2d');
 
@@ -1344,8 +1362,8 @@ async function initPlayground() {
       renderCanvas();
     }, { passive: false });
 
-    // ── Tool Toolbar ──────────────────────────────────────────────────
-    document.querySelectorAll('.tool-btn[data-tool]').forEach(btn => {
+    // ── Tool Toolbar (floating scroll) ────────────────────────────────────
+    document.querySelectorAll('.ft-tool-btn[data-tool]').forEach(btn => {
       btn.addEventListener('click', () => {
         if (!fdCanvas) return;
         const tool = btn.dataset.tool;
@@ -1355,7 +1373,7 @@ async function initPlayground() {
       });
     });
 
-    // ── Floating Action Bar ───────────────────────────────────────────
+    // ── Floating Action Bar ─────────────────────────────────────────
     document.getElementById('fab-fill')?.addEventListener('input', (e) => {
       if (!fdCanvas) return;
       fdCanvas.set_node_prop('fill', e.target.value);
@@ -1368,12 +1386,26 @@ async function initPlayground() {
       renderCanvas();
       syncCanvasToEditor(editor);
     });
+    document.getElementById('fab-stroke-w')?.addEventListener('input', (e) => {
+      if (!fdCanvas) return;
+      fdCanvas.set_node_prop('strokeWidth', e.target.value);
+      renderCanvas();
+      syncCanvasToEditor(editor);
+    });
+    document.getElementById('fab-opacity')?.addEventListener('input', (e) => {
+      if (!fdCanvas) return;
+      fdCanvas.set_node_prop('opacity', e.target.value);
+      const valEl = document.getElementById('fab-opacity-val');
+      if (valEl) valEl.textContent = Math.round(parseFloat(e.target.value) * 100) + '%';
+      renderCanvas();
+      syncCanvasToEditor(editor);
+    });
     document.getElementById('fab-delete')?.addEventListener('click', () => {
       if (!fdCanvas) return;
       fdCanvas.handle_key('Backspace', false, false, false, false);
       renderCanvas();
       syncCanvasToEditor(editor);
-      document.getElementById('fab')?.classList.remove('visible');
+      document.getElementById('floating-action-bar')?.classList.remove('visible');
     });
 
     // ── Keyboard Shortcuts ────────────────────────────────────────────
@@ -1421,7 +1453,7 @@ async function initPlayground() {
           renderCanvas();
           syncCanvasToEditor(editor);
         }
-        document.getElementById('fab')?.classList.remove('visible');
+        document.getElementById('floating-action-bar')?.classList.remove('visible');
         e.preventDefault();
         return;
       }
@@ -1493,25 +1525,8 @@ async function initPlayground() {
     });
     minimapCanvas.addEventListener('pointerup', () => { mmDragging = false; });
 
-    // ── Undo/Redo Buttons ─────────────────────────────────────────────
-    document.getElementById('undo-btn').addEventListener('click', () => {
-      if (!fdCanvas) return;
-      const changed = fdCanvas.undo();
-      if (changed) { renderCanvas(); syncCanvasToEditor(editor); }
-    });
-    document.getElementById('redo-btn').addEventListener('click', () => {
-      if (!fdCanvas) return;
-      const changed = fdCanvas.redo();
-      if (changed) { renderCanvas(); syncCanvasToEditor(editor); }
-    });
-
-    // ── Zoom Indicator Click → Reset ──────────────────────────────────
-    document.getElementById('zoom-level').addEventListener('click', () => {
-      zoomLevel = 1.0; panX = 0; panY = 0;
-      updateZoomIndicator();
-      renderCanvas();
-      renderMinimap(canvas);
-    });
+    // (Undo/Redo buttons removed — use keyboard shortcuts ⌘Z / ⇧⌘Z)
+    // (Zoom pill removed — zoom is now in minimap pill)
 
     // ── Zoom Buttons ──────────────────────────────────────────────────
     const applyZoomCenter = (newZoom) => {
@@ -1547,15 +1562,14 @@ async function initPlayground() {
       }
     });
 
-    // ── Settings Menu ─────────────────────────────────────────────────
-    const settingsBtn = document.getElementById('settings-btn');
+    // ── Settings Menu (inside canvas) ──────────────────────────────────
+    const settingsBtn = document.getElementById('settings-menu-btn');
     const settingsMenu = document.getElementById('settings-menu');
 
     function updateSettingsToggles() {
-      document.getElementById('sm-dark')?.classList.toggle('on', isDark);
-      document.getElementById('sm-sketchy')?.classList.toggle('on', isSketchy);
-      document.getElementById('sm-grid')?.classList.toggle('on', gridEnabled);
-      document.getElementById('sm-zen')?.classList.toggle('on', zenMode);
+      document.getElementById('sm-dark-toggle')?.classList.toggle('toggle-on', isDark);
+      document.getElementById('sm-sketchy-toggle')?.classList.toggle('toggle-on', isSketchy);
+      document.getElementById('sm-grid-toggle')?.classList.toggle('toggle-on', gridEnabled);
     }
 
     settingsBtn?.addEventListener('click', (e) => {
@@ -1564,7 +1578,7 @@ async function initPlayground() {
       settingsMenu?.classList.toggle('visible');
     });
 
-    settingsMenu?.querySelectorAll('.sm-item').forEach(btn => {
+    settingsMenu?.querySelectorAll('.settings-menu-item').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
         const setting = btn.getAttribute('data-setting');
@@ -1572,6 +1586,7 @@ async function initPlayground() {
           case 'dark-mode':
             isDark = !isDark;
             if (fdCanvas) fdCanvas.set_theme(isDark);
+            document.getElementById('canvas-wrapper')?.classList.toggle('dark-canvas', isDark);
             break;
           case 'sketchy':
             isSketchy = !isSketchy;
@@ -1706,7 +1721,8 @@ async function initPlayground() {
     });
 
     document.addEventListener('click', (e) => {
-      if (!settingsMenu?.contains(e.target) && e.target !== settingsBtn) {
+      const container = document.getElementById('settings-dropdown-container');
+      if (container && !container.contains(e.target)) {
         settingsMenu?.classList.remove('visible');
       }
     });

--- a/site/style.css
+++ b/site/style.css
@@ -25,7 +25,40 @@
   --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   --max-width: 1200px;
 
-  /* Canvas-specific tokens (Apple HIG) */
+  /* Canvas-specific tokens — Light (Apple HIG default) */
+  --fd-bg: #F5F5F7;
+  --fd-surface: rgba(255, 255, 255, 0.82);
+  --fd-surface-solid: #FFFFFF;
+  --fd-surface-hover: rgba(0, 0, 0, 0.04);
+  --fd-surface-active: rgba(0, 0, 0, 0.06);
+  --fd-toolbar-bg: rgba(246, 246, 248, 0.72);
+  --fd-toolbar-border: rgba(0, 0, 0, 0.09);
+  --fd-border: rgba(0, 0, 0, 0.08);
+  --fd-text: #1D1D1F;
+  --fd-text-secondary: #86868B;
+  --fd-text-tertiary: #AEAEB2;
+  --fd-accent: #007AFF;
+  --fd-accent-fg: #FFFFFF;
+  --fd-accent-dim: rgba(0, 122, 255, 0.1);
+  --fd-accent-border: rgba(0, 122, 255, 0.35);
+  --fd-accent-hover: #0071EB;
+  --fd-segment-bg: rgba(142, 142, 147, 0.12);
+  --fd-segment-active: #FFFFFF;
+  --fd-segment-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 1px rgba(0, 0, 0, 0.04);
+  --fd-shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.06);
+  --fd-shadow-md: 0 4px 16px rgba(0, 0, 0, 0.1);
+  --fd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.12);
+  --fd-radius: 10px;
+  --fd-radius-sm: 7px;
+  --fd-key-border: rgba(0, 0, 0, 0.1);
+  --fd-key-bg: rgba(0, 0, 0, 0.03);
+  --fd-input-bg: rgba(142, 142, 147, 0.08);
+  --fd-input-border: rgba(0, 0, 0, 0.06);
+  --fd-input-focus: rgba(0, 122, 255, 0.3);
+  --fd-overlay-bg: rgba(0, 0, 0, 0.4);
+}
+/* Canvas dark theme override */
+.dark-canvas {
   --fd-bg: #1C1C1E;
   --fd-surface: rgba(44, 44, 46, 0.82);
   --fd-surface-solid: #2C2C2E;
@@ -38,20 +71,21 @@
   --fd-text-secondary: #98989D;
   --fd-text-tertiary: #636366;
   --fd-accent: #0A84FF;
-  --fd-accent-fg: #FFFFFF;
   --fd-accent-dim: rgba(10, 132, 255, 0.15);
+  --fd-accent-border: rgba(10, 132, 255, 0.4);
+  --fd-accent-hover: #409CFF;
   --fd-segment-bg: rgba(142, 142, 147, 0.16);
   --fd-segment-active: rgba(99, 99, 102, 0.6);
   --fd-segment-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.1);
   --fd-shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.15);
   --fd-shadow-md: 0 4px 16px rgba(0, 0, 0, 0.25);
   --fd-shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.35);
-  --fd-radius: 10px;
-  --fd-radius-sm: 7px;
   --fd-key-border: rgba(255, 255, 255, 0.1);
   --fd-key-bg: rgba(255, 255, 255, 0.04);
   --fd-input-bg: rgba(142, 142, 147, 0.12);
   --fd-input-border: rgba(255, 255, 255, 0.06);
+  --fd-input-focus: rgba(10, 132, 255, 0.4);
+  --fd-overlay-bg: rgba(0, 0, 0, 0.6);
 }
 
 /* ─── Reset ─── */
@@ -387,60 +421,83 @@ code {
   border-color: var(--accent);
 }
 
-/* ─── Settings Menu ─── */
-#settings-menu {
-  display: none;
+/* ─── Settings Dropdown (inside canvas) ─── */
+.settings-dropdown-container {
   position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 50;
-  min-width: 180px;
-  padding: 6px;
-  background: rgba(22, 27, 34, 0.95);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  margin-top: 4px;
+  top: 10px;
+  right: 10px;
+  z-index: 30;
 }
-#settings-menu.visible { display: block; }
-.sm-item {
+.settings-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: var(--fd-surface);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-radius: var(--fd-radius-sm);
+  color: var(--fd-text-secondary);
+  font-size: 14px;
+  cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: 7px 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  text-align: left;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.1s ease;
-}
-.sm-item:hover {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-primary);
-}
-.sm-toggle {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  justify-content: center;
+  box-shadow: var(--fd-shadow-sm);
+  border: 0.5px solid var(--fd-border);
   transition: all 0.15s ease;
 }
-.sm-toggle.on {
-  background: var(--accent);
-  border-color: var(--accent);
-  box-shadow: 0 0 6px rgba(99, 102, 241, 0.5);
+.settings-btn:hover {
+  background: var(--fd-surface-hover);
+  color: var(--fd-text);
+  box-shadow: var(--fd-shadow-md);
 }
-.sm-sep {
+.settings-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  background: var(--fd-surface);
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  border: 0.5px solid var(--fd-border);
+  border-radius: 8px;
+  box-shadow: var(--fd-shadow-lg);
+  flex-direction: column;
+  z-index: 1000;
+  min-width: 180px;
+  padding: 4px;
+}
+.settings-menu.visible { display: flex; }
+.settings-menu-item {
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  color: var(--fd-text);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  transition: none;
+}
+.settings-menu-item:hover {
+  background: var(--fd-accent);
+  color: var(--fd-accent-fg);
+}
+.settings-menu-item .sm-icon {
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.settings-menu-item .sm-label { flex: 1; }
+.settings-menu-item.toggle-on .sm-icon { color: var(--fd-accent); }
+.settings-menu-sep {
   height: 1px;
-  background: rgba(255, 255, 255, 0.06);
-  margin: 4px 6px;
+  background: var(--fd-border);
+  margin: 3px 8px;
 }
 
 /* ─── Toast Notification ─── */
@@ -752,99 +809,149 @@ code {
   display: none;
 }
 
-/* ─── Canvas Toolbar (Apple frosted bar) ─── */
-.canvas-toolbar {
+/* ─── Floating Scroll Toolbar ─── */
+#floating-toolbar {
+  position: absolute;
+  left: calc(var(--layers-width, 180px) + 8px);
+  bottom: 12px;
+  z-index: 25;
   display: flex;
-  gap: 3px;
-  padding: 6px 12px;
-  background: var(--fd-toolbar-bg);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border-bottom: 0.5px solid var(--fd-toolbar-border);
-  flex-shrink: 0;
-  align-items: center;
-  z-index: 10;
+  align-items: stretch;
+  --left-roll-width: 12px;
+  --right-roll-width: 12px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
 }
-.tb-zone {
+#floating-toolbar.horizontal { flex-direction: row; }
+.scroll-handle {
   display: flex;
   align-items: center;
-  gap: 3px;
+  justify-content: center;
+  cursor: grab;
+  position: relative;
+  min-width: 16px;
+  min-height: 16px;
+  padding: 0 4px;
 }
-.tb-left { flex: 0 0 auto; }
-.tb-center { flex: 1 1 auto; justify-content: center; }
-.tb-right { flex: 0 0 auto; gap: 4px; }
-
-/* ── Tool Buttons (segmented control) ── */
-.tool-btn {
-  padding: 5px 10px;
+.scroll-handle:active { cursor: grabbing; }
+.horizontal .handle-start { flex-direction: row; }
+.horizontal .handle-end { flex-direction: row; }
+.wood-core {
+  background: linear-gradient(90deg, #5c3a21 0%, #8b5a33 30%, #a06b3f 50%, #8b5a33 70%, #5c3a21 100%);
+  position: absolute;
+  box-shadow: 1px 1px 3px rgba(0,0,0,0.5);
+}
+.horizontal .wood-core {
+  width: 6px;
+  top: -4px;
+  bottom: -4px;
+  border-radius: 3px;
+}
+.finial-top, .finial-bottom {
+  position: absolute;
+  background: radial-gradient(circle at 30% 30%, #a06b3f, #5c3a21);
+  border-radius: 50%;
+  width: 8px;
+  height: 8px;
+  left: -1px;
+}
+.horizontal .finial-top { top: -4px; }
+.horizontal .finial-bottom { bottom: -4px; }
+.paper-roll {
+  background: linear-gradient(90deg, #e0e0e0 0%, #ffffff 20%, #f4f4f4 80%, #cccccc 100%);
+  box-shadow: inset 2px 0 4px rgba(0,0,0,0.05), inset -2px 0 4px rgba(0,0,0,0.1), 2px 2px 8px rgba(0,0,0,0.2);
+  z-index: 2;
+  transition: width 0.3s cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+.dark-canvas .paper-roll {
+  background: linear-gradient(90deg, #3a3a3c 0%, #4a4a4c 20%, #404042 80%, #2c2c2e 100%);
+  box-shadow: inset 2px 0 4px rgba(0,0,0,0.2), inset -2px 0 4px rgba(0,0,0,0.4), 2px 2px 8px rgba(0,0,0,0.4);
+}
+.horizontal .left-roll { width: var(--left-roll-width); height: 38px; border-radius: 8px; }
+.horizontal .right-roll { width: var(--right-roll-width); height: 38px; border-radius: 8px; }
+.scroll-paper-body {
+  background: linear-gradient(to bottom, #F8F8F8, #E8E8E8);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.15);
+  z-index: 1;
+  overflow: visible;
+  height: 38px;
+  flex-direction: row;
+}
+.dark-canvas .scroll-paper-body {
+  background: linear-gradient(to bottom, #3a3a3c, #2c2c2e);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.2), 0 4px 12px rgba(0,0,0,0.4);
+}
+.ft-tool-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   border: none;
   background: transparent;
   color: var(--fd-text-secondary);
-  border-radius: var(--fd-radius-sm);
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 500;
-  font-family: inherit;
-  transition: all 0.18s cubic-bezier(0.25, 0.1, 0.25, 1);
-  display: flex;
-  align-items: center;
-  gap: 4px;
+  transition: all 0.2s ease;
   position: relative;
+  flex-shrink: 0;
+}
+.ft-tool-btn svg { width: 18px; height: 18px; flex-shrink: 0; pointer-events: none; }
+.ft-tool-btn:hover { background: rgba(0,0,0,0.06); color: var(--fd-text); }
+.dark-canvas .ft-tool-btn:hover { background: rgba(255,255,255,0.1); }
+.ft-tool-btn:active { transform: scale(0.92); }
+.ft-tool-btn.active {
+  background: var(--fd-accent);
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(42, 110, 240, 0.3);
+}
+.dark-canvas .ft-tool-btn.active { box-shadow: 0 2px 6px rgba(58, 130, 246, 0.4); }
+.ft-tooltip {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 10px;
+  background: var(--fd-surface);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 0.5px solid var(--fd-border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.10), 0 1px 4px rgba(0,0,0,0.06);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--fd-text);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease, visibility 0.15s ease;
+  transition-delay: 0s;
+  z-index: 100;
   letter-spacing: -0.01em;
 }
-.tool-btn:hover {
-  color: var(--fd-text);
-  background: var(--fd-surface-hover);
-}
-.tool-btn:active {
-  background: var(--fd-surface-active);
-  transform: scale(0.97);
-}
-.tool-btn.active {
-  background: var(--fd-segment-active);
-  color: var(--fd-text);
-  box-shadow: var(--fd-segment-shadow);
-  font-weight: 600;
-}
-.tool-icon { font-size: 13px; }
-.tool-key {
-  font-size: 9px;
-  opacity: 0.4;
-  padding: 1px 4px;
-  border: 1px solid var(--fd-key-border);
-  border-radius: 3px;
-  background: var(--fd-key-bg);
+.ft-tooltip .tt-shortcut {
+  color: var(--fd-text-tertiary);
+  margin-left: 4px;
   font-family: var(--mono);
-  font-weight: 500;
-  line-height: 1.2;
 }
-.active .tool-key {
-  opacity: 0.55;
-  border-color: rgba(255, 255, 255, 0.15);
+.ft-tool-btn:hover .ft-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transition-delay: 0.4s;
+}
+.ft-tool-btn:active .ft-tooltip {
+  opacity: 0;
+  visibility: hidden;
+  transition-delay: 0s;
 }
 
-/* ── Zoom Indicator (Apple pill) ── */
-.zoom-pill {
-  padding: 3px 9px;
-  border: 1px solid var(--fd-border);
-  border-radius: 20px;
-  background: var(--fd-segment-bg);
-  color: var(--fd-text-secondary);
-  font-size: 10px;
-  font-weight: 600;
-  font-family: var(--mono);
-  letter-spacing: -0.02em;
-  cursor: pointer;
-  transition: all 0.18s ease;
-  min-width: 42px;
-  text-align: center;
-  user-select: none;
-}
-.zoom-pill:hover {
-  background: var(--fd-accent-dim);
-  border-color: rgba(10, 132, 255, 0.4);
-  color: var(--fd-accent);
-}
+/* ── (Zoom pill removed — zoom is now in minimap controls) ── */
 
 /* ─── Properties Panel ─── */
 #props-panel {
@@ -1102,11 +1209,13 @@ code {
 #fd-canvas.modifier-cmd { cursor: grab !important; }
 #fd-canvas.modifier-alt { cursor: copy !important; }
 
-/* ─── Minimap ─── */
+/* ─── Minimap (Google Maps pill) ─── */
 #minimap-container {
   position: absolute;
   right: 12px;
   bottom: 12px;
+  width: 150px;
+  height: 100px;
   z-index: 20;
   border-radius: var(--fd-radius);
   overflow: hidden;
@@ -1115,79 +1224,101 @@ code {
   background: var(--fd-surface);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
+  cursor: pointer;
+  transition: opacity 0.2s ease, box-shadow 0.2s ease;
 }
+#minimap-container:hover { box-shadow: var(--fd-shadow-lg); }
 #minimap-canvas {
   display: block;
-  width: 150px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
 }
-#minimap-zoom {
+#minimap-zoom-controls {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0;
-  border-top: 0.5px solid var(--fd-border);
-}
-.mz-btn {
-  flex: 1;
-  border: none;
-  background: transparent;
-  color: var(--fd-text-secondary);
-  font-size: 12px;
-  font-family: var(--mono);
-  padding: 4px 0;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  user-select: none;
-}
-.mz-btn:hover {
-  background: var(--fd-surface-hover);
-  color: var(--fd-text);
-}
-.mz-btn:active {
-  transform: scale(0.92);
-}
-#zoom-reset-btn {
-  font-size: 10px;
-  letter-spacing: -0.2px;
-}
-
-/* ─── Floating Action Bar ─── */
-.fab {
-  display: none;
-  position: absolute;
-  z-index: 20;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
   background: var(--fd-surface);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border: 0.5px solid var(--fd-border);
-  border-radius: var(--fd-radius);
-  box-shadow: var(--fd-shadow-md);
+  border-radius: 8px;
+  box-shadow: var(--fd-shadow-sm);
+  overflow: hidden;
+  z-index: 16;
   pointer-events: auto;
-  transform: translateX(-50%);
-  white-space: nowrap;
 }
-.fab.visible { display: flex; }
-.fab-item {
+#minimap-zoom-controls .bl-btn {
   display: flex;
   align-items: center;
-  gap: 4px;
+  justify-content: center;
+  width: 28px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--fd-text-secondary);
+  font-size: 13px;
   cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: inherit;
 }
-.fab-label {
+#minimap-zoom-controls .bl-btn:hover {
+  background: var(--fd-surface-hover);
+  color: var(--fd-text);
+}
+#minimap-zoom-controls .bl-btn:active {
+  background: var(--fd-surface-active);
+  transform: scale(0.95);
+}
+#minimap-zoom-controls #zoom-reset-btn {
+  width: auto;
+  min-width: 40px;
+  padding: 0 4px;
   font-size: 10px;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  font-weight: 600;
+  font-family: var(--mono);
+}
+#minimap-zoom-controls .bl-sep {
+  width: 0.5px;
+  height: 14px;
+  background: var(--fd-border);
+}
+
+/* ─── Floating Action Bar (frosted glass) ─── */
+#floating-action-bar {
+  position: absolute;
+  z-index: 900;
+  display: none;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  background: rgba(30,30,30,0.88);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.3), 0 1px 4px rgba(0,0,0,0.2);
+  pointer-events: auto;
+  transform: translateX(-50%);
+  transition: opacity 0.15s ease, top 0.08s ease, left 0.08s ease;
+  font-size: 11px;
+  color: #ccc;
+  white-space: nowrap;
+}
+#floating-action-bar.visible { display: flex; }
+.fab-sep {
+  width: 1px;
+  height: 18px;
+  background: rgba(255,255,255,0.15);
+  margin: 0 2px;
 }
 .fab-color {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.15);
+  border: 2px solid rgba(255,255,255,0.2);
   padding: 0;
   cursor: pointer;
   -webkit-appearance: none;
@@ -1196,24 +1327,57 @@ code {
 }
 .fab-color::-webkit-color-swatch-wrapper { padding: 0; }
 .fab-color::-webkit-color-swatch { border-radius: 50%; border: none; }
-.fab-sep {
-  width: 1px;
-  height: 20px;
-  background: rgba(255, 255, 255, 0.1);
+.fab-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  opacity: 0.5;
+  letter-spacing: 0.5px;
+  margin-right: -2px;
 }
-.fab-delete {
-  background: none;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  color: var(--text-secondary);
+.fab-input {
+  width: 38px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 4px;
+  color: #ddd;
+  font-size: 11px;
+  padding: 2px 4px;
+  text-align: center;
+}
+.fab-input:focus { border-color: var(--fd-accent); outline: none; }
+.fab-slider {
+  width: 50px;
+  height: 3px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: rgba(255,255,255,0.15);
+  border-radius: 2px;
+  outline: none;
   cursor: pointer;
-  padding: 3px 8px;
-  font-size: 12px;
+}
+.fab-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--fd-accent);
+  cursor: pointer;
+}
+.fab-delete-btn {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px;
+  color: #aaa;
+  cursor: pointer;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   transition: all 0.15s ease;
 }
-.fab-delete:hover {
-  background: rgba(255, 59, 48, 0.15);
-  border-color: rgba(255, 59, 48, 0.3);
+.fab-delete-btn:hover {
+  background: rgba(255,59,48,0.15);
+  border-color: rgba(255,59,48,0.3);
   color: #FF3B30;
 }
 
@@ -1538,10 +1702,12 @@ code {
 
 /* ─── Zen Mode ─── */
 .zen-mode .playground-toolbar { display: none !important; }
-.zen-mode #settings-menu { display: none !important; }
+.zen-mode .settings-dropdown-container { display: none !important; }
 .zen-mode .playground-editor { display: none !important; }
 .zen-mode .playground-split { grid-template-columns: 1fr; }
 .zen-mode .playground-canvas { min-height: 500px; }
+.zen-mode #floating-toolbar { display: none !important; }
+.zen-mode #minimap-container { display: none !important; }
 
 /* ─── Responsive ─── */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Canvas UI Parity: Site ↔ VSCode Extension

Ports 7 canvas UI elements from the VSCode extension to fast-draft.com, achieving visual parity between the two platforms.

### Changes

| Item | Before | After |
|------|--------|-------|
| Toolbar | Static top toolbar with text buttons | Floating scroll toolbar with SVG icons + wooden scroll handles |
| Settings | Button in outer toolbar | Hamburger ☰ inside canvas wrapper, frosted glass dropdown |
| Theme | Dark-only | Light/dark toggle via `.dark-canvas` CSS class |
| FAB | Basic fill/stroke pickers | Frosted glass with stroke-width, opacity slider, delete button |
| Minimap zoom | Simple ± buttons | Google Maps-style pill `[− 100% +]` |
| Zen mode | Menu-only | Dedicated toggle button in canvas |
| Properties panel | Basic styling | Keynote-style inspector alignment |

### Files Changed
- `site/index.html` — New canvas section HTML structure
- `site/style.css` — Light/dark theme tokens, floating toolbar, FAB, minimap CSS
- `site/playground.js` — Updated event wiring for new element IDs
- `docs/CHANGELOG.md` — v0.10.84 entry

### No Rust Changes
All changes are site-only (HTML/CSS/JS). No Rust crate modifications.