### PR TITLE
fix(site): FOUC script defaults to light theme + bump CSS cache

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,12 +17,12 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.92" />
+  <link rel="stylesheet" href="style.css?v=0.10.93" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
       var saved = localStorage.getItem('fd-theme');
-      var dark = saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+      var dark = saved ? saved === 'dark' : false; // Default to light (matches extension)
       if (dark) document.documentElement.classList.add('dark-theme');
       else document.documentElement.classList.add('light-theme');
     })();


### PR DESCRIPTION
## Fix

The FOUC-preventing `<script>` in `<head>` was still using `window.matchMedia('(prefers-color-scheme: dark)')` as the fallback when no saved theme preference exists. Since the marketing page has a dark design, this caused the canvas to always default to dark mode, overriding the light default set in PR #482.

### Changes
- `index.html`: FOUC script defaults to `false` (light) instead of `prefers-color-scheme`
- `index.html`: CSS cache-buster bumped from `v=0.10.92` → `v=0.10.93`