### PR TITLE
fix(site): guard canvas.width/height assignment to prevent buffer clear flash

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.108"></script>
+  <script type="module" src="playground.js?v=0.10.109"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1714,10 +1714,17 @@ async function initPlayground() {
       const layersW = getLayersPanelWidth();
       const propsW = getPropsPanelWidth();
       const canvasWidth = rect.width - layersW - propsW;
-      canvas.width = canvasWidth * dpr;
-      canvas.height = rect.height * dpr;
-      canvas.style.width = canvasWidth + 'px';
-      canvas.style.height = rect.height + 'px';
+      const newW = Math.round(canvasWidth * dpr);
+      const newH = Math.round(rect.height * dpr);
+      // Only reassign if dimensions actually changed —
+      // canvas.width = X clears the pixel buffer (HTML5 spec),
+      // causing a 1-frame blank flash on every ResizeObserver tick.
+      if (canvas.width !== newW || canvas.height !== newH) {
+        canvas.width = newW;
+        canvas.height = newH;
+        canvas.style.width = canvasWidth + 'px';
+        canvas.style.height = rect.height + 'px';
+      }
       if (fdCanvas) {
         fdCanvas.resize(canvasWidth, rect.height);
       }


### PR DESCRIPTION
### Root Cause

In HTML5, assigning `canvas.width` or `canvas.height` **clears the entire pixel buffer** (by spec). `ResizeObserver` fires during drag when the props panel opens/closes, calling `resizeCanvas()` which unconditionally set `canvas.width`/`canvas.height` — wiping pixels even when dimensions hadn't changed, causing a 1-frame blank flash.

PR #510 protected `resolve()` in `resize()` but didn't prevent the canvas clearing from the JS-side `canvas.width=` assignment.

### Fix

Compare new dimensions with current before assigning. Only clear and resize when they actually differ.

```javascript
const newW = Math.round(canvasWidth * dpr);
const newH = Math.round(rect.height * dpr);
if (canvas.width !== newW || canvas.height !== newH) {
  canvas.width = newW;
  canvas.height = newH;
  // ...
}
```