### PR TITLE
feat(site): theme toggle in navbar + canvas toolbar (R3.13)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.92 — Theme Toggle in Navbar + Canvas Toolbar (R3.13)
+
+- **UX (R3.13)**: Discoverable Light/Dark theme toggle — ☀️/🌙 icon button added to navbar (between nav links and Install Extension) and canvas toolbar (after Eraser, separated by divider); removed hidden Dark Mode from ☰ settings menu
+- **UX (R3.13)**: OS preference detection — respects `prefers-color-scheme: dark` on first visit; manual choice persists in `localStorage` (`fd-theme` key); FOUC-preventing `<script>` in `<head>` applies theme before first paint
+- **UX (R3.13)**: Canvas toolbar keyboard shortcut `D` toggles theme — matches tool shortcut pattern (V/R/O/T/A/P/E)
+- **SITE**: Changes in `site/index.html`, `site/style.css`, `site/playground.js`
+
 ### v0.10.91 — Remove Example Selector (R6.8)
 
 - **CLEANUP (R6.8)**: Removed multi-example selector from playground — collapsed 3 example files (`card`, `login`, `welcome`) into a single `DEFAULT_FD` constant keeping only the card example; removed `<select>` dropdown, `<label>`, event listener, and `.toolbar-label`/`.toolbar-select` CSS rules; ~150 lines removed across `playground.js`, `index.html`, `style.css`

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -81,7 +81,7 @@ FD (Fast Draft) is a file format and interactive canvas for drawing, design, and
 #### R3c: Navigation & View
 
 - **R3.6** _(done)_: Pan (Space+drag, middle-click, ⌘-hold), zoom (see R3.20), grid (see R3.21)
-- **R3.13** _(done)_: Light/dark theme toggle — toolbar button, preference persists via VS Code state
+- **R3.13** _(done)_: Light/dark theme toggle — navbar ☀️/🌙 button + canvas toolbar icon + `D` shortcut; `prefers-color-scheme` detection on first visit; `localStorage` persistence; FOUC-preventing head script; VS Code extension auto-detects IDE theme
 - **R3.14** _(done)_: Design | Spec view toggle — segmented control; Spec View shows annotations overlay; spec badge toggle button (◇) for persistent badge visibility in Design mode; context menu shows View Spec / Remove Spec for annotated nodes; badges use faint/active states based on selection
 - **R3.20** _(done)_: Zoom — ⌘+/⌘−, ⌘0 zoom-to-fit, pinch-to-zoom; zoom indicator in toolbar
 - **R3.21** _(done)_: Grid overlay — toggleable dot/line grid with adaptive spacing; keyboard shortcut `G`

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,16 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.89" />
+  <link rel="stylesheet" href="style.css?v=0.10.90" />
+  <!-- FOUC prevention: apply saved theme before first paint -->
+  <script>
+    (function() {
+      var saved = localStorage.getItem('fd-theme');
+      var dark = saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (dark) document.documentElement.classList.add('dark-theme');
+      else document.documentElement.classList.add('light-theme');
+    })();
+  </script>
 </head>
 <body>
   <!-- ─── Navigation ─── -->
@@ -31,6 +40,9 @@
         <a href="#features">Features</a>
         <a href="#benchmarks">Benchmarks</a>
         <a href="#architecture">Architecture</a>
+        <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+          <span class="theme-icon">☀️</span>
+        </button>
         <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install Extension</a>
       </div>
       <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Toggle menu">
@@ -101,7 +113,7 @@
             <div class="settings-dropdown-container" id="settings-dropdown-container">
               <button class="settings-btn" id="settings-menu-btn" title="Settings &amp; tools">☰</button>
               <div class="settings-menu" id="settings-menu">
