### PR TITLE
feat(site): default split 40/60, playground height 75vh

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.96" />
+  <link rel="stylesheet" href="style.css?v=0.10.99" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {

--- a/site/style.css
+++ b/site/style.css
@@ -489,13 +489,13 @@ code {
 
 .playground-split {
   display: grid;
-  grid-template-columns: var(--editor-width, 1fr) auto 1fr;
+  grid-template-columns: var(--editor-width, 2fr) auto 3fr;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   overflow: hidden;
   background: var(--border);
   box-shadow: var(--shadow), var(--shadow-glow);
-  min-height: 80vh;
+  min-height: 75vh;
 }
 
 /* ── Split Resize Handle ── */


### PR DESCRIPTION
## Changes\n\n- Default split ratio changed from 50/50 to **40/60** (editor 40%, canvas 60%) — gives the canvas more room\n- Playground height reduced from **80vh to 75vh** — better balance with page content\n\nCSS-only change: `grid-template-columns: 2fr auto 3fr` + `min-height: 75vh`