### PR TITLE
fix(sync): prevent node flash after move via echo-back guards

### DIFF
--- a/.agents/workflows/merge.md
+++ b/.agents/workflows/merge.md
@@ -14,17 +14,17 @@ description: Merge an existing PR into main and sync local branch
    git config core.hooksPath .githooks
    ```
 
-2. Verify the PR is ready (CI green, no blocking reviews):
+2. **Wait for CI** to pass (blocks until all checks complete):
 
-   ```bash
-   gh pr view <PR_NUMBER> --json state,statusCheckRollup
-   ```
+    ```bash
+    gh pr checks <PR_NUMBER> --watch --fail-fast
+    ```
 
 3. Merge the PR and delete the source branch:
 
-   ```bash
-   gh pr merge <PR_NUMBER> --merge --delete-branch
-   ```
+    ```bash
+    gh pr merge <PR_NUMBER> --squash --delete-branch
+    ```
 
 4. Sync local `main`:
 

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -45,17 +45,23 @@ description: Create a Pull Request and merge feature branch into main
    - `title`: conventional format like `feat(core): add FD parser`
    - `body`: summary of changes, what was tested
 
-7. Merge the PR and delete the branch:
+7. **Wait for CI** to pass (blocks until all checks complete):
 
-   ```bash
-   gh pr merge <PR_NUMBER> --merge --delete-branch
-   ```
+    ```bash
+    gh pr checks <PR_NUMBER> --watch --fail-fast
+    ```
 
-8. Sync local main:
+8. Merge the PR and delete the branch:
+
+    ```bash
+    gh pr merge <PR_NUMBER> --squash --delete-branch
+    ```
+
+9. Sync local main:
 
    ```bash
    git checkout main
    git pull origin main
    ```
 
-9. Report the PR URL and merge status to the user.
+10. Report the PR URL and merge status to the user.

--- a/.agents/workflows/publish.md
+++ b/.agents/workflows/publish.md
@@ -17,10 +17,16 @@ description: Publish all FD packages to their respective registries
    - `CARGO_REGISTRY_TOKEN`, `NPM_TOKEN`, `VSCE_PAT`, `VSX_PAT`
    - `GEMINI_API_KEY` (for AI features in fd-vscode)
 
-2. **Verify CI passes**:
+2. **Verify CI passes** (local + remote):
 
    ```bash
    cargo clippy --workspace -- -D warnings && cargo test --workspace
+   ```
+
+   If there's an open PR, also wait for remote CI:
+
+   ```bash
+   gh pr checks <PR_NUMBER> --watch --fail-fast
    ```
 
 3. **Bump versions** in all affected `Cargo.toml` / `package.json`

--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -137,20 +137,26 @@ git checkout -b feat/<descriptive-name>
     - Title in conventional format
     - Body summarizing changes + test results
 
-16. **Merge PR** and clean up:
+16. **Wait for CI** to pass:
 
     ```bash
