### PR TITLE
fix: bump cache-bust version for light theme deploy

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.10.109" />
+  <link rel="stylesheet" href="style.css?v=0.10.111" />
 
 </head>
 <body>
@@ -438,7 +438,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.10.110"></script>
+  <script type="module" src="playground.js?v=0.10.111"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {


### PR DESCRIPTION
Bump style.css and playground.js version to v0.10.111 to bust Cloudflare cache after light theme changes.