### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Renamify Proposals

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Fix XSS Vulnerability in Renamify Proposals
+**Vulnerability:** Untrusted node IDs were being concatenated and injected into the DOM via `innerHTML` in the VS Code webview's Renamify proposals panel. This presented a Cross-Site Scripting (XSS) vulnerability if malicious node IDs were rendered.
+**Learning:** In the VS Code extension webview template string (`fd-vscode/src/webview-html.ts`), elements injected via script tag interpolation are vulnerable to DOM-based XSS if user input (e.g. from `.fd` files) is parsed and rendered with `innerHTML`.
+**Prevention:** Avoid `innerHTML` for displaying untrusted data. Build DOM elements explicitly with `document.createElement()` and use safe APIs like `textContent` for node IDs, or safely escape them before embedding in HTML strings.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2861,11 +2861,29 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         items.forEach((p, i) => {
           const row = document.createElement('div');
           row.className = 'renamify-row';
-          row.innerHTML =
-            '<input type="checkbox" checked data-idx="' + i + '">' +
-            '<span class="renamify-old">@' + p.oldId + '</span>' +
-            '<span class="renamify-arrow">→</span>' +
-            '<span class="renamify-new">@' + p.newId + '</span>';
+
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = true;
+          cb.dataset.idx = String(i);
+          row.appendChild(cb);
+
+          const oldSpan = document.createElement('span');
+          oldSpan.className = 'renamify-old';
+          // Security: Use textContent to prevent XSS from untrusted node IDs
+          oldSpan.textContent = '@' + p.oldId;
+          row.appendChild(oldSpan);
+
+          const arrow = document.createElement('span');
+          arrow.className = 'renamify-arrow';
+          arrow.textContent = '→';
+          row.appendChild(arrow);
+
+          const newSpan = document.createElement('span');
+          newSpan.className = 'renamify-new';
+          newSpan.textContent = '@' + p.newId;
+          row.appendChild(newSpan);
+
           body.appendChild(row);
         });
         footer.style.display = 'flex';


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in Renamify Proposals

**🚨 Severity:** HIGH
**💡 Vulnerability:** The Renamify Proposals panel in the VS Code extension webview (`fd-vscode/src/webview-html.ts`) was using `innerHTML` to concatenate and render untrusted node IDs directly into the DOM.
**🎯 Impact:** A malicious or specially crafted `.fd` file with unescaped HTML characters in node IDs could execute arbitrary JavaScript within the context of the VS Code webview (DOM-based XSS).
**🔧 Fix:** Replaced the unsafe `innerHTML` string concatenation with safe DOM generation using `document.createElement()` and `textContent` to construct the rows.
**✅ Verification:**
- Built the frontend (`cd fd-vscode && pnpm run build:webview`).
- Verified that all unit and E2E UX tests pass successfully (`pnpm test`).
- Verified that linting passes (`pnpm lint`).
- Created a `.jules/sentinel.md` journal entry to record this pattern to prevent future occurrences.

---
*PR created automatically by Jules for task [4198438611853980290](https://jules.google.com/task/4198438611853980290) started by @khangnghiem*