### PR TITLE
fix: bump cache-bust version to 0.11.1

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.11.0" />
+  <link rel="stylesheet" href="style.css?v=0.11.1" />
 
 </head>
 <body>
@@ -435,7 +435,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.11.0"></script>
+  <script type="module" src="playground.js?v=0.11.1"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {


### PR DESCRIPTION
Bump cache-bust version from 0.11.0 to 0.11.1 to force Cloudflare CDN to serve the fixed `playground.js` with correct CodeMirror imports.