### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in renamify panel

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-10 - Cross-Site Scripting (XSS) in Renamify Panel
+**Vulnerability:** Found an XSS vulnerability in `fd-vscode/src/webview-html.ts` where untrusted node IDs (`p.oldId` and `p.newId`) from the extension's `.fd` files were directly interpolated into `row.innerHTML` in the Renamify panel.
+**Learning:** Even though the source is internal extension files, untrusted input rendered directly as `innerHTML` causes an XSS injection risk.
+**Prevention:** Avoid `innerHTML` for dynamically generating DOM nodes. Always use safer DOM APIs like `document.createElement()` and `textContent` when rendering untrusted or user-controlled data.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2884,11 +2884,29 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         items.forEach((p, i) => {
           const row = document.createElement('div');
           row.className = 'renamify-row';
-          row.innerHTML =
-            '<input type="checkbox" checked data-idx="' + i + '">' +
-            '<span class="renamify-old">@' + p.oldId + '</span>' +
-            '<span class="renamify-arrow">→</span>' +
-            '<span class="renamify-new">@' + p.newId + '</span>';
+
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = true;
+          cb.dataset.idx = i.toString();
+
+          const oldSpan = document.createElement('span');
+          oldSpan.className = 'renamify-old';
+          oldSpan.textContent = '@' + p.oldId;
+
+          const arrowSpan = document.createElement('span');
+          arrowSpan.className = 'renamify-arrow';
+          arrowSpan.textContent = '→';
+
+          const newSpan = document.createElement('span');
+          newSpan.className = 'renamify-new';
+          newSpan.textContent = '@' + p.newId;
+
+          row.appendChild(cb);
+          row.appendChild(oldSpan);
+          row.appendChild(arrowSpan);
+          row.appendChild(newSpan);
+
           body.appendChild(row);
         });
         footer.style.display = 'flex';


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Cross-Site Scripting (XSS) in the `renamify-panel` logic within `fd-vscode/src/webview-html.ts` due to interpolating untrusted identifiers (`p.oldId`, `p.newId`) straight into `row.innerHTML`.
🎯 Impact: An attacker could supply a specially crafted `.fd` file with malicious node IDs that, when analyzed by the AI renaming feature, executes arbitrary JavaScript within the VS Code webview environment, potentially accessing sensitive session data or VS Code APIs.
🔧 Fix: Replaced `row.innerHTML` with safe DOM element creation (`document.createElement()`) and used `textContent` to safely insert text data.
✅ Verification: Ran `pnpm test`, `pnpm lint`, and `pnpm compile` inside the extension directory. The UI behaves identically to before, but renders text safely without evaluating it as HTML. Added finding to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8407614315737850735](https://jules.google.com/task/8407614315737850735) started by @khangnghiem*