### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in webview-html renderProposals

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-01 - DOM Injection in Webview from Untrusted Files
+**Vulnerability:** Untrusted string data (`oldId`, `newId` from parsed `.fd` files) was injected directly into the DOM using `row.innerHTML` in the renamify webview panel, creating an XSS vulnerability.
+**Learning:** Even internal VSCode webviews are susceptible to XSS if they render user-controlled configuration files without proper escaping. Using `.innerHTML` to construct UI elements dynamically from file data is a common pitfall.
+**Prevention:** Avoid `.innerHTML` entirely when handling data parsed from files. Instead, use safe DOM APIs like `document.createElement`, `textContent`, and `appendChild` to construct UI trees, guaranteeing that untrusted data is treated strictly as text.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2884,11 +2884,28 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         items.forEach((p, i) => {
           const row = document.createElement('div');
           row.className = 'renamify-row';
-          row.innerHTML =
-            '<input type="checkbox" checked data-idx="' + i + '">' +
-            '<span class="renamify-old">@' + p.oldId + '</span>' +
-            '<span class="renamify-arrow">→</span>' +
-            '<span class="renamify-new">@' + p.newId + '</span>';
+
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.checked = true;
+          checkbox.dataset.idx = String(i);
+          row.appendChild(checkbox);
+
+          const oldSpan = document.createElement('span');
+          oldSpan.className = 'renamify-old';
+          oldSpan.textContent = '@' + p.oldId;
+          row.appendChild(oldSpan);
+
+          const arrowSpan = document.createElement('span');
+          arrowSpan.className = 'renamify-arrow';
+          arrowSpan.textContent = '→';
+          row.appendChild(arrowSpan);
+
+          const newSpan = document.createElement('span');
+          newSpan.className = 'renamify-new';
+          newSpan.textContent = '@' + p.newId;
+          row.appendChild(newSpan);
+
           body.appendChild(row);
         });
         footer.style.display = 'flex';


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** DOM-based Cross-Site Scripting (XSS). The `fd-vscode/src/webview-html.ts` file rendered unescaped `oldId` and `newId` string data (derived directly from parsed `.fd` files) via `row.innerHTML`. A malicious `.fd` file could execute arbitrary HTML/JavaScript within the VSCode Webview context.
🎯 **Impact:** High. Attackers could theoretically craft an `.fd` file that, when opened and a rename action proposed, executes arbitrary scripts leading to further context escape or credential harvesting within the user's IDE.
🔧 **Fix:** Replaced `.innerHTML` string concatenation in `renderProposals` with safe DOM APIs (`document.createElement`, `textContent`, `appendChild`). This ensures all injected data is safely rendered as explicit text nodes.
✅ **Verification:** Verified that malicious payloads (e.g., `<img src=x onerror=alert(1)>`) render cleanly as plain text without triggering execution in a simulated webview context using Playwright. Automated `pnpm lint` and tests successfully pass. Recorded findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10357068484234610317](https://jules.google.com/task/10357068484234610317) started by @khangnghiem*