### PR TITLE
fix(site): reset global code bg/padding on syntax highlight overlay

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.108" />
+  <link rel="stylesheet" href="style.css?v=0.10.109" />
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
     (function() {

--- a/site/style.css
+++ b/site/style.css
@@ -344,6 +344,9 @@ code {
   line-height: inherit;
   tab-size: inherit;
   color: #ABB2BF; /* Atom One Dark foreground — always dark */
+  background: transparent; /* override global code bg */
+  padding: 0;
+  border-radius: 0;
 }
 /* Token colors — Atom One Dark palette */
 .fd-comment { color: #5C6370; font-style: italic; }


### PR DESCRIPTION
The global `code { background: var(--bg-card) }` rule was inherited by `#fd-highlight code`, giving highlighted text a light background in light-theme mode while spaces showed the dark `#282C34` editor bg.

Fix: explicitly set `background: transparent`, `padding: 0`, `border-radius: 0` on `#fd-highlight code`.