### PR TITLE
fix(site): fix broken canvas interactions — editor.blur() ReferenceError after CodeMirror refactor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.101 — Fix Canvas Interactions After CodeMirror Refactor (R6.11)
+
+- **FIX (R6.11)**: All canvas interactions (click, drag, shape creation, selection) were completely broken — `pointerdown` handler called `editor.blur()` but `editor` was undefined after the CodeMirror 6 refactor (commit `4d6ab749`); `ReferenceError` crashed the handler before `handle_pointer_down()` could run; fixed to `editorView?.contentDOM.blur()`
+- **FIX (R6.11)**: Keyboard shortcuts fired while typing in CodeMirror — `document.activeElement === editor` check was broken (same undefined `editor`); replaced with idiomatic `editorView?.hasFocus ?? false`
+- **CLEANUP**: Removed 2 dead `const editor = document.getElementById('fd-editor')` declarations left behind by CodeMirror refactor in `aiTouch` and `renamify` functions
+- **SITE**: Changes in `site/playground.js`, `site/index.html` (cache-bust v0.11.2)
+
 ### v0.10.100 — Mobile Touch Interactions (R6.11)
 
 - **FIX (R6.11)**: Canvas touch interactions now work on mobile — single-finger tap, drag, draw all functional; root cause was missing `e.preventDefault()` on canvas `pointerdown` and missing `touch-action: none` CSS, causing browser to intercept touch gestures for page scrolling

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.11.1" />
+  <link rel="stylesheet" href="style.css?v=0.11.2" />
 
 </head>
 <body>
@@ -435,7 +435,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.11.1"></script>
+  <script type="module" src="playground.js?v=0.11.2"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -1387,8 +1387,7 @@ async function aiTouch() {
     // Splice modified blocks back into the original document
     const result = spliceModifiedBlocks(fdText, refined, selectedIds);
 
-    // Update editor and canvas
-    const editor = document.getElementById('fd-editor');
+    // Update CodeMirror and canvas
     if (editorView) {
       const cur = editorView.state.doc.toString();
       editorView.dispatch({ changes: { from: 0, to: cur.length, insert: result } });
@@ -1583,8 +1582,7 @@ async function renamify() {
       result = result.replace(pattern, `@${newId}`);
     }
 
-    // Update editor and canvas
-    const editor = document.getElementById('fd-editor');
+    // Update CodeMirror and canvas
     if (editorView) {
       const cur = editorView.state.doc.toString();
       editorView.dispatch({ changes: { from: 0, to: cur.length, insert: result } });
@@ -2006,8 +2004,8 @@ async function initPlayground() {
         return;
       }
 
-      // Blur textarea so keyboard shortcuts work on canvas
-      editor.blur();
+      // Blur CodeMirror so keyboard shortcuts work on canvas
+      editorView?.contentDOM.blur();
 
       const { x, y } = screenToScene(e.clientX, e.clientY, canvas);
 
@@ -2246,7 +2244,7 @@ async function initPlayground() {
     // ── Keyboard Shortcuts ────────────────────────────────────────────
     document.addEventListener('keydown', (e) => {
       if (!fdCanvas) return;
-      const editorFocused = document.activeElement === editor;
+      const editorFocused = editorView?.hasFocus ?? false;
 
       // Space → pan mode
       if (e.code === 'Space' && !e.repeat && !editorFocused) {


### PR DESCRIPTION
## Fix Canvas Interactions After CodeMirror Refactor

**Root cause:** The CodeMirror 6 refactor (commit `4d6ab749`) renamed the editor container variable from `editor` to `editorMount` but missed updating two references in `playground.js`:

1. **Line 2010** — `editor.blur()` → `ReferenceError` crashes the `pointerdown` handler before `handle_pointer_down()` runs, breaking ALL canvas interactions (click, drag, shape creation, selection)
2. **Line 2249** — `document.activeElement === editor` → always `false`, causing keyboard shortcuts to fire while typing in CodeMirror

### Changes
- `editor.blur()` → `editorView?.contentDOM.blur()` (CodeMirror 6 idiomatic)
- `document.activeElement === editor` → `editorView?.hasFocus ?? false` (CodeMirror 6 idiomatic)
- Removed 2 dead `const editor` declarations in `aiTouch` and `renamify`
- Bumped cache version 0.11.1 → 0.11.2

### Verification
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅
- Browser console confirmed `ReferenceError: editor is not defined` pre-fix