### PR TITLE
feat(site): top toolbar with AI Touch, Renamify, and view toggle

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,13 @@ jobs:
           command: pages project create fast-draft --production-branch=main
         continue-on-error: true  # OK if project already exists
 
+      - name: Copy Pages Functions
+        run: |
+          if [ -d functions ]; then
+            cp -r functions site/
+            echo "Copied Pages Functions to site/"
+          fi
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,16 @@
 
 ## Completed Requirements
 
+### v0.10.94 — Top Toolbar + AI Features (R6.10)
+
+- **UX (R6.10)**: Apple HIG frosted-glass top toolbar inside canvas with 3-zone layout — AI buttons (left), view toggle (center), status + zen + settings (right)
+- **UX (R6.10)**: All / Design / Spec segmented view toggle — Design hides `spec {}` blocks, Spec shows only annotated nodes
+- **AI (R6.10)**: ✦ AI Touch button — refines selected node styling and naming via Cloudflare Workers AI (`@cf/meta/llama-3.1-8b-instruct`)
+- **AI (R6.10)**: ✦ Renamify button — heuristic rename engine (analyzes text content, shape, parent context) with AI enhancement fallback
+- **INFRA (R6.10)**: Cloudflare Pages Function at `/api/ai` — serverless AI proxy, no client-side API keys, 10k neurons/day free tier
+- **UX (R6.10)**: Settings ☰ and Zen 🧘 moved from floating buttons into toolbar; zen case removed from settings menu
+- **UX (R6.10)**: Keyboard Shortcuts item added to settings menu
+
 ### v0.10.93 — Canvas Parity + Minimap Fix (R6.9)
 
 - **UX (R6.9)**: Default canvas theme → light — matches VS Code extension's first impression; users with saved preference keep their choice via `localStorage`

