### PR TITLE
fix(site): align Code and Design header bars — match padding

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.100" />
+  <link rel="stylesheet" href="style.css?v=0.10.101" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {

--- a/site/style.css
+++ b/site/style.css
@@ -573,7 +573,7 @@ code {
 #canvas-toolbar {
   display: flex;
   gap: 3px;
-  padding: 5px 10px;
+  padding: 10px 16px;
   background: var(--fd-toolbar-bg, rgba(246,246,248,0.72));
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);


### PR DESCRIPTION
## Fix\n\nAligns Code and Design header bars by matching canvas toolbar padding (`5px 10px` → `10px 16px`) to editor header padding.\n\n1-line CSS change.