### PR TITLE
fix(site): bump playground.js version to 0.10.104 for cache bust

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.103"></script>
+  <script type="module" src="playground.js?v=0.10.104"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {


### PR DESCRIPTION
Bump playground.js version parameter from `0.10.103` → `0.10.104` to bust stale cache, ensuring users get the `frame @card` fix from PR #503.