### PR TITLE
refactor(site): remove example selector from playground

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@
 
 ## Completed Requirements
 
+### v0.10.91 — Remove Example Selector (R6.8)
+
+- **CLEANUP (R6.8)**: Removed multi-example selector from playground — collapsed 3 example files (`card`, `login`, `welcome`) into a single `DEFAULT_FD` constant keeping only the card example; removed `<select>` dropdown, `<label>`, event listener, and `.toolbar-label`/`.toolbar-select` CSS rules; ~150 lines removed across `playground.js`, `index.html`, `style.css`
+
 ### v0.10.90 — Fix Frame Auto-Resize (R3.2)
 
 - **FIX (R3.2)**: Frames no longer involuntarily resize to enclose their children — frames have declared `width`/`height` and should maintain those dimensions; previously `finalize_child_bounds()` and `expand_group_to_children()` treated frames identically to groups, auto-expanding bounds to fit the child bounding box on every pointer release; now all frames (not just `clip: true`) are skipped in auto-sizing logic; only groups auto-size

--- a/site/index.html
+++ b/site/index.html
@@ -80,12 +80,7 @@
       <div class="playground-toolbar">
         <div class="toolbar-left">
           <span class="playground-label">▶ Live Playground</span>
-          <label for="example-select" class="toolbar-label">Example:</label>
-          <select id="example-select" class="toolbar-select">
-            <option value="card">Card Component</option>
-            <option value="login">Login Form</option>
-            <option value="welcome">Welcome Screen</option>
-          </select>
+
         </div>
         <div class="toolbar-right"></div>
       </div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -1,7 +1,6 @@
 // ─── FD Playground — WASM-powered interactive editor ───
 
-const EXAMPLES = {
-  card: `# A card with a button that reacts on hover
+const DEFAULT_FD = `# A card with a button that reacts on hover
 
 style accent {
   fill: #6C5CE7
@@ -29,139 +28,7 @@ group @card {
   }
 }
 
-@card -> center_in: canvas`,
-
-  login: `# Login form with spec annotations
-
-style accent {
-  fill: #6C5CE7
-  corner: 10
-}
-
-style base_text {
-  fill: #333333
-  font: "Inter" regular 14
-}
-
-group @login_form {
-  spec {
-    "User authentication entry point"
-    accept: "email + password fields visible"
-    status: todo
-  }
-  text @title "Welcome Back" {
-    fill: #1A1A2E
-    font: "Inter" bold 24
-  }
-  rect @email_field {
-    text @email_hint "Email" {
-      use: base_text
-      fill: #999999
-    }
-    w: 280 h: 44
-    stroke: #DDDDDD 1
-    corner: 8
-  }
-  rect @pass_field {
-    text @pass_hint "Password" {
-      use: base_text
-      fill: #999999
-    }
-    w: 280 h: 44
-    stroke: #DDDDDD 1
-    corner: 8
-  }
-  rect @login_btn {
-    spec {
-      "Primary CTA"
-      accept: "disabled when fields empty"
-      status: done
-      priority: high
-    }
-    text @btn_label "Sign In" {
-      fill: #FFFFFF
-      font: "Inter" semibold 16
-    }
-    w: 280 h: 48
-    use: accent
-    fill: #5A4BD1
-    when :hover {
-      fill: #4A3BC1
-      scale: 1.02
-      ease: spring 200ms
-    }
-  }
-  layout: column gap=16 pad=32
-}
-
-@login_form -> center_in: canvas`,
-
-  welcome: `# Welcome to Fast Draft!
-
-style accent { fill: #6C5CE7 }
-style soft { fill: #DFE6E9; corner: 12 }
-style label_style { font: "Inter" 500 14; fill: #2D3436 }
-
-text @welcome_title "Welcome to Fast Draft" {
-  x: 180  y: 40
-  font: "Inter" 700 28
-  fill: #2D3436
-}
-
-text @welcome_sub "Edit this code to see changes live!" {
-  x: 180  y: 80
-  font: "Inter" 400 14
-  fill: #636E72
-}
-
-rect @step1_bg {
-  x: 60  y: 140
-  w: 200  h: 140
-  use: soft
-}
-
-text @step1_title "1. Draw Shapes" {
-  x: 80  y: 160
-  use: label_style
-}
-
-rect @step1_demo {
-  x: 220  y: 200
-  w: 30  h: 30
-  use: accent
-  corner: 6
-  when :hover { scale: 1.1; ease: spring 200ms }
-}
-
-rect @step2_bg {
-  x: 300  y: 140
-  w: 200  h: 140
-  use: soft
-}
-
-text @step2_title "2. Add Text" {
-  x: 320  y: 160
-  use: label_style
-}
-
-rect @step3_bg {
-  x: 540  y: 140
-  w: 200  h: 140
-  use: soft
-}
-
-text @step3_title "3. Style It" {
-  x: 560  y: 160
-  use: label_style
-}
-
-ellipse @step3_demo {
-  x: 700  y: 200
-  w: 20  h: 20
-  fill: #E17055
-  when :hover { fill: #00B894; ease: ease_out 300ms }
-}`
-};
+@card -> center_in: canvas`;
 
 // ─── State ───────────────────────────────────────────────────────────────
 let fdCanvas = null;
@@ -1151,8 +1018,8 @@ async function initPlayground() {
   const loading = document.getElementById('canvas-loading');
   const wrapper = document.getElementById('canvas-wrapper');
 
-  // Load initial example
-  editor.value = EXAMPLES.card;
+  // Load default FD content
+  editor.value = DEFAULT_FD;
 
   try {
     // Load WASM module
@@ -1561,17 +1428,7 @@ async function initPlayground() {
       renderMinimap(canvas);
     });
 
-    // ── Example Selector ──────────────────────────────────────────────
-    document.getElementById('example-select').addEventListener('change', (e) => {
-      const example = EXAMPLES[e.target.value];
-      if (example) {
-        editor.value = example;
-        if (fdCanvas) fdCanvas.set_text(example);
-        // Reset zoom/pan for new example
-        panX = 0; panY = 0; zoomLevel = 1.0;
-        updateZoomIndicator();
-      }
-    });
+
 
     // ── Settings Menu (inside canvas) ──────────────────────────────────
     const settingsBtn = document.getElementById('settings-menu-btn');

--- a/site/style.css
+++ b/site/style.css
@@ -381,24 +381,7 @@ code {
   align-items: center;
   gap: 12px;
 }
-.toolbar-label {
-  color: var(--text-secondary);
-  font-size: 0.9rem;
-  font-weight: 500;
-}
-.toolbar-select {
-  background: var(--bg-card);
-  color: var(--text-primary);
-  border: 1px solid var(--border);
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  font-family: var(--font);
-  font-size: 0.9rem;
-  cursor: pointer;
-  outline: none;
-  transition: border-color var(--transition);
-}
-.toolbar-select:focus { border-color: var(--accent); }
+
 .toolbar-btn {
   background: var(--bg-card);
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Removed multi-example selector from playground. One strong example > three mediocre options competing for attention.

### Changes
- Collapsed `EXAMPLES` object (card, login, welcome) into single `DEFAULT_FD` constant keeping only the card example
- Removed `<select>` dropdown and `<label>` from `index.html`
- Removed `.toolbar-label` and `.toolbar-select` CSS rules from `style.css`
- Removed `example-select` change event listener from `playground.js`

### Result
- ~150 lines removed across 3 files
- Cleaner first impression — no decision paralysis, less toolbar clutter
- Card example showcases 6 core features: style, layout, hover, constraints, comments, nesting