### PR TITLE
fix(site): force exact 42px height on both Code and Design bars

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.101" />
+  <link rel="stylesheet" href="style.css?v=0.10.102" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {

--- a/site/style.css
+++ b/site/style.css
@@ -521,6 +521,8 @@ code {
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
+  height: 42px;
+  box-sizing: border-box;
   border-bottom: 1px solid var(--border);
   font-size: 0.8rem;
   font-weight: 600;
@@ -574,6 +576,8 @@ code {
   display: flex;
   gap: 3px;
   padding: 10px 16px;
+  height: 42px;
+  box-sizing: border-box;
   background: var(--fd-toolbar-bg, rgba(246,246,248,0.72));
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);


### PR DESCRIPTION
## Fix\n\nForces both Code and Design header bars to exactly `42px` height with `box-sizing: border-box`. Previous fix matched padding but buttons in the toolbar still made it 3px taller. Now both bars are pixel-identical.