-                <button class="settings-menu-item" id="sm-dark-toggle" data-setting="dark-mode"><span class="sm-icon">🌙</span><span class="sm-label">Dark Mode</span></button>
+
                 <button class="settings-menu-item" id="sm-sketchy-toggle" data-setting="sketchy"><span class="sm-icon">✏️</span><span class="sm-label">Sketchy</span></button>
                 <button class="settings-menu-item" id="sm-grid-toggle" data-setting="grid"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span></button>
                 <div class="settings-menu-sep"></div>
@@ -156,6 +168,8 @@
                 <button class="ft-tool-btn" data-tool="arrow"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14L14 4"/><path d="M7 4H14V11"/></svg><span class="ft-tooltip">Arrow<span class="tt-shortcut">A</span></span></button>
                 <button class="ft-tool-btn" data-tool="text"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4H14"/><path d="M9 4V15"/><path d="M6 15H12"/></svg><span class="ft-tooltip">Text<span class="tt-shortcut">T</span></span></button>
                 <button class="ft-tool-btn" data-tool="eraser"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 5L8 12L5.5 14.5H2.5V12L9.5 5L12.25 2.25Z"/><path d="M8.5 6L12 9.5"/><line x1="5" y1="15" x2="15" y2="15"/></svg><span class="ft-tooltip">Eraser<span class="tt-shortcut">E</span></span></button>
