### PR TITLE
feat(ci): auto-purge Cloudflare CDN cache after deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,3 +47,13 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy site --project-name=fast-draft --commit-dirty=true
+
+      - name: Purge Cloudflare CDN cache
+        if: success()
+        run: |
+          curl -sf -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}' \
+            | jq '.success'


### PR DESCRIPTION
## What\n\nAdds automatic Cloudflare CDN cache purge after every deploy. This ensures `fast-draft.com` immediately serves fresh CSS/JS/HTML instead of stale cached assets.\n\n## How\n\nNew step in `pages.yml` after deploy:\n```yaml\n- name: Purge Cloudflare CDN cache\n  run: curl ... purge_everything\n```\n\n## Prerequisites\n\n⚠️ Requires `CLOUDFLARE_ZONE_ID` to be added as a GitHub secret. Get it from Cloudflare Dashboard → fast-draft.com → Overview → API section.