### PR TITLE
fix(site): add cache-busting and make zen exit button unmissable

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css?v=0.10.89" />
 </head>
 <body>
   <!-- ─── Navigation ─── -->
@@ -441,7 +441,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js"></script>
+  <script type="module" src="playground.js?v=0.10.89"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1196,7 +1196,7 @@ async function initPlayground() {
     zenBtn?.addEventListener('click', () => {
       zenMode = !zenMode;
       document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
-      zenBtn.textContent = zenMode ? '✕' : '🧘';
+      zenBtn.textContent = zenMode ? '✕ Exit Zen' : '🧘';
       zenBtn.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)';
       setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
     });
@@ -1610,7 +1610,7 @@ async function initPlayground() {
             zenMode = !zenMode;
             document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
             const zb = document.getElementById('zen-toggle-btn');
-            if (zb) { zb.textContent = zenMode ? '✕' : '🧘'; zb.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)'; }
+            if (zb) { zb.textContent = zenMode ? '✕ Exit Zen' : '🧘'; zb.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)'; }
             settingsMenu?.classList.remove('visible');
             // Trigger resize after layout change
             setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);

--- a/site/style.css
+++ b/site/style.css
@@ -1720,8 +1720,8 @@ code {
   text-align: center;
   cursor: pointer;
   box-shadow: var(--fd-shadow-sm);
-  transition: all 0.15s ease;
-  opacity: 0.6;
+  transition: all 0.2s ease;
+  opacity: 0.7;
 }
 .zen-toggle-canvas:hover {
   background: var(--fd-surface-hover);
@@ -1730,10 +1730,19 @@ code {
   opacity: 1;
 }
 .zen-toggle-canvas:active { transform: scale(0.95); }
-/* In zen mode: more visible since it's the only exit */
+/* In zen mode: expand to pill with text, high contrast */
 .zen-mode .zen-toggle-canvas {
+  width: auto;
+  height: auto;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  line-height: 1.4;
   opacity: 1;
-  background: var(--fd-surface-hover);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 .zen-mode .playground-toolbar { display: none !important; }
 .zen-mode .settings-dropdown-container { display: none !important; }


### PR DESCRIPTION
## Root Cause\n\nCloudflare CDN was caching stale `style.css` missing the `.zen-toggle-canvas` class. The button existed in the DOM but had no positioning styles → invisible.\n\n## Fix\n\n1. **Cache-busting**: Added `?v=0.10.89` to `style.css` and `playground.js` links in `index.html`\n2. **Bigger exit button**: In zen mode, the button expands from 32×32 icon to a text pill reading "✕ Exit Zen" with high-contrast white-on-dark styling\n3. **Better normal-mode visibility**: Bumped opacity from 0.6 to 0.7