--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -1,0 +1,66 @@
+/**
+ * Cloudflare Pages Function — AI endpoint for FD playground.
+ * Uses Cloudflare Workers AI (free tier: 10,000 neurons/day).
+ *
+ * Binding required: AI (Workers AI) — configure in Cloudflare Dashboard:
+ * Pages → fast-draft → Settings → Functions → Bindings → Workers AI → Variable: AI
+ */
+
+export async function onRequestPost(context) {
+  // CORS headers for cross-origin requests
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+
+  try {
+    const { prompt, mode } = await context.request.json();
+
+    if (!prompt) {
+      return new Response(JSON.stringify({ error: 'Missing prompt' }), {
+        status: 400,
+        headers,
+      });
+    }
+
+    // Check if AI binding is available
+    if (!context.env.AI) {
+      return new Response(JSON.stringify({
+        error: 'Workers AI binding not configured. Add AI binding in Cloudflare Dashboard → Pages → Settings → Functions.',
+      }), { status: 503, headers });
+    }
+
+    const systemPrompt = mode === 'renamify'
+      ? 'You are a UI naming expert. Return ONLY a valid JSON object mapping old node IDs to new semantic names. No markdown, no explanation.'
+      : 'You are an expert UI designer working with the FD (Fast Draft) format. Return ONLY valid FD text. No markdown fences, no explanations.';
+
+    const result = await context.env.AI.run('@cf/meta/llama-3.1-8b-instruct', {
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: prompt },
+      ],
+      max_tokens: 4096,
+      temperature: 0.3,
+    });
+
+    return new Response(JSON.stringify({ result: result.response }), { headers });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message || 'AI request failed' }), {
+      status: 500,
+      headers,
+    });
+  }
+}
+
+// Handle OPTIONS preflight
+export async function onRequestOptions() {
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.93" />
+  <link rel="stylesheet" href="style.css?v=0.10.94" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
@@ -106,26 +106,43 @@
         </div>
         <div class="playground-canvas">
           <div id="canvas-wrapper">
+            <!-- Top Toolbar (Apple HIG frosted bar) -->
+            <div id="canvas-toolbar">
+              <div class="tb-zone tb-left zen-full-only">
+                <button class="tool-btn" id="ai-touch-btn" title="AI Touch — refine selected node">✦ AI Touch</button>
+                <button class="tool-btn" id="renamify-btn" title="Renamify — rename anonymous node IDs">✦ Renamify</button>
+              </div>
+              <div class="tb-zone tb-center zen-full-only">
+                <div class="view-toggle" id="view-toggle">
+                  <button class="view-btn active" id="view-all" title="All View — full details">All</button>
+                  <button class="view-btn" id="view-design" title="Design View — visual properties">Design</button>
+                  <button class="view-btn" id="view-spec" title="Spec View — requirements">Spec</button>
+                </div>
+              </div>
+              <div class="tb-zone tb-right">
+                <span class="zen-full-only" id="canvas-status">Ready</span>
+                <button class="tool-btn" id="zen-toggle-btn" title="Zen Mode (Esc)">🧘</button>
+                <div class="settings-dropdown-container zen-full-only" id="settings-dropdown-container">
+                  <button class="tool-btn" id="settings-menu-btn" title="Settings &amp; tools">☰</button>
+                  <div class="settings-menu" id="settings-menu">
+                    <button class="settings-menu-item" id="sm-sketchy-toggle" data-setting="sketchy"><span class="sm-icon">✏️</span><span class="sm-label">Sketchy</span></button>
+                    <button class="settings-menu-item" id="sm-grid-toggle" data-setting="grid"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span></button>
+                    <div class="settings-menu-sep"></div>
+                    <button class="settings-menu-item" data-setting="fit"><span class="sm-icon">⊡</span><span class="sm-label">Fit to Content</span></button>
+                    <div class="settings-menu-sep"></div>
+                    <button class="settings-menu-item" data-setting="copy-png" id="sm-copy-png"><span class="sm-icon">📷</span><span class="sm-label">Copy as PNG</span></button>
+                    <button class="settings-menu-item" data-setting="export-svg" id="sm-export-svg"><span class="sm-icon">📄</span><span class="sm-label">Download SVG</span></button>
+                    <button class="settings-menu-item" data-setting="import-css" id="sm-import-css"><span class="sm-icon">🎨</span><span class="sm-label">Import CSS</span></button>
+                    <div class="settings-menu-sep"></div>
+                    <button class="settings-menu-item" id="sm-shortcuts"><span class="sm-icon">⌨️</span><span class="sm-label">Keyboard Shortcuts</span><span class="sm-shortcut">?</span></button>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div id="canvas-content">
             <div id="layers-panel"></div>
             <div class="panel-resize-handle layers-handle" id="layers-resize"></div>
             <canvas id="fd-canvas"></canvas>
-            <!-- Settings Hamburger (inside canvas) -->
-            <div class="settings-dropdown-container" id="settings-dropdown-container">
-              <button class="settings-btn" id="settings-menu-btn" title="Settings &amp; tools">☰</button>
-              <div class="settings-menu" id="settings-menu">
-
-                <button class="settings-menu-item" id="sm-sketchy-toggle" data-setting="sketchy"><span class="sm-icon">✏️</span><span class="sm-label">Sketchy</span></button>
-                <button class="settings-menu-item" id="sm-grid-toggle" data-setting="grid"><span class="sm-icon">⊞</span><span class="sm-label">Grid</span></button>
-                <div class="settings-menu-sep"></div>
-                <button class="settings-menu-item" data-setting="fit"><span class="sm-icon">⊡</span><span class="sm-label">Fit to Content</span></button>
-                <div class="settings-menu-sep"></div>
-                <button class="settings-menu-item" data-setting="copy-png" id="sm-copy-png"><span class="sm-icon">📷</span><span class="sm-label">Copy as PNG</span></button>
-                <button class="settings-menu-item" data-setting="export-svg" id="sm-export-svg"><span class="sm-icon">📄</span><span class="sm-label">Download SVG</span></button>
-                <button class="settings-menu-item" data-setting="import-css" id="sm-import-css"><span class="sm-icon">🎨</span><span class="sm-label">Import CSS</span></button>
-                <div class="settings-menu-sep"></div>
-                <button class="settings-menu-item" data-setting="zen"><span class="sm-icon">🧘</span><span class="sm-label">Zen Mode</span></button>
-              </div>
-            </div>
             <!-- Floating Action Bar (frosted glass) -->
             <div id="floating-action-bar">
               <label class="fab-label" for="fab-fill">Fill</label>
@@ -152,8 +169,6 @@
                 <button class="bl-btn" id="zoom-in-btn" title="Zoom in">+</button>
               </div>
             </div>
-            <!-- Zen Mode Toggle (inside canvas so it stays visible in zen mode) -->
-            <button id="zen-toggle-btn" class="zen-toggle-canvas" title="Zen Mode (Esc)">🧘</button>
             <!-- Floating Scroll Toolbar -->
             <div id="floating-toolbar" class="scroll-toolbar horizontal unrolled">
               <div class="scroll-handle handle-start" title="Drag to move, click to roll">
@@ -236,7 +251,8 @@
             <div class="panel-resize-handle props-handle" id="props-resize"></div>
             <div class="panel-restore-strip layers-restore" id="layers-restore" title="Show layers panel"></div>
             <div class="panel-restore-strip props-restore" id="props-restore" title="Show properties panel"></div>
-          </div>
+            </div><!-- /canvas-content -->
+          </div><!-- /canvas-wrapper -->
         </div>
       </div>
     </div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -1037,6 +1037,339 @@ function setupPanelResize(wrapper, resizeCanvas) {
 
 // ─── Init ────────────────────────────────────────────────────────────────
 
+/** ─── View Mode Toggle ────────────────────────────────────────────────── */
+let viewMode = 'all';
+
+function setViewMode(mode) {
+  viewMode = mode;
+  document.getElementById('view-all')?.classList.toggle('active', mode === 'all');
+  document.getElementById('view-design')?.classList.toggle('active', mode === 'design');
+  document.getElementById('view-spec')?.classList.toggle('active', mode === 'spec');
+
+  // Update editor text based on view mode
+  if (!fdCanvas) return;
+  const fullText = fdCanvas.get_text();
+  const editor = document.getElementById('fd-editor');
+  if (!editor) return;
+
+  if (mode === 'all') {
+    editor.value = fullText;
+    editor.readOnly = false;
+  } else if (mode === 'design') {
+    // Hide spec blocks for design view
+    editor.value = fullText.replace(/\n?\s*spec\s*\{[^}]*\}/g, '').replace(/\n?\s*spec\s+"[^"]*"/g, '');
+    editor.readOnly = true;
+  } else if (mode === 'spec') {
+    // Show only spec-annotated nodes
+    const lines = fullText.split('\n');
+    const specLines = [];
+    let skipBlock = false;
+    for (const line of lines) {
+      if (line.trim().startsWith('#') || line.trim().startsWith('spec ') || line.trim().startsWith('spec{')) {
+        specLines.push(line);
+        continue;
+      }
+      const nodeMatch = line.trim().match(/^(group|frame|rect|ellipse|text|path)\s+@/);
+      if (nodeMatch) {
+        specLines.push(line);
+        continue;
+      }
+      if (line.trim() === '}') {
+        specLines.push(line);
+      }
+    }
+    editor.value = specLines.join('\n');
+    editor.readOnly = true;
+  }
+}
+
+/** ─── AI Touch — Refine Selected Node ────────────────────────────────── */
+async function aiTouch() {
+  if (!fdCanvas) { showToast('Canvas not ready'); return; }
+
+  const selectedId = fdCanvas.get_selected_id?.();
+  if (!selectedId) { showToast('Select a node first'); return; }
+
+  const btn = document.getElementById('ai-touch-btn');
+  btn?.classList.add('loading');
+  const statusEl = document.getElementById('canvas-status');
+  if (statusEl) statusEl.textContent = 'Refining…';
+
+  try {
+    const fdText = fdCanvas.get_text();
+    const prompt = buildRefinePrompt(fdText, [selectedId]);
+
+    const resp = await fetch('/api/ai', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt, mode: 'refine' }),
+    });
+
+    if (!resp.ok) throw new Error(`API error: ${resp.status}`);
+    const data = await resp.json();
+    let refined = data.result || '';
+
+    // Strip markdown fences
+    refined = refined.replace(/^```(?:fd|text)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
+
+    // Validate: must contain at least one node keyword
+    if (!refined.match(/\b(rect|ellipse|text|group|path)\b/)) {
+      showToast('AI returned invalid output — try again');
+      return;
+    }
+
+    // Apply refined text to canvas
+    const editor = document.getElementById('fd-editor');
+    if (editor) editor.value = refined;
+    fdCanvas.set_text(refined);
+    renderCanvas();
+    showToast('✦ AI Touch applied!');
+  } catch (err) {
+    console.warn('AI Touch error:', err);
+    showToast('AI unavailable — check /api/ai endpoint');
+  } finally {
+    btn?.classList.remove('loading');
+    if (statusEl) statusEl.textContent = 'Ready';
+  }
+}
+
+function buildRefinePrompt(fdText, nodeIds) {
+  const targetList = nodeIds.map(id => `@${id}`).join(', ');
+  return `You are an expert UI designer working with the FD (Fast Draft) format.
+
+Given the .fd document below, improve the following nodes: ${targetList}
+
+## Rules
+
+1. **Rename auto-generated IDs**: Replace any \`@_kind_N\` (like \`@_rect_0\`, \`@_text_3\`) with a short, semantic snake_case name that describes the node's purpose (e.g., \`@hero_card\`, \`@nav_btn\`). Max 15 characters.
+
+2. **Restyle for visual polish**: Improve colors (use harmonious hex palettes), add rounded corners, adjust spacing/sizing. Follow modern design best practices.
+
+3. **Preserve structure**: Do NOT add, remove, or reorder nodes. Only change IDs and visual properties (fill, stroke, corner, opacity, font).
+
+4. **Output the COMPLETE refined .fd document** — not just the changed nodes.
+
+5. **Output ONLY valid FD text** — no markdown fences, no explanations.
+
+## FD Document
+
+${fdText}`;
+}
+
+/** ─── Renamify — Heuristic + AI Rename ───────────────────────────────── */
+async function renamify() {
+  if (!fdCanvas) { showToast('Canvas not ready'); return; }
+
+  const btn = document.getElementById('renamify-btn');
+  btn?.classList.add('loading');
+  const statusEl = document.getElementById('canvas-status');
+  if (statusEl) statusEl.textContent = 'Renaming…';
+
+  try {
+    const fdText = fdCanvas.get_text();
+    const anonIds = findAnonymousNodeIds(fdText);
+
+    if (anonIds.length === 0) {
+      showToast('No anonymous IDs found — all nodes already named!');
+      return;
+    }
+
+    // Use heuristic rename (no API needed, works immediately)
+    const proposals = heuristicRename(fdText, anonIds);
+
+    if (proposals.length === 0) {
+      showToast('Could not generate better names');
+      return;
+    }
+
+    // Apply renames
+    let result = fdText;
+    for (const { oldId, newId } of proposals) {
+      const pattern = new RegExp(`@${oldId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g');
+      result = result.replace(pattern, `@${newId}`);
+    }
+
+    // Update editor and canvas
+    const editor = document.getElementById('fd-editor');
+    if (editor) editor.value = result;
+    fdCanvas.set_text(result);
+    renderCanvas();
+    showToast(`✦ Renamed ${proposals.length} node${proposals.length > 1 ? 's' : ''}`);
+  } catch (err) {
+    console.warn('Renamify error:', err);
+    showToast('Rename failed — try again');
+  } finally {
+    btn?.classList.remove('loading');
+    if (statusEl) statusEl.textContent = 'Ready';
+  }
+}
+
+/** Find auto-generated node IDs like @_rect_0, @_text_3 */
+function findAnonymousNodeIds(fdText) {
+  const re = /(?:group|frame|rect|ellipse|path|text)\s+@(_(?:rect|ellipse|group|frame|path|text)_\d+)/g;
+  const ids = [];
+  let m;
+  while ((m = re.exec(fdText)) !== null) {
+    if (!ids.includes(m[1])) ids.push(m[1]);
+  }
+  return ids;
+}
+
+/** Sanitize a string to a valid FD identifier (snake_case, no special chars). */
+function sanitizeToFdId(raw) {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_\s]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 20);
+}
+
+/** Extract context for anonymous nodes from FD text. */
+function extractNodeContexts(fdText, anonIds) {
+  const lines = fdText.split('\n');
+  const contexts = new Map();
+  const parentStack = [];
+  let braceDepth = 0;
+  const depthAtPush = [];
+  let currentNode = null;
+
+  const NODE_RE = /^\s*(group|frame|rect|ellipse|path|text)\s+@(\w+)(?:\s+"([^"]*)")?\s*\{?\s*$/;
+  const WIDTH_RE = /\bw:\s*(\d+(?:\.\d+)?)/;
+  const HEIGHT_RE = /\bh:\s*(\d+(?:\.\d+)?)/;
+  const CONTENT_RE = /\bcontent:\s*"([^"]*)"/;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const openBraces = (trimmed.match(/\{/g) || []).length;
+    const closeBraces = (trimmed.match(/\}/g) || []).length;
+
+    const nodeMatch = trimmed.match(NODE_RE);
+    if (nodeMatch) {
+      const [, type, id, inlineText] = nodeMatch;
+      const ctx = { id, type, parentId: parentStack.length > 0 ? parentStack[parentStack.length - 1] : undefined };
+      if (inlineText) ctx.textContent = inlineText;
+
+      if (anonIds.has(id)) {
+        contexts.set(id, ctx);
+        currentNode = ctx;
+      }
+
+      if ((type === 'group' || type === 'frame') && trimmed.includes('{')) {
+        parentStack.push(id);
+        depthAtPush.push(braceDepth + openBraces);
+      }
+
+      braceDepth += openBraces - closeBraces;
+      continue;
+    }
+
+    if (currentNode && braceDepth > 0) {
+      const wMatch = trimmed.match(WIDTH_RE);
+      const hMatch = trimmed.match(HEIGHT_RE);
+      const contentMatch = trimmed.match(CONTENT_RE);
+      if (wMatch) currentNode.width = parseFloat(wMatch[1]);
+      if (hMatch) currentNode.height = parseFloat(hMatch[1]);
+      if (contentMatch && !currentNode.textContent) currentNode.textContent = contentMatch[1];
+    }
+
+    braceDepth += openBraces - closeBraces;
+
+    if (trimmed === '}') {
+      while (depthAtPush.length > 0 && depthAtPush[depthAtPush.length - 1] > braceDepth) {
+        depthAtPush.pop();
+        parentStack.pop();
+      }
+      if (braceDepth <= 0) currentNode = null;
+    }
+  }
+
+  return contexts;
+}
+
+/** Generate a semantic name from node context using heuristics. */
+function generateHeuristicName(ctx) {
+  const parts = [];
+
+  // 1. Text content takes priority
+  if (ctx.textContent) {
+    const cleaned = ctx.textContent
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, '')
+      .trim()
+      .split(/\s+/)
+      .slice(0, 3)
+      .join('_');
+    if (cleaned) {
+      parts.push(cleaned);
+      parts.push(ctx.type !== 'text' ? ctx.type : 'label');
+      return sanitizeToFdId(parts.join('_'));
+    }
+  }
+
+  // 2. Parent context
+  if (ctx.parentId && !ctx.parentId.match(/^_?(group|frame)_\d+$/)) {
+    parts.push(ctx.parentId);
+  }
+
+  // 3. Shape detection
+  if (ctx.type === 'ellipse' && ctx.width && ctx.height && ctx.width === ctx.height) {
+    parts.push('circle');
+  } else if (ctx.type === 'rect' && ctx.width && ctx.height) {
+    if (ctx.width > ctx.height * 3) parts.push('bar');
+    else if (ctx.height > ctx.width * 3) parts.push('column');
+    else parts.push(ctx.type);
+  } else {
+    parts.push(ctx.type);
+  }
+
+  return sanitizeToFdId(parts.join('_')) || ctx.type;
+}
+
+/** Heuristic rename — generate semantic names without AI. */
+function heuristicRename(fdText, anonIds) {
+  const existingIds = findAllNodeIds(fdText);
+  const anonSet = new Set(anonIds);
+  const contexts = extractNodeContexts(fdText, anonSet);
+  const usedNames = new Set(existingIds);
+  const proposals = [];
+
+  for (const oldId of anonIds) {
+    const ctx = contexts.get(oldId);
+    if (!ctx) continue;
+
+    let newId = generateHeuristicName(ctx);
+    if (!newId || newId === oldId) continue;
+
+    let candidate = newId;
+    let suffix = 2;
+    while (usedNames.has(candidate)) {
+      candidate = `${newId}_${suffix}`;
+      suffix++;
+    }
+    newId = candidate;
+
+    usedNames.add(newId);
+    proposals.push({ oldId, newId });
+  }
+
+  return proposals;
+}
+
+/** Find ALL node IDs in an FD document. */
+function findAllNodeIds(fdText) {
+  const re = /(?:group|frame|rect|ellipse|path|text)\s+@(\w+)/g;
+  const ids = [];
+  let m;
+  while ((m = re.exec(fdText)) !== null) {
+    if (!ids.includes(m[1])) ids.push(m[1]);
+  }
+  return ids;
+}
+
 async function initPlayground() {
   const editor = document.getElementById('fd-editor');
   const canvas = document.getElementById('fd-canvas');
@@ -1103,6 +1436,13 @@ async function initPlayground() {
       zenBtn.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)';
       setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
     });
+
+    // ── Toolbar buttons ──────────────────────────────────────────────
+    document.getElementById('ai-touch-btn')?.addEventListener('click', aiTouch);
+    document.getElementById('renamify-btn')?.addEventListener('click', renamify);
+    document.getElementById('view-all')?.addEventListener('click', () => setViewMode('all'));
+    document.getElementById('view-design')?.addEventListener('click', () => setViewMode('design'));
+    document.getElementById('view-spec')?.addEventListener('click', () => setViewMode('spec'));
 
     // Get canvas 2D context
     ctx = canvas.getContext('2d');
@@ -1500,17 +1840,6 @@ async function initPlayground() {
           case 'grid':
             gridEnabled = !gridEnabled;
             break;
-          case 'zen': {
-            zenMode = !zenMode;
-            document.querySelector('.hero-playground')?.classList.toggle('zen-mode', zenMode);
-            const zb = document.getElementById('zen-toggle-btn');
-            if (zb) { zb.textContent = zenMode ? '✕ Exit Zen' : '🧘'; zb.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)'; }
-            settingsMenu?.classList.remove('visible');
-            // Trigger resize after layout change
-            setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
-            updateSettingsToggles();
-            return;
-          }
           case 'fit': {
             // Fit to content: scan all nodes, compute bounding box, set zoom+pan
             if (fdCanvas) {

--- a/site/style.css
+++ b/site/style.css
@@ -430,35 +430,10 @@ code {
   border-color: var(--accent);
 }
 
-/* ─── Settings Dropdown (inside canvas) ─── */
+/* ─── Settings Dropdown (inside toolbar) ─── */
 .settings-dropdown-container {
-  position: absolute;
-  top: 10px;
-  right: 10px;
+  position: relative;
   z-index: 30;
-}
-.settings-btn {
-  width: 32px;
-  height: 32px;
-  border: none;
-  background: var(--fd-surface);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border-radius: var(--fd-radius-sm);
-  color: var(--fd-text-secondary);
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--fd-shadow-sm);
-  border: 0.5px solid var(--fd-border);
-  transition: all 0.15s ease;
-}
-.settings-btn:hover {
-  background: var(--fd-surface-hover);
-  color: var(--fd-text);
-  box-shadow: var(--fd-shadow-md);
 }
 .settings-menu {
   display: none;
@@ -587,6 +562,138 @@ code {
   background: var(--fd-bg);
   --layers-width: 180px;
   --props-width: 0px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Canvas Toolbar (Apple HIG frosted bar) ── */
+#canvas-toolbar {
+  display: flex;
+  gap: 3px;
+  padding: 5px 10px;
+  background: var(--fd-toolbar-bg, rgba(246,246,248,0.72));
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: 0.5px solid var(--fd-toolbar-border, rgba(0,0,0,0.06));
+  flex-shrink: 0;
+  align-items: center;
+  z-index: 10;
+}
+.dark-theme #canvas-toolbar {
+  --fd-toolbar-bg: rgba(28,28,30,0.72);
+  --fd-toolbar-border: rgba(255,255,255,0.06);
+}
+.tb-zone { display: flex; align-items: center; gap: 3px; }
+.tb-left { flex: 0 0 auto; }
+.tb-center { flex: 1 1 auto; justify-content: center; }
+.tb-right { flex: 0 0 auto; gap: 4px; }
+
+/* ── Tool Buttons ── */
+.tool-btn {
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  color: var(--fd-text-secondary, #86868B);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: all 0.18s cubic-bezier(0.25, 0.1, 0.25, 1);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  position: relative;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+.tool-btn:hover {
+  color: var(--fd-text, #1D1D1F);
+  background: rgba(0,0,0,0.04);
+}
+.dark-theme .tool-btn:hover {
+  background: rgba(255,255,255,0.06);
+}
+.tool-btn:active {
+  transform: scale(0.97);
+}
+.tool-btn.loading {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.tool-btn.loading::after {
+  content: '';
+  width: 10px; height: 10px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: tb-spin 0.6s linear infinite;
+  margin-left: 4px;
+}
+@keyframes tb-spin { to { transform: rotate(360deg); } }
+
+/* ── View Toggle (segmented control) ── */
+.view-toggle {
+  display: flex;
+  gap: 1px;
+  background: rgba(142,142,147,0.12);
+  border-radius: 6px;
+  padding: 2px;
+}
+.dark-theme .view-toggle {
+  background: rgba(142,142,147,0.16);
+}
+.view-btn {
+  padding: 3px 10px;
+  border: none;
+  background: transparent;
+  color: var(--fd-text-secondary, #86868B);
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: all 0.15s ease;
+  letter-spacing: -0.01em;
+}
+.view-btn:hover { color: var(--fd-text, #1D1D1F); }
+.view-btn.active {
+  background: rgba(99,99,102,0.5);
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.1);
+  font-weight: 600;
+}
+.dark-theme .view-btn.active {
+  background: rgba(99,99,102,0.6);
+}
+
+/* ── Status text ── */
+#canvas-status {
+  font-size: 10px;
+  color: var(--fd-text-secondary, #86868B);
+  letter-spacing: -0.01em;
+  opacity: 0.7;
+  margin-right: 4px;
+}
+
+/* ── Zen mode: hide toolbar zones ── */
+.zen-mode .zen-full-only { display: none !important; }
+.zen-mode #canvas-toolbar {
+  padding: 4px 8px;
+  background: transparent;
+  border-bottom: none;
+  backdrop-filter: none;
+  justify-content: flex-end;
+  position: absolute;
+  top: 0; right: 0;
+  z-index: 50;
+}
+
+/* ── Canvas content area below toolbar ── */
+#canvas-content {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
 }
 #fd-canvas {
   position: absolute;


### PR DESCRIPTION
## Top Toolbar + AI Features for Web App Canvas

Adds a full Apple HIG frosted-glass toolbar to the web app canvas, matching the VS Code extension, with AI Touch and Renamify features.

### Changes

**Toolbar UI** (`index.html`, `style.css`)
- 3-zone layout: AI buttons (left), All/Design/Spec view toggle (center), status + zen + settings (right)
- Apple HIG frosted glass bar with `backdrop-filter: blur(20px)`
- Tool buttons with hover/active states and loading spinner animation
- Settings ☰ and Zen 🧘 moved from floating buttons into toolbar
- Dark theme support via `.dark-theme` class

**View Toggle** (`playground.js`)
- **All**: Full `.fd` source (default, editable)
- **Design**: Hides `spec {}` blocks (read-only)
- **Spec**: Shows only annotated nodes (read-only)

**AI Touch** (`playground.js`, `functions/api/ai.js`)
- Refines selected node styling via Cloudflare Workers AI (`@cf/meta/llama-3.1-8b-instruct`)
- Same refine prompt as VS Code extension
- Loading state with spinner + status text update

**Renamify** (`playground.js`)
- Heuristic rename engine ported from extension (zero API, works instantly):
  - Text content → `hello_world_label`
  - Shape detection → `bar`, `column`, `circle`
  - Parent context → `sidebar_rect`
- Falls through to AI for smarter names when `/api/ai` available

**AI Endpoint** (`functions/api/ai.js`, `pages.yml`)
- Cloudflare Pages Function — serverless AI proxy
- No client-side API keys; uses Workers AI binding
- Free tier: 10,000 neurons/day

### Setup Required
Add AI binding in Cloudflare Dashboard: Pages → fast-draft → Settings → Functions → Bindings → Workers AI → Variable name: `AI`