### PR TITLE
🎨 Palette: Add ARIA labels to icon-only close buttons

### DIFF
--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2732,7 +2732,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <div id="annotation-card">
     <div class="card-header">
       <span id="card-title">Spec</span>
-      <button class="card-close" id="card-close-btn">×</button>
+      <button class="card-close" id="card-close-btn" aria-label="Close">×</button>
     </div>
     <div class="field-group">
       <label class="field-label" for="ann-description">Description</label>
@@ -2795,7 +2795,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
   <div id="renamify-panel">
     <div class="renamify-header">
       <span class="renamify-title">✦ Renamify</span>
-      <button class="renamify-close" id="renamify-close">×</button>
+      <button class="renamify-close" id="renamify-close" aria-label="Close">×</button>
     </div>
     <div class="renamify-body" id="renamify-body"></div>
     <div class="renamify-footer" id="renamify-footer" style="display:none">
@@ -2805,7 +2805,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
   </div>
   <div id="anim-picker">
-    <div class="picker-header"><span class="picker-icon">⚡</span> Add Animation <button class="picker-close" id="anim-picker-close">×</button></div>
+    <div class="picker-header"><span class="picker-icon">⚡</span> Add Animation <button class="picker-close" id="anim-picker-close" aria-label="Close">×</button></div>
     <div class="picker-body" id="anim-picker-body"></div>
   </div>
 

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1860,7 +1860,7 @@ function buildShortcutHelpHtml() {
     <div class="help-panel">
       <div class="help-header">
         <h3>Keyboard Shortcuts</h3>
-        <button class="help-close">×</button>
+        <button class="help-close" aria-label="Close">×</button>
       </div>
       <div class="help-body">
   `;
@@ -2233,7 +2233,7 @@ function addAcceptRow(value) {
   item.className = "accept-item";
   item.innerHTML = `
     <input type="text" value="${escapeAttr(value)}" placeholder="Acceptance criterion">
-    <button class="card-close" style="font-size:14px">×</button>
+    <button class="card-close" style="font-size:14px" aria-label="Close">×</button>
   `;
   item.querySelector("button").addEventListener("click", () => {
     item.remove();
@@ -3768,7 +3768,7 @@ function refreshLibraryPanel() {
 
   let html = `<div class="lib-header">`;
   html += `<span class="lib-title">📦 Libraries</span>`;
-  html += `<button class="lib-close" id="lib-close-btn" title="Close">×</button>`;
+  html += `<button class="lib-close" id="lib-close-btn" title="Close" aria-label="Close">×</button>`;
   html += `</div>`;
   html += `<input class="lib-search" id="lib-search" type="text" placeholder="Search components…" value="${escapeAttr(librarySearchQuery)}">`;
 

--- a/fd-vscode/webview/src/context-menu.js
+++ b/fd-vscode/webview/src/context-menu.js
@@ -312,7 +312,7 @@ function addAcceptRow(value) {
   item.className = "accept-item";
   item.innerHTML = `
     <input type="text" value="${escapeAttr(value)}" placeholder="Acceptance criterion">
-    <button class="card-close" style="font-size:14px">×</button>
+    <button class="card-close" style="font-size:14px" aria-label="Close">×</button>
   `;
   item.querySelector("button").addEventListener("click", () => {
     item.remove();

--- a/fd-vscode/webview/src/panels.js
+++ b/fd-vscode/webview/src/panels.js
@@ -950,7 +950,7 @@ function refreshLibraryPanel() {
 
   let html = `<div class="lib-header">`;
   html += `<span class="lib-title">📦 Libraries</span>`;
-  html += `<button class="lib-close" id="lib-close-btn" title="Close">×</button>`;
+  html += `<button class="lib-close" id="lib-close-btn" title="Close" aria-label="Close">×</button>`;
   html += `</div>`;
   html += `<input class="lib-search" id="lib-search" type="text" placeholder="Search components…" value="${escapeAttr(librarySearchQuery)}">`;
 

--- a/fd-vscode/webview/src/shortcuts.js
+++ b/fd-vscode/webview/src/shortcuts.js
@@ -610,7 +610,7 @@ function buildShortcutHelpHtml() {
     <div class="help-panel">
       <div class="help-header">
         <h3>Keyboard Shortcuts</h3>
-        <button class="help-close">×</button>
+        <button class="help-close" aria-label="Close">×</button>
       </div>
       <div class="help-body">
   `;


### PR DESCRIPTION
## What
Added `aria-label="Close"` to various icon-only "×" close buttons throughout the webview HTML template and corresponding JS view files. 

## Why
Screen reader users would otherwise hear "button" or the math symbol "multiply" instead of understanding these buttons close their respective panels (Library, Spec Card, Settings, etc.).

## Accessibility
This improves the structural accessibility of the UI by ensuring interactive elements provide a clear, screen-reader-friendly label indicating their function, following basic WCAG patterns for icon-only buttons. No visual styling or positioning was changed.

---
*PR created automatically by Jules for task [11157523478058034061](https://jules.google.com/task/11157523478058034061) started by @khangnghiem*