### PR TITLE
fix(deploy): prevent WASM cache mismatch — no-cache instead of immutable

### DIFF
--- a/site/_headers
+++ b/site/_headers
@@ -1,6 +1,8 @@
-# WASM binary — content-addressed by build, safe to cache forever
+# WASM — filenames are NOT content-hashed, so never cache immutably.
+# no-cache = always revalidate with CDN (304 if unchanged, fast).
+# This prevents stale .wasm + fresh .js mismatch after deploys.
 /wasm/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: no-cache
 
 # All pages — security headers
 /*


### PR DESCRIPTION
## Fix: WASM cache mismatch → "import function must be callable"

**Root cause:** `site/_headers` set `Cache-Control: public, max-age=31536000, immutable` on `/wasm/*`, but filenames are NOT content-hashed (always `fd_wasm_bg.wasm`). After a deploy, browsers serve the old `.wasm` from their 1-year immutable cache while fetching the new `.js` glue from CDN → import mismatch → crash.

**Fix:** Changed to `Cache-Control: no-cache` — browser always revalidates with CDN (304 Not Modified if unchanged). No bandwidth impact since Cloudflare uses ETag.