### PR TITLE
fix(site): bump cache-bust versions for JS/CSS

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.90" />
+  <link rel="stylesheet" href="style.css?v=0.10.92" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
@@ -450,7 +450,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.89"></script>
+  <script type="module" src="playground.js?v=0.10.92"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {


### PR DESCRIPTION
Fix stale CDN-cached JS/CSS by bumping query-string cache busters.

The theme toggle (PR #481) was deployed correctly to Cloudflare but wasn't working because `index.html` was still referencing `playground.js?v=0.10.89` and `style.css?v=0.10.90`. CDN served the old cached versions instead of the newly deployed files.

Bumps both to `v=0.10.92` to force cache invalidation.