### PR TITLE
fix(site): repaint after genuine canvas resize to prevent blank frame

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.109"></script>
+  <script type="module" src="playground.js?v=0.10.110"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1724,6 +1724,8 @@ async function initPlayground() {
         canvas.height = newH;
         canvas.style.width = canvasWidth + 'px';
         canvas.style.height = rect.height + 'px';
+        // Buffer was cleared — schedule repaint so we don't show a blank frame
+        renderDirty = true;
       }
       if (fdCanvas) {
         fdCanvas.resize(canvasWidth, rect.height);


### PR DESCRIPTION
When the props panel opens on node click, canvas dimensions change and the HTML5 buffer is correctly cleared. But `renderDirty` was already false (consumed by the previous frame), so no repaint followed — the node appeared to vanish until the next `pointermove`.

Fix: set `renderDirty = true` inside the dimension-change guard so the render loop repaints immediately after a genuine resize.