### PR TITLE
fix(wasm): use performance.now() for hover_start_ms instead of Date.now()

### DIFF
--- a/crates/fd-wasm/Cargo.toml
+++ b/crates/fd-wasm/Cargo.toml
@@ -22,6 +22,8 @@ web-sys = { workspace = true, features = [
     "CanvasGradient",
     "HtmlCanvasElement",
     "TextMetrics",
+    "Performance",
+    "Window",
     "console",
 ] }
 js-sys = { workspace = true }

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -395,7 +395,10 @@ impl FdCanvas {
         self.hovered_id = hit;
         let hovered_changed = prev_hovered != self.hovered_id;
         if hovered_changed && self.hovered_id.is_some() {
-            self.hover_start_ms = js_sys::Date::now();
+            self.hover_start_ms = web_sys::window()
+                .and_then(|w| w.performance())
+                .map(|p| p.now())
+                .unwrap_or(0.0);
         }
 
         // Eraser: delete nodes on drag-over


### PR DESCRIPTION
## Fix: Post-Click Node Flashing — Time Base Mismatch

### Root Cause
`hover_start_ms` was set with `js_sys::Date::now()` (epoch millis ~1.7 trillion) but compared against `performance.now()` (page-relative ~4000) passed from the JS render loop. This made `elapsed = time_ms - hover_start_ms` a huge negative number, causing hover animations to immediately jump past their duration — producing a visual flash/jump on every hover state change.

### Fix
Use `web_sys::Performance::now()` which returns the same time base as `requestAnimationFrame` callback that JS passes to `render()`.

### Testing
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅  
- `cargo test --workspace` ✅
- WASM built for site and VS Code extension