-    gh pr merge <PR_NUMBER> --merge --delete-branch
+    gh pr checks <PR_NUMBER> --watch --fail-fast
     ```
 
-17. **Sync main**:
+17. **Merge PR** and clean up:
+
+    ```bash
+    gh pr merge <PR_NUMBER> --squash --delete-branch
+    ```
+
+18. **Sync main**:
 
     ```bash
     git checkout main
     git pull origin main
     ```
 
-18. **Verify site deploy** (if `site/`, `crates/fd-wasm/`, or `crates/fd-core/` changed):
+19. **Verify site deploy** (if `site/`, `crates/fd-wasm/`, or `crates/fd-core/` changed):
 
     Wait for the `pages.yml` deploy workflow to complete:
 
@@ -163,7 +169,7 @@ git checkout -b feat/<descriptive-name>
 
     > **Skip** if the change is docs-only, CI config, or VS Code extension-only.
 
-19. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
+20. **Build & Publish VS Code extension** (if `fd-vscode/`, `crates/fd-wasm/`, `crates/fd-core/`, `crates/fd-editor/`, `crates/fd-render/`, or `tree-sitter-fd/` were changed):
 
     > ⚠️ **MANDATORY**: Read `.env` for `VSCE_PAT`, `VSX_PAT`, and `GEMINI_API_KEY` BEFORE publishing.
     > Never rely on interactive prompts — always pass tokens via flags.
@@ -193,10 +199,10 @@ git checkout -b feat/<descriptive-name>
     > Skip publish if the change is local-only or version wasn't bumped.
     > **NEVER** publish to only one registry — both Marketplace AND Open VSX are required.
 
-20. Report PR URL, merge status, deploy verification, and publish results to user.
+21. Report PR URL, merge status, deploy verification, and publish results to user.
 
 ---
 
 ## `/yolo` — Full Pipeline
 
-Runs **all steps 1–19** in sequence (local + deploy).
+Runs **all steps 1–21** in sequence (local + deploy).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fd-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "lasso",
  "log",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "fd-editor"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "fd-core",
  "fd-render",
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "fd-lsp"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "fd-core",
  "log",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "fd-render"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "fd-core",
  "kurbo",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "fd-wasm"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "fd-core",
  "fd-editor",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.86 — Fix Node Flashing After Move
+
+- **FIX**: Nodes no longer flash/flicker after being moved on the canvas — root cause was an async echo-back race in the VS Code extension: `suppressEchoBack` was cleared synchronously after `applyEdit()`, but VS Code fires `onDidChangeTextDocument` asynchronously, sending text back to the webview → `set_text()` → `resolve()` → fresh bounds that clobber in-place move deltas for one frame; fixed by timeout-guarding `suppressEchoBack` for 200ms (matching existing `suppressCursorSync` pattern)
+- **FIX (site)**: Website playground no longer flashes after canvas interaction — `syncCanvasToEditor()` now clears the pending editor→canvas debounce timer, preventing a stale 50ms callback from calling `set_text()` → `resolve()` after `suppressSync` is already cleared
+
 ### v0.10.85 — Edge Selection (R3.1)
 
 - **FEATURE (R3.1)**: Edges are now selectable on canvas — click an edge stroke (5px hit radius) to select, Shift+click for multi-select, marquee box selection includes edges; selected edges show #4FC3F7 highlight stroke; Delete/Backspace removes selected edges via `RemoveEdge` mutation (undoable); properties panel shows edge-specific properties (from/to, arrow, curve, stroke, flow)

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.85",
+  "version": "0.10.86",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/extension.ts
+++ b/fd-vscode/src/extension.ts
@@ -96,7 +96,12 @@ class FdEditorProvider implements vscode.CustomTextEditorProvider {
             incoming
           );
           await vscode.workspace.applyEdit(edit);
-          suppressEchoBack = false;
+          // Delay clearing — VS Code may fire onDidChangeTextDocument
+          // asynchronously after applyEdit resolves. Without the delay,
+          // the echo sends setText back to the webview → set_text() →
+          // resolve() → fresh bounds that clobber in-place move deltas,
+          // causing a visible one-frame flash after dragging nodes.
+          setTimeout(() => { suppressEchoBack = false; }, 200);
           // Delay re-enabling cursor sync — selection events fire asynchronously
           setTimeout(() => { suppressCursorSync = false; }, 200);
           break;

--- a/site/playground.js
+++ b/site/playground.js
@@ -170,6 +170,8 @@ let isDark = true;
 let isSketchy = false;
 let animFrameId = null;
 let suppressSync = false;
+/** Debounce timer for editor→canvas sync (hoisted for syncCanvasToEditor to clear) */
+let editorDebounceTimer = null;
 
 // Pointer tracking
 let activePointerId = -1;
@@ -421,6 +423,11 @@ function updateZoomIndicator() {
 function syncCanvasToEditor(editor) {
   if (!fdCanvas) return;
   suppressSync = true;
+  // Cancel any pending debounced input→canvas sync — it would fire
+  // after suppressSync is cleared, calling set_text() → resolve() →
+  // fresh bounds that clobber in-place move deltas, causing a flash.
+  clearTimeout(editorDebounceTimer);
+  editorDebounceTimer = null;
   editor.value = fdCanvas.get_text();
   suppressSync = false;
 }
@@ -1213,11 +1220,10 @@ async function initPlayground() {
     setupPanelResize(wrapper, resizeCanvas);
 
     // ── Text Editor → Canvas ──────────────────────────────────────────
-    let debounceTimer = null;
     editor.addEventListener('input', () => {
       if (suppressSync) return;
-      clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
+      clearTimeout(editorDebounceTimer);
+      editorDebounceTimer = setTimeout(() => {
         if (fdCanvas) fdCanvas.set_text(editor.value);
       }, 50);
     });


### PR DESCRIPTION
## Fix Node Flashing After Move

### Problem
Nodes flash/flicker for one frame after being moved on the canvas.

### Root Cause
1. **VS Code extension echo-back race** — `suppressEchoBack` was cleared synchronously after `await applyEdit()`, but VS Code fires `onDidChangeTextDocument` asynchronously after the flag is false. This echo sends text back to the webview → `set_text()` → `resolve()` → fresh bounds from `resolve_layout()` that clobber in-place move deltas.

2. **Website playground debounce leak** — `syncCanvasToEditor()` sets `editor.value` synchronously with `suppressSync`, but the `input` handler's 50ms debounce fires after `suppressSync` is cleared, calling `set_text()` → `resolve()` → bounds flash.

### Fix
1. ✅ Timeout-guard `suppressEchoBack` for 200ms (matching existing `suppressCursorSync` pattern) in `extension.ts`
2. ✅ Clear `editorDebounceTimer` inside `syncCanvasToEditor()` in `playground.js`

### Tests
- `cargo clippy --workspace` ✅
- `cargo test --workspace` ✅
- `pnpm test` ✅ (241 tests)