+                <div class="ft-sep"></div>
+                <button class="ft-tool-btn" id="canvas-theme-btn" title="Toggle theme (D)"><span class="ft-theme-icon">☀️</span><span class="ft-tooltip">Theme<span class="tt-shortcut">D</span></span></button>
               </div>
               <div class="scroll-handle handle-end" title="Drag to move, click to roll">
                 <div class="paper-roll right-roll"></div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -33,7 +33,11 @@ group @card {
 // ─── State ───────────────────────────────────────────────────────────────
 let fdCanvas = null;
 let ctx = null;
-let isDark = true;
+let isDark = (function() {
+  const saved = localStorage.getItem('fd-theme');
+  if (saved) return saved === 'dark';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+})();
 let isSketchy = false;
 let animFrameId = null;
 let suppressSync = false;
@@ -63,6 +67,23 @@ function getLayersPanelWidth() {
 function getPropsPanelWidth() {
   const panel = document.getElementById('props-panel');
   return (panel && panel.classList.contains('visible')) ? panel.offsetWidth : 0;
+}
+
+/** Apply theme globally — single source of truth. */
+function applyTheme(dark) {
+  isDark = dark;
+  // Canvas wrapper
+  document.getElementById('canvas-wrapper')?.classList.toggle('dark-canvas', dark);
+  // WASM renderer
+  if (fdCanvas) fdCanvas.set_theme(dark);
+  // Navbar icon
+  const navIcon = document.querySelector('#theme-toggle .theme-icon');
+  if (navIcon) navIcon.textContent = dark ? '☀️' : '🌙';
+  // Canvas toolbar icon
+  const canvasIcon = document.querySelector('#canvas-theme-btn .ft-theme-icon');
+  if (canvasIcon) canvasIcon.textContent = dark ? '☀️' : '🌙';
+  // Persist
+  localStorage.setItem('fd-theme', dark ? 'dark' : 'light');
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
@@ -1053,10 +1074,21 @@ async function initPlayground() {
     setupPropsPanel(editor);
     setupContextMenu(editor);
 
-    // Set initial dark state on canvas wrapper
-    if (isDark) {
-      wrapper.classList.add('dark-canvas');
-    }
+    // Set initial dark state on canvas wrapper + update icons
+    wrapper.classList.toggle('dark-canvas', isDark);
+    applyTheme(isDark);
+
+    // Navbar theme toggle
+    document.getElementById('theme-toggle')?.addEventListener('click', () => {
+      applyTheme(!isDark);
+      renderCanvas();
+    });
+
+    // Canvas toolbar theme toggle
+    document.getElementById('canvas-theme-btn')?.addEventListener('click', () => {
+      applyTheme(!isDark);
+      renderCanvas();
+    });
 
     // Zen toggle button (inside canvas — stays visible in zen mode)
     const zenBtn = document.getElementById('zen-toggle-btn');
@@ -1322,6 +1354,13 @@ async function initPlayground() {
           e.preventDefault();
           return;
         }
+        // Theme toggle shortcut (D)
+        if (e.key.toLowerCase() === 'd') {
+          applyTheme(!isDark);
+          renderCanvas();
+          e.preventDefault();
+          return;
+        }
       }
 
       // Delete (only when canvas focused)
@@ -1435,7 +1474,6 @@ async function initPlayground() {
     const settingsMenu = document.getElementById('settings-menu');
 
     function updateSettingsToggles() {
-      document.getElementById('sm-dark-toggle')?.classList.toggle('toggle-on', isDark);
       document.getElementById('sm-sketchy-toggle')?.classList.toggle('toggle-on', isSketchy);
       document.getElementById('sm-grid-toggle')?.classList.toggle('toggle-on', gridEnabled);
     }
@@ -1451,11 +1489,6 @@ async function initPlayground() {
         e.stopPropagation();
         const setting = btn.getAttribute('data-setting');
         switch (setting) {
-          case 'dark-mode':
-            isDark = !isDark;
-            if (fdCanvas) fdCanvas.set_theme(isDark);
-            document.getElementById('canvas-wrapper')?.classList.toggle('dark-canvas', isDark);
-            break;
           case 'sketchy':
             isSketchy = !isSketchy;
             if (fdCanvas) fdCanvas.set_sketchy_mode(isSketchy);

--- a/site/style.css
+++ b/site/style.css
@@ -153,6 +153,32 @@ code {
   transition: color var(--transition);
 }
 .nav-links a:hover { color: var(--text-primary); }
+
+/* ─── Navbar Theme Toggle ─── */
+.theme-toggle-btn {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  padding: 0;
+  line-height: 1;
+}
+.theme-toggle-btn:hover {
+  background: var(--bg-card-hover);
+  transform: scale(1.08);
+  border-color: var(--text-muted);
+}
+.theme-toggle-btn:active {
+  transform: scale(0.95);
+}
+
 .btn-nav {
   background: var(--accent) !important;
   color: #fff !important;
@@ -932,6 +958,20 @@ code {
   opacity: 0;
   visibility: hidden;
   transition-delay: 0s;
+}
+
+/* ─── Toolbar Theme Toggle + Separator ─── */
+.ft-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--fd-border);
+  margin: 0 2px;
+  flex-shrink: 0;
+}
+.ft-theme-icon {
+  font-size: 16px;
+  line-height: 1;
+  pointer-events: none;
 }
 
 /* ── (Zoom pill removed — zoom is now in minimap controls) ── */


### PR DESCRIPTION
## Summary

Add discoverable Light/Dark theme toggle to navbar and canvas toolbar. Remove hidden Dark Mode from ☰ settings menu.

## Changes

### Navbar Toggle
- ☀️/🌙 icon button between nav links and Install Extension
- 36×36 circular button with hover scale animation

### Canvas Toolbar Toggle
- ☀️/🌙 icon after Eraser tool, separated by vertical divider
- Keyboard shortcut `D` for quick toggle

### OS Preference + Persistence
- Respects `prefers-color-scheme: dark` on first visit
- Manual choice persists in `localStorage` (`fd-theme` key)
- FOUC-preventing `<script>` in `<head>` applies theme before first paint

### Cleanup
- Removed Dark Mode from ☰ settings menu (redundant)
- Single `applyTheme()` function syncs navbar + canvas + WASM

## Files Changed
- `site/index.html` — navbar button, toolbar icon, FOUC script, settings cleanup
- `site/style.css` — toggle button styles, toolbar separator
- `site/playground.js` — applyTheme(), OS detect, localStorage, D shortcut
- `docs/CHANGELOG.md` — v0.10.92 entry
- `docs/REQUIREMENTS.md` — R3.13 extended