### PR TITLE
chore: bump versions for v0.1.14 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 license = "MIT"
 authors = ["Khang Nghiêm"]

--- a/examples/demo.fd
+++ b/examples/demo.fd
@@ -258,8 +258,8 @@ frame @pipeline {
   w: 460 h: 236
   use: card
   shadow: (0,2,16,#00000010)
-  x: 280
-  y: 540
+  x: 275.2
+  y: 546.1
 }
 
 # Pipeline stages as connected nodes
@@ -326,6 +326,11 @@ ellipse @stage_prod {
 text @_text_2 "Text" {
   x: 405.5
   y: 851.8
+}
+
+text @_text_0 "Text" {
+  x: 360.6
+  y: 657.3
 }
 
 # ─── Flows ───

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.68",
+  "version": "0.10.85",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/tree-sitter-fd/package.json
+++ b/tree-sitter-fd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-fd",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Tree-sitter grammar for FD (Fast Draft) files",
   "license": "MIT",
   "author": "Khang Nghiêm",


### PR DESCRIPTION
Version bump for v0.1.14 release.

- Rust workspace: 0.1.13 → 0.1.14
- fd-vscode: 0.10.68 → 0.10.85
- tree-sitter-fd: 0.1.1 → 0.1.2
- demo.fd cleanup (remove redundant auto-comments)