### PR TITLE
refactor(site): unify zen mode into single toggle button inside canvas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,11 +17,12 @@
 
 ## Completed Requirements
 
-### v0.10.88 — Fix Zen Mode Exit on Web (R6.8)
+### v0.10.88 — Unified Zen Mode Toggle (R6.8)
 
-- **FIX (R6.8)**: Zen mode on the website playground now has a visible exit button — frosted-glass "✕ Exit Zen" pill in the top-right corner of the canvas, shown only in zen mode; clicking it or pressing Escape exits zen mode and restores the full editor layout
+- **UX (R6.8)**: Zen toggle moved from outer toolbar into the canvas wrapper — single 🧘/✕ button that stays visible in both normal and zen mode; clicking toggles zen on/off with icon swap; positioned top-right of canvas as frosted-glass 32×32 pill; settings menu "Zen Mode" and Escape key both sync the button icon
 - **FIX**: Fixed scoping bug in Escape key handler — `resizeCanvas()` was called from `setupContextMenu()` but scoped inside `initPlayground()`; replaced with `window.dispatchEvent(new Event('resize'))` to trigger the `ResizeObserver`
-- **SITE**: Changes in `site/index.html` (button markup), `site/style.css` (exit button styles), `site/playground.js` (click handler + Escape fix)
+- **CLEANUP**: Removed separate `#zen-exit-btn` and outer toolbar `#zen-toggle-btn`; unified into one `#zen-toggle-btn` inside `#canvas-wrapper`
+- **SITE**: Changes in `site/index.html`, `site/style.css`, `site/playground.js`
 
 ### v0.10.87 — Animation Duration & Breaks (R1.5, R5.6)
 

--- a/site/index.html
+++ b/site/index.html
@@ -87,9 +87,7 @@
             <option value="welcome">Welcome Screen</option>
           </select>
         </div>
-        <div class="toolbar-right">
-          <button id="zen-toggle-btn" class="toolbar-btn" title="Zen Mode">🧘</button>
-        </div>
+        <div class="toolbar-right"></div>
       </div>
       <input type="file" id="css-file-input" accept=".css" style="display:none">
       <div id="playground-container" class="playground-split">
@@ -147,8 +145,8 @@
                 <button class="bl-btn" id="zoom-in-btn" title="Zoom in">+</button>
               </div>
             </div>
-            <!-- Zen Mode Exit Button -->
-            <button id="zen-exit-btn" class="zen-exit-btn" title="Exit Zen Mode (Esc)">✕ Exit Zen</button>
+            <!-- Zen Mode Toggle (inside canvas so it stays visible in zen mode) -->
+            <button id="zen-toggle-btn" class="zen-toggle-canvas" title="Zen Mode (Esc)">🧘</button>
             <!-- Floating Scroll Toolbar -->
             <div id="floating-toolbar" class="scroll-toolbar horizontal unrolled">
               <div class="scroll-handle handle-start" title="Drag to move, click to roll">

--- a/site/playground.js
+++ b/site/playground.js
@@ -704,6 +704,8 @@ function setupContextMenu(editor) {
       if (zenMode) {
         zenMode = false;
         document.querySelector('.hero-playground')?.classList.remove('zen-mode');
+        const zb = document.getElementById('zen-toggle-btn');
+        if (zb) { zb.textContent = '🧘'; zb.title = 'Zen Mode (Esc)'; }
         // Trigger resize via observer (resizeCanvas is scoped to initPlayground)
         setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
       }
@@ -1189,17 +1191,13 @@ async function initPlayground() {
       wrapper.classList.add('dark-canvas');
     }
 
-    // Zen toggle button
-    document.getElementById('zen-toggle-btn')?.addEventListener('click', () => {
+    // Zen toggle button (inside canvas — stays visible in zen mode)
+    const zenBtn = document.getElementById('zen-toggle-btn');
+    zenBtn?.addEventListener('click', () => {
       zenMode = !zenMode;
       document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
-      setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
-    });
-
-    // Zen exit button (visible only in zen mode)
-    document.getElementById('zen-exit-btn')?.addEventListener('click', () => {
-      zenMode = false;
-      document.querySelector('.hero-playground')?.classList.remove('zen-mode');
+      zenBtn.textContent = zenMode ? '✕' : '🧘';
+      zenBtn.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)';
       setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
     });
 
@@ -1611,6 +1609,8 @@ async function initPlayground() {
           case 'zen': {
             zenMode = !zenMode;
             document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
+            const zb = document.getElementById('zen-toggle-btn');
+            if (zb) { zb.textContent = zenMode ? '✕' : '🧘'; zb.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)'; }
             settingsMenu?.classList.remove('visible');
             // Trigger resize after layout change
             setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);

--- a/site/style.css
+++ b/site/style.css
@@ -1701,33 +1701,40 @@ code {
 }
 
 /* ─── Zen Mode ─── */
-.zen-exit-btn {
-  display: none;
+.zen-toggle-canvas {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 8px;
+  right: 8px;
   z-index: 50;
-  padding: 6px 14px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: 0.5px solid var(--fd-border);
   border-radius: 8px;
   background: var(--fd-surface);
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   color: var(--fd-text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  font-family: inherit;
+  font-size: 16px;
+  line-height: 32px;
+  text-align: center;
   cursor: pointer;
   box-shadow: var(--fd-shadow-sm);
   transition: all 0.15s ease;
+  opacity: 0.6;
 }
-.zen-exit-btn:hover {
+.zen-toggle-canvas:hover {
   background: var(--fd-surface-hover);
   color: var(--fd-text);
   box-shadow: var(--fd-shadow-md);
+  opacity: 1;
 }
-.zen-exit-btn:active { transform: scale(0.95); }
-.zen-mode .zen-exit-btn { display: block; }
+.zen-toggle-canvas:active { transform: scale(0.95); }
+/* In zen mode: more visible since it's the only exit */
+.zen-mode .zen-toggle-canvas {
+  opacity: 1;
+  background: var(--fd-surface-hover);
+}
 .zen-mode .playground-toolbar { display: none !important; }
 .zen-mode .settings-dropdown-container { display: none !important; }
 .zen-mode .playground-editor { display: none !important; }


### PR DESCRIPTION
## Summary\n\nUnifies zen mode into a single toggle button. Previously there were 3 entry/exit points (outer toolbar button, settings menu, separate exit button) — now there's one `#zen-toggle-btn` inside the canvas that stays visible in both modes.\n\n## Changes\n\n- **HTML**: Moved `#zen-toggle-btn` from outer toolbar into `#canvas-wrapper`; removed `#zen-exit-btn`\n- **CSS**: New `.zen-toggle-canvas` class — 32×32 frosted-glass pill, always visible, more prominent in zen mode\n- **JS**: Single toggle with icon swap (🧘↔✕); all 3 code paths sync the icon (button click, Escape, settings menu)\n\n## Testing\n\n- `cargo clippy --workspace -- -D warnings` ✅\n- `cargo fmt --all -- --check` ✅\n- `cargo test --workspace` ✅\n- Site-only change (HTML/CSS/JS)