### PR TITLE
fix(wasm): skip resolve() in resize() during active interactions

### DIFF
--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -246,7 +246,20 @@ impl FdCanvas {
             width: width as f32,
             height: height as f32,
         };
-        self.engine.resolve();
+        // Skip resolve() during active interactions (drag, draw, resize).
+        // ResizeObserver fires when the properties panel opens/closes,
+        // changing the canvas width. resolve() creates a fresh bounds
+        // HashMap from constraints, clobbering in-place drag deltas and
+        // causing nodes to snap back (flashing) every frame.
+        let interacting = self.select_tool.dragging
+            || self.select_tool.resize_handle.is_some()
+            || self.rect_tool.is_drawing()
+            || self.pen_tool.is_drawing()
+            || self.ellipse_tool.is_drawing()
+            || self.arrow_tool.drawing;
+        if !interacting {
+            self.engine.resolve();
+        }
     }
 
     /// Handle pointer down event. Returns true if the graph changed.


### PR DESCRIPTION
## Fix: Drag Flashing — ResizeObserver → resolve() Clobbers Bounds

### Root Cause
`ResizeObserver` fires `resizeCanvas()` → `fdCanvas.resize()` whenever the properties panel opens/closes (changing canvas width). `resize()` called `engine.resolve()`, which creates a **fresh bounds HashMap from constraints**, clobbering in-place drag deltas. This caused nodes to snap back to their constraint-computed positions every frame — "flashing like crazy" during drag.

### Fix
Check if a pointer interaction is active (drag, resize handle, drawing rect/ellipse/pen/arrow) and skip `resolve()` during those gestures. Bounds are already maintained in-place by `apply_mutation()` during drag.

### Testing
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅  
- `cargo test --workspace` ✅
- WASM built for site and VS Code extension