### PR TITLE
feat(site): taller playground (80vh) + draggable split resize handle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.96 — Taller Playground + Resizable Split (R6.6)
+
+- **UX (R6.6)**: Playground min-height bumped from `70vh` to `80vh` — ~100px more workspace on typical laptop screens
+- **UX (R6.6)**: Draggable split resize handle between Code Mode and Canvas — drag to adjust editor/canvas ratio (25–75% range); double-click to reset to 50/50; ratio persists in `localStorage`; handle highlights with accent on hover/drag; hidden in zen mode and mobile breakpoint
+- **SITE**: Changes in `site/index.html`, `site/style.css`, `site/playground.js`
+
 ### v0.10.95 — Hero Section Compaction (R6.5)
 
 - **UX (R6.5)**: Compacted hero section to push the live playground above the fold — removed "Open Source · MIT License" badge (already in footer), inlined 3 stats (5× / 6.5× / 370) as a single compact text row below CTAs, removed "▶ Live Playground" toolbar label; tightened `#hero` padding (80→64px top, 48→32px bottom), `hero-content` margin (40→16px), CTA margin (32→16px); ~200px vertical savings

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.95" />
+  <link rel="stylesheet" href="style.css?v=0.10.96" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
@@ -88,6 +88,7 @@
           </div>
           <textarea id="fd-editor" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
         </div>
+        <div class="split-resize-handle" id="split-resize"></div>
         <div class="playground-canvas">
           <div id="canvas-wrapper">
             <!-- Top Toolbar (Apple HIG frosted bar) -->
@@ -450,7 +451,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.92"></script>
+  <script type="module" src="playground.js?v=0.10.96"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -862,6 +862,66 @@ function renderMinimap(canvas) {
   mc._minimap = { sx, sy, sw: sceneW, sh: sceneH, scale, ox, oy };
 }
 
+// ─── Split Resize (code ↔ canvas) ────────────────────────────────────────
+
+/** Set up drag-to-resize for the code/canvas split. */
+function setupSplitResize(container, resizeCanvas) {
+  const handle = document.getElementById('split-resize');
+  if (!handle || !container) return;
+
+  const MIN_FRAC = 0.25; // editor min 25%
+  const MAX_FRAC = 0.75; // editor max 75%
+
+  // Restore persisted fraction
+  const savedFrac = parseFloat(localStorage.getItem('fd-split-fraction'));
+  if (savedFrac >= MIN_FRAC && savedFrac <= MAX_FRAC) {
+    container.style.setProperty('--editor-width', `${savedFrac}fr`);
+  }
+
+  let dragging = false;
+  let containerRect = null;
+
+  handle.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragging = true;
+    containerRect = container.getBoundingClientRect();
+    handle.classList.add('active');
+    handle.setPointerCapture(e.pointerId);
+  });
+
+  handle.addEventListener('pointermove', (e) => {
+    if (!dragging || !containerRect) return;
+    const x = e.clientX - containerRect.left;
+    let frac = x / containerRect.width;
+    frac = Math.max(MIN_FRAC, Math.min(MAX_FRAC, frac));
+    container.style.setProperty('--editor-width', `${frac}fr`);
+    resizeCanvas();
+    renderCanvas();
+  });
+
+  const endDrag = () => {
+    if (!dragging) return;
+    dragging = false;
+    handle.classList.remove('active');
+    // Persist fraction
+    const style = container.style.getPropertyValue('--editor-width');
+    const frac = parseFloat(style);
+    if (!isNaN(frac)) localStorage.setItem('fd-split-fraction', String(frac));
+  };
+  handle.addEventListener('pointerup', endDrag);
+  handle.addEventListener('pointercancel', endDrag);
+
+  // Double-click to reset to 50/50
+  handle.addEventListener('dblclick', (e) => {
+    e.preventDefault();
+    container.style.setProperty('--editor-width', '1fr');
+    localStorage.removeItem('fd-split-fraction');
+    resizeCanvas();
+    renderCanvas();
+  });
+}
+
 // ─── Panel Resize ────────────────────────────────────────────────────────
 
 /** Set up drag-to-resize for layers and properties panels. */
@@ -1603,6 +1663,7 @@ async function initPlayground() {
 
     // ── Panel Resize Setup ───────────────────────────────────────────
     setupPanelResize(wrapper, resizeCanvas);
+    setupSplitResize(document.getElementById('playground-container'), resizeCanvas);
 
     // ── Text Editor → Canvas ──────────────────────────────────────────
     editor.addEventListener('input', () => {

--- a/site/style.css
+++ b/site/style.css
@@ -489,14 +489,27 @@ code {
 
 .playground-split {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 2px;
+  grid-template-columns: var(--editor-width, 1fr) auto 1fr;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   overflow: hidden;
   background: var(--border);
   box-shadow: var(--shadow), var(--shadow-glow);
-  min-height: 70vh;
+  min-height: 80vh;
+}
+
+/* ── Split Resize Handle ── */
+.split-resize-handle {
+  width: 6px;
+  cursor: col-resize;
+  background: var(--border);
+  position: relative;
+  z-index: 2;
+  transition: background 0.15s;
+}
+.split-resize-handle:hover,
+.split-resize-handle.active {
+  background: var(--accent);
 }
 .playground-editor, .playground-canvas {
   background: var(--bg-card);
@@ -1857,6 +1870,7 @@ code {
 .zen-mode .settings-dropdown-container { display: none !important; }
 .zen-mode .playground-editor { display: none !important; }
 .zen-mode .playground-split { grid-template-columns: 1fr; }
+.zen-mode .split-resize-handle { display: none; }
 .zen-mode .playground-canvas { min-height: 500px; }
 .zen-mode #floating-toolbar { display: none !important; }
 .zen-mode #minimap-container { display: none !important; }
@@ -1886,6 +1900,7 @@ code {
     grid-template-columns: 1fr;
     min-height: auto;
   }
+  .split-resize-handle { display: none; }
   .playground-editor { min-height: 280px; }
   .playground-canvas { min-height: 320px; }
 


### PR DESCRIPTION
## Summary\n\nMakes the playground bigger and lets users resize the code/canvas split.\n\n### Changes\n- **80vh** playground min-height (was 70vh) — ~100px more workspace\n- **Draggable split handle** between Code Mode and Canvas — drag to adjust ratio (25–75%), double-click resets to 50/50, persists in localStorage\n- **Responsive:** handle hidden in zen mode and mobile breakpoint\n- Cache versions bumped to `v=0.10.96`\n\n### Impact\n- Zero Rust changes — site-only (HTML + CSS + JS)\n- No breaking changes