### PR TITLE
fix(site): Code Mode scroll sync + Atom One Dark syntax theme

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,16 @@
 
 ## Completed Requirements
 
+### v0.10.99 — Code Mode Scroll Fix + Atom One Dark Theme (R6.11)
+
+- **FIX (R6.11)**: Code Mode scroll sync fixed — syntax highlight overlay (`#fd-highlight`) now uses `overflow: hidden` instead of `overflow: auto`, relying entirely on JS `scrollTop` sync; previously the overlay had independent scroll behavior that diverged from the textarea
+- **UX (R6.11)**: Syntax highlighting switched from VS Code dark+ to **Atom One Dark** palette — warmer, more cohesive colors: comments `#5C6370` (muted gray), keywords `#C678DD` (purple), node IDs `#E06C75` (red), properties `#D19A66` (orange), strings `#98C379` (green), other keywords `#56B6C2` (cyan), style names `#E5C07B` (yellow)
+- **UX (R6.11)**: Light theme overrides updated to **Atom One Light** palette — comments `#A0A1A7`, keywords `#A626A4`, node IDs `#E45649`, strings `#50A14F`, properties/numbers `#986801`, other keywords `#0184BC`
+- **UX (R6.11)**: Code editor background changed to `#282C34` (Atom One Dark) for thematic consistency
+- **FIX (R6.11)**: WASM error fallback improved — shows "Canvas couldn't start" with actual error message instead of misleading "Playground requires WebAssembly"
+- **PERF (R6.11)**: Scroll sync throttled via `requestAnimationFrame` — prevents redundant scroll handler calls for smoother 60fps scrolling
+- **SITE**: Changes in `site/style.css`, `site/playground.js`, `site/index.html` (cache-bust v0.10.105)
+
 ### v0.10.98 — Cross-Platform Foundations (R5.9, R6.12)
 
 - **CORE (R5.9)**: `DrawBackend` trait — platform-agnostic 2D rendering abstraction in `fd-render/src/backend.rs`; ~30 methods (fill, stroke, path, text, transform, clip) mirroring Canvas2D API; ready for `Canvas2dBackend`, `CoreGraphicsBackend`, and `VelloBackend` implementations

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.103" />
+  <link rel="stylesheet" href="style.css?v=0.10.105" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.104"></script>
+  <script type="module" src="playground.js?v=0.10.105"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1751,7 +1751,14 @@ async function initPlayground() {
     });
 
     // ── Scroll sync (textarea → highlight overlay) ────────────────────
