### PR TITLE
fix(editor): hide settings menu in zen mode

### DIFF
--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2554,7 +2554,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <span class="zen-full-only" id="status">Loading WASM…</span>
       <button class="tool-btn" id="zen-toggle-btn" title="Switch to Zen mode">🧘</button>
       <!-- Settings Hamburger ☰ -->
-      <div class="settings-dropdown-container" id="settings-dropdown-container">
+      <div class="settings-dropdown-container zen-full-only" id="settings-dropdown-container">
       <button class="tool-btn" id="settings-menu-btn" title="Settings & tools">☰</button>
       <div class="settings-menu" id="settings-menu">
         <button class="settings-menu-item" id="sm-grid-toggle"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span><span class="sm-shortcut">G</span></button>


### PR DESCRIPTION
## What\n\nHide the ☰ settings hamburger menu in zen mode so only the "✕ Exit Zen" button is visible.\n\n## How\n\nOne-line change: added `zen-full-only` class to `#settings-dropdown-container`. This reuses the existing `.zen-mode .zen-full-only { display: none !important; }` CSS rule.