### PR TITLE
test/pen-tool-r3-4-tests

### DIFF
--- a/crates/fd-editor/src/tools_tests.rs
+++ b/crates/fd-editor/src/tools_tests.rs
@@ -1741,3 +1741,218 @@ fn select_tool_reclick_keeps_selection() {
         "re-clicking should keep selection"
     );
 }
+
+#[test]
+fn tool_pen_basic_draw() {
+    let mut tool = PenTool::new();
+    assert_eq!(tool.kind(), ToolKind::Pen);
+    assert!(!tool.is_drawing());
+
+    // 1. PointerDown: Starts drawing, creates Path
+    let muts = tool.handle(
+        &InputEvent::PointerDown {
+            x: 10.0,
+            y: 20.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    assert!(tool.is_drawing());
+    assert_eq!(muts.len(), 1);
+
+    let path_id = match &muts[0] {
+        GraphMutation::AddNode { parent_id, node } => {
+            assert_eq!(*parent_id, NodeId::intern("root"));
+            assert!(node.id.as_str().starts_with("path_"));
+            if let NodeKind::Path { commands } = &node.kind {
+                assert_eq!(commands.len(), 1);
+                assert!(matches!(commands[0], PathCmd::MoveTo(10.0, 20.0)));
+            } else {
+                panic!("Expected Path node");
+            }
+            node.id
+        }
+        _ => panic!("Expected AddNode"),
+    };
+
+    // 2. PointerMove: Updates path with LineTo
+    let muts = tool.handle(
+        &InputEvent::PointerMove {
+            x: 15.0,
+            y: 25.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    assert_eq!(muts.len(), 1);
+    match &muts[0] {
+        GraphMutation::UpdatePath { id, commands } => {
+            assert_eq!(*id, path_id);
+            assert_eq!(commands.len(), 2);
+            assert!(matches!(commands[0], PathCmd::MoveTo(10.0, 20.0)));
+            assert!(matches!(commands[1], PathCmd::LineTo(15.0, 25.0)));
+        }
+        _ => panic!("Expected UpdatePath"),
+    }
+
+    // 3. PointerMove again
+    let _ = tool.handle(
+        &InputEvent::PointerMove {
+            x: 20.0,
+            y: 30.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+
+    // 4. PointerUp: Finalizes with Catmull-Rom smoothing
+    let muts = tool.handle(
+        &InputEvent::PointerUp {
+            x: 20.0,
+            y: 30.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    assert!(!tool.is_drawing());
+    assert_eq!(muts.len(), 1);
+    match &muts[0] {
+        GraphMutation::UpdatePath { id, commands } => {
+            assert_eq!(*id, path_id);
+            assert_eq!(commands.len(), 3); // MoveTo, CubicTo, CubicTo
+            assert!(matches!(commands[0], PathCmd::MoveTo(10.0, 20.0)));
+            assert!(matches!(
+                commands[1],
+                PathCmd::CubicTo(_, _, _, _, 15.0, 25.0)
+            ));
+            assert!(matches!(
+                commands[2],
+                PathCmd::CubicTo(_, _, _, _, 20.0, 30.0)
+            ));
+        }
+        _ => panic!("Expected UpdatePath"),
+    }
+}
+
+#[test]
+fn tool_pen_two_points() {
+    let mut tool = PenTool::new();
+
+    // Down
+    tool.handle(
+        &InputEvent::PointerDown {
+            x: 0.0,
+            y: 0.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    // Move
+    tool.handle(
+        &InputEvent::PointerMove {
+            x: 100.0,
+            y: 100.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    // Up - exactly 2 points should just be MoveTo + LineTo
+    let muts = tool.handle(
+        &InputEvent::PointerUp {
+            x: 100.0,
+            y: 100.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+
+    match &muts[0] {
+        GraphMutation::UpdatePath { commands, .. } => {
+            assert_eq!(commands.len(), 2);
+            assert!(matches!(commands[0], PathCmd::MoveTo(0.0, 0.0)));
+            assert!(matches!(commands[1], PathCmd::LineTo(100.0, 100.0)));
+        }
+        _ => panic!("Expected UpdatePath"),
+    }
+}
+
+#[test]
+fn tool_pen_cancel() {
+    let mut tool = PenTool::new();
+
+    tool.handle(
+        &InputEvent::PointerDown {
+            x: 0.0,
+            y: 0.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    assert!(tool.is_drawing());
+
+    tool.cancel();
+    assert!(!tool.is_drawing());
+
+    // Moving after cancel does nothing
+    let muts = tool.handle(
+        &InputEvent::PointerMove {
+            x: 100.0,
+            y: 100.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+    assert!(muts.is_empty());
+}
+
+#[test]
+fn tool_pen_subsampling() {
+    let mut tool = PenTool::new();
+    tool.handle(
+        &InputEvent::PointerDown {
+            x: 0.0,
+            y: 0.0,
+            pressure: 1.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+
+    // Feed 100 points
+    for i in 1..=100 {
+        tool.handle(
+            &InputEvent::PointerMove {
+                x: i as f32,
+                y: i as f32,
+                pressure: 1.0,
+                modifiers: Modifiers::NONE,
+            },
+            None,
+        );
+    }
+
+    let muts = tool.handle(
+        &InputEvent::PointerUp {
+            x: 100.0,
+            y: 100.0,
+            modifiers: Modifiers::NONE,
+        },
+        None,
+    );
+
+    match &muts[0] {
+        GraphMutation::UpdatePath { commands, .. } => {
+            // Should be subsampled to max 64 points
+            // 1 MoveTo + 63 CubicTo = 64 commands
+            assert_eq!(commands.len(), 64);
+        }
+        _ => panic!("Expected UpdatePath"),
+    }
+}

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -222,7 +222,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | R3.1        | `tools::tests::select_tool_*`, `hit::tests::*`                                                                                                                                                                                                                     | ✅ 5 tests + 3 hit tests       |
 | R3.2        | `select_tool_drag`, `select_tool_shift_drag_*`, resize integ., `sync_resize_frame_children_reflow`, `sync_resize_frame_centered_text_recenters`, `sync_move_frame_flush_no_jump`, `sync_move_frame_children_follow_after_flush`, `sync_frame_does_not_auto_resize` | ✅ 8 tests                     |
 | R3.3        | `rect_tool_*`, `ellipse_tool_*`, `text_tool_*`                                                                                                                                                                                                                     | ✅ 7 tests                     |
-| R3.4        | _(pen tool — captures pressure, no unit test)_                                                                                                                                                                                                                     | ⚠️ No pen tool tests           |
+| R3.4        | `tool_pen_basic_draw`, `tool_pen_two_points`, `tool_pen_cancel`, `tool_pen_subsampling`                                                                                                                                                                          | ✅ Covered by PenTool unit tests |
 | R3.5        | _(planned)_                                                                                                                                                                                                                                                        | —                              |
 | R3.6        | E2E UX: zoom/pan/pinch tests in `e2e-ux.test.ts`                                                                                                                                                                                                                   | ✅ 4 E2E tests                 |
 | R3.7        | `commands::tests::*`, `undo_redo::*`                                                                                                                                                                                                                               | ✅ 5 unit + 7 integration      |
@@ -250,7 +250,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | R3.48       | `eraser_tool_lifecycle`, `eraser_tool_clear_resets_state`, `eraser_tool_pointerdown_clears_previous_ids`, `erase_child_preserves_group`, `erase_last_child_leaves_empty_group`, `erase_nested_cascade`                                                             | ✅ 6 tests                     |
 | R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`, `render2d::tests::*`                                                                                                                                                                                                         | ✅ 3 hit + 6 layout + 3 render |
 
-**Total**: 182 Rust tests + 188 TypeScript tests = **370 tests**
+**Total**: 186 Rust tests + 188 TypeScript tests = **374 tests**
 
 ## Requirement Index
 


### PR DESCRIPTION
Fixes the test coverage gap for PenTool functionality (R3.4 requirement) which lacked unit tests capturing pressure data and Catmull-Rom smoothing logic.

- Added `tool_pen_basic_draw`, `tool_pen_two_points`, `tool_pen_cancel`, and `tool_pen_subsampling` unit tests to `crates/fd-editor/src/tools_tests.rs`.
- Covered pointer events (Down, Move, Up), smooth cubic bezier spline generation (Catmull-Rom logic), 2-point threshold, sub-sampling to a max of 64 points, and cancellation.
- Updated `docs/REQUIREMENTS.md` to reflect `✅ Covered by PenTool unit tests` for R3.4 and updated total test count.

---
*PR created automatically by Jules for task [7221215252965766013](https://jules.google.com/task/7221215252965766013) started by @khangnghiem*