-    editor.addEventListener('scroll', () => syncHighlightScroll(editor));
+    let scrollRafId = null;
+    editor.addEventListener('scroll', () => {
+      if (scrollRafId) return;
+      scrollRafId = requestAnimationFrame(() => {
+        syncHighlightScroll(editor);
+        scrollRafId = null;
+      });
+    });
 
     // ── Pointer Events ────────────────────────────────────────────────
     canvas.addEventListener('pointerdown', (e) => {
@@ -2242,10 +2249,12 @@ async function initPlayground() {
 
   } catch (err) {
     console.error('Failed to load WASM:', err);
+    const errDetail = err.message ? `<code style="font-size:12px;opacity:0.7;display:block;margin-bottom:12px">${err.message}</code>` : '';
     loading.innerHTML = `
-      <p style="color: var(--text-secondary); text-align: center; max-width: 320px;">
-        <strong>Playground requires WebAssembly</strong><br><br>
-        Install the
+      <p style="color: var(--text-secondary); text-align: center; max-width: 360px;">
+        <strong>Canvas couldn't start</strong><br><br>
+        ${errDetail}
+        Try reloading the page. If the issue persists, install the
         <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank">VS Code extension</a>
         for the full canvas experience, or
         <a href="https://github.com/khangnghiem/fast-draft" target="_blank">build from source</a>.

--- a/site/style.css
+++ b/site/style.css
@@ -325,7 +325,7 @@ code {
   position: absolute;
   inset: 0;
   margin: 0;
-  overflow: auto;
+  overflow: hidden; /* JS controls scrollTop via syncHighlightScroll */
   pointer-events: none;
   white-space: pre-wrap;
   word-wrap: break-word;
@@ -345,26 +345,26 @@ code {
   tab-size: inherit;
   color: var(--text-primary);
 }
-/* Token colors — VS Code dark+ palette */
-.fd-comment { color: #6A9955; font-style: italic; }
-.fd-keyword { color: #C586C0; }
-.fd-node-id { color: #9CDCFE; }
-.fd-property { color: #DCDCAA; }
-.fd-string  { color: #CE9178; }
-.fd-hex     { color: #CE9178; }
-.fd-number  { color: #B5CEA8; }
-.fd-kw-other { color: #569CD6; }
-.fd-style-name { color: #4EC9B0; }
-/* Light theme overrides */
-.light-theme .fd-comment  { color: #008000; }
-.light-theme .fd-keyword  { color: #AF00DB; }
-.light-theme .fd-node-id  { color: #001080; }
-.light-theme .fd-property { color: #795E26; }
-.light-theme .fd-string   { color: #A31515; }
-.light-theme .fd-hex      { color: #A31515; }
-.light-theme .fd-number   { color: #098658; }
-.light-theme .fd-kw-other { color: #0000FF; }
-.light-theme .fd-style-name { color: #267F99; }
+/* Token colors — Atom One Dark palette */
+.fd-comment { color: #5C6370; font-style: italic; }
+.fd-keyword { color: #C678DD; }
+.fd-node-id { color: #E06C75; }
+.fd-property { color: #D19A66; }
+.fd-string  { color: #98C379; }
+.fd-hex     { color: #D19A66; }
+.fd-number  { color: #D19A66; }
+.fd-kw-other { color: #56B6C2; }
+.fd-style-name { color: #E5C07B; }
+/* Light theme overrides — Atom One Light palette */
+.light-theme .fd-comment  { color: #A0A1A7; font-style: italic; }
+.light-theme .fd-keyword  { color: #A626A4; }
+.light-theme .fd-node-id  { color: #E45649; }
+.light-theme .fd-property { color: #986801; }
+.light-theme .fd-string   { color: #50A14F; }
+.light-theme .fd-hex      { color: #986801; }
+.light-theme .fd-number   { color: #986801; }
+.light-theme .fd-kw-other { color: #0184BC; }
+.light-theme .fd-style-name { color: #C18401; }
 
 /* ─── Hero Playground ─── */
 .hero-playground {
@@ -540,7 +540,12 @@ code {
 .split-resize-handle.active {
   background: var(--accent);
 }
-.playground-editor, .playground-canvas {
+.playground-editor {
+  background: #282C34; /* Atom One Dark editor background */
+  display: flex;
+  flex-direction: column;
+}
+.playground-canvas {
   background: var(--bg-card);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Changes

Fixes 6 web app issues on fast-draft.com:

1. **Code Mode Scroll Sync** — `#fd-highlight` overlay changed from `overflow: auto` to `overflow: hidden`; JS `scrollTop` sync is now the sole scroll mechanism, eliminating desync between textarea and highlight overlay
2. **Atom One Dark Theme** — Syntax highlighting switched from VS Code dark+ to Atom One Dark palette (9 token colors updated)
3. **Atom One Light Theme** — Light theme overrides updated to match Atom One Light palette
4. **Editor Background** — Code editor uses `#282C34` (Atom One Dark) instead of `--bg-card`
5. **WASM Fallback UX** — Error shows "Canvas couldn't start" + actual error message instead of misleading "Playground requires WebAssembly"
6. **RAF Scroll Throttle** — `requestAnimationFrame` wraps scroll handler for smooth 60fps scrolling

## Testing

- `cargo clippy --workspace` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅ (all tests pass)
- Cache-bust versions bumped to `0.10.105`