### PR TITLE
feat(site): compact hero section — inline stats, remove badge, tighten spacing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.95 — Hero Section Compaction (R6.5)
+
+- **UX (R6.5)**: Compacted hero section to push the live playground above the fold — removed "Open Source · MIT License" badge (already in footer), inlined 3 stats (5× / 6.5× / 370) as a single compact text row below CTAs, removed "▶ Live Playground" toolbar label; tightened `#hero` padding (80→64px top, 48→32px bottom), `hero-content` margin (40→16px), CTA margin (32→16px); ~200px vertical savings
+- **CLEANUP**: Removed dead CSS for `.hero-badge`, `.playground-label`, old `.hero-stats`/`.stat-value`/`.stat-label`/`.stat-divider` rules; cleaned stale mobile responsive overrides
+- **SITE**: Changes in `site/index.html`, `site/style.css`
+
 ### v0.10.94 — Top Toolbar + AI Features (R6.10)
 
 - **UX (R6.10)**: Apple HIG frosted-glass top toolbar inside canvas with 3-zone layout — AI buttons (left), view toggle (center), status + zen + settings (right)

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.94" />
+  <link rel="stylesheet" href="style.css?v=0.10.95" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
@@ -58,7 +58,6 @@
       <div class="hero-grid"></div>
     </div>
     <div class="hero-content">
-      <div class="hero-badge">Open Source · MIT License</div>
       <h1>Design as <span class="gradient-text">Code</span></h1>
       <p class="hero-sub">A file format and canvas for drawing, design, and animation — right inside your code editor. Draw it or code it? <strong>Both.</strong></p>
       <div class="hero-cta">
@@ -69,33 +68,18 @@
           <span class="btn-icon">★</span> View on GitHub
         </a>
       </div>
-      <div class="hero-stats">
-        <div class="stat">
-          <span class="stat-value">5×</span>
-          <span class="stat-label">fewer tokens than SVG</span>
-        </div>
-        <div class="stat-divider"></div>
-        <div class="stat">
-          <span class="stat-value">6.5×</span>
-          <span class="stat-label">smaller than Excalidraw</span>
-        </div>
-        <div class="stat-divider"></div>
-        <div class="stat">
-          <span class="stat-value">370</span>
-          <span class="stat-label">tests passing</span>
-        </div>
+      <div class="hero-stats-inline">
+        <span class="stat-chip"><strong>5×</strong> fewer tokens than SVG</span>
+        <span class="stat-dot">·</span>
+        <span class="stat-chip"><strong>6.5×</strong> smaller than Excalidraw</span>
+        <span class="stat-dot">·</span>
+        <span class="stat-chip"><strong>370</strong> tests passing</span>
       </div>
     </div>
 
     <!-- ─── Playground Embedded in Hero ─── -->
     <div class="hero-playground">
-      <div class="playground-toolbar">
-        <div class="toolbar-left">
-          <span class="playground-label">▶ Live Playground</span>
 
-        </div>
-        <div class="toolbar-right"></div>
-      </div>
       <input type="file" id="css-file-input" accept=".css" style="display:none">
       <div id="playground-container" class="playground-split">
         <div class="playground-editor">

--- a/site/style.css
+++ b/site/style.css
@@ -218,7 +218,7 @@ code {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 80px 24px 48px;
+  padding: 64px 24px 32px;
   overflow: hidden;
 }
 .hero-bg {
@@ -249,20 +249,9 @@ code {
   z-index: 1;
   text-align: center;
   max-width: 800px;
-  margin-bottom: 40px;
+  margin-bottom: 16px;
 }
-.hero-badge {
-  display: inline-block;
-  padding: 6px 16px;
-  border-radius: 100px;
-  border: 1px solid var(--border);
-  background: rgba(108, 92, 231, 0.1);
-  color: var(--text-secondary);
-  font-size: 0.85rem;
-  font-weight: 500;
-  margin-bottom: 20px;
-  letter-spacing: 0.02em;
-}
+
 #hero h1 {
   font-size: clamp(2.2rem, 5vw, 3.8rem);
   font-weight: 800;
@@ -288,7 +277,7 @@ code {
   gap: 16px;
   justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: 32px;
+  margin-bottom: 16px;
 }
 .btn {
   display: inline-flex;
@@ -326,31 +315,26 @@ code {
   transform: translateY(-2px);
 }
 .btn-icon { font-size: 0.9em; }
-.hero-stats {
+/* ── Hero Stats (inline) ── */
+.hero-stats-inline {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 32px;
+  gap: 8px;
   flex-wrap: wrap;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
-.stat { text-align: center; }
-.stat-value {
-  display: block;
-  font-size: 1.8rem;
-  font-weight: 800;
+.hero-stats-inline strong {
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+  font-weight: 800;
 }
-.stat-label {
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-}
-.stat-divider {
-  width: 1px;
-  height: 40px;
-  background: var(--border);
+.stat-dot {
+  color: var(--text-muted);
+  font-size: 0.7rem;
 }
 
 /* ─── Hero Playground ─── */
@@ -361,12 +345,7 @@ code {
   max-width: var(--max-width);
   margin-top: 8px;
 }
-.playground-label {
-  color: var(--accent);
-  font-weight: 700;
-  font-size: 0.9rem;
-  letter-spacing: 0.02em;
-}
+
 
 /* ─── Sections ─── */
 .section { padding: 100px 24px; }
@@ -1910,17 +1889,12 @@ code {
   .playground-editor { min-height: 280px; }
   .playground-canvas { min-height: 320px; }
 
-  .hero-stats { gap: 16px; }
-  .stat-divider { display: none; }
-
   .features-grid { grid-template-columns: 1fr; }
   .modes-grid { grid-template-columns: 1fr; }
   .crate-grid { grid-template-columns: 1fr 1fr; }
 
   #hero h1 { font-size: 2rem; }
   .hero-sub { font-size: 1rem; }
-
-  .playground-label { display: none; }
 
   #layers-panel, #props-panel { display: none !important; }
   #floating-toolbar { left: 8px; }


### PR DESCRIPTION
## Summary\n\nCompacts the hero section to push the live playground significantly above the fold (~200px vertical savings).\n\n### Changes\n- **Removed** \"Open Source · MIT License\" badge (already visible in footer)\n- **Inlined** 3 hero stats (5×/6.5×/370) as compact text row below CTAs instead of separate large block\n- **Removed** \"▶ Live Playground\" toolbar label (playground is self-evident)\n- **Tightened** padding & margins: hero top 80→64px, bottom 48→32px, hero-content margin 40→16px, CTA margin 32→16px\n- **Cleaned up** dead CSS: `.hero-badge`, `.playground-label`, old `.hero-stats`/`.stat-value`/`.stat-label`/`.stat-divider`\n\n### Impact\n- On 13-14\" laptop: playground now ~200px more visible above the fold\n- Zero Rust changes — site-only (HTML + CSS)\n- Bump CSS cache to `v=0.10.95`