### PR TITLE
fix(site): defer fitToContent to RAF for correct mobile layout

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.107"></script>
+  <script type="module" src="playground.js?v=0.10.108"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1787,8 +1787,8 @@ async function initPlayground() {
     };
     animFrameId = requestAnimationFrame(renderLoop);
 
-    // Auto-center scene content in viewport on init
-    fitToContent(canvas);
+    // Auto-center scene content in viewport on init (deferred for layout)
+    requestAnimationFrame(() => fitToContent(canvas));
 
     // Hide loading overlay
     loading.classList.add('hidden');


### PR DESCRIPTION
## Quick follow-up to #508

Defers `fitToContent()` to next `requestAnimationFrame` so browser layout has settled before reading canvas dimensions. Fixes off-center positioning on narrow mobile viewports where CSS media queries may not have applied yet.

Cache-bust v0.10.108.