### PR TITLE
fix(z-order): add bumpGeneration() to z-order handlers + VS Code keybinding overrides

### DIFF
--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -1382,4 +1382,248 @@ mod tests {
         // Fill should still be present
         assert!(resolved.fill.is_some());
     }
+
+    #[test]
+    fn z_order_bring_forward() {
+        let mut sg = SceneGraph::new();
+        let a = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("a"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _b = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("b"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _c = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("c"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+
+        // Initial: [a, b, c]
+        let ids: Vec<&str> = sg
+            .children(sg.root)
+            .iter()
+            .map(|&i| sg.graph[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+
+        // Bring @a forward → should swap a and b → [b, a, c]
+        let changed = sg.bring_forward(a);
+        assert!(changed);
+        let ids: Vec<&str> = sg
+            .children(sg.root)
+            .iter()
+            .map(|&i| sg.graph[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["b", "a", "c"]);
+    }
+
+    #[test]
+    fn z_order_send_backward() {
+        let mut sg = SceneGraph::new();
+        let _a = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("a"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _b = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("b"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let c = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("c"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+
+        // Send @c backward → should swap c and b → [a, c, b]
+        let changed = sg.send_backward(c);
+        assert!(changed);
+        let ids: Vec<&str> = sg
+            .children(sg.root)
+            .iter()
+            .map(|&i| sg.graph[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "c", "b"]);
+    }
+
+    #[test]
+    fn z_order_bring_to_front() {
+        let mut sg = SceneGraph::new();
+        let a = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("a"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _b = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("b"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _c = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("c"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+
+        // Bring @a to front → [b, c, a]
+        let changed = sg.bring_to_front(a);
+        assert!(changed);
+        let ids: Vec<&str> = sg
+            .children(sg.root)
+            .iter()
+            .map(|&i| sg.graph[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["b", "c", "a"]);
+    }
+
+    #[test]
+    fn z_order_send_to_back() {
+        let mut sg = SceneGraph::new();
+        let _a = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("a"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _b = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("b"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let c = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("c"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+
+        // Send @c to back → [c, a, b]
+        let changed = sg.send_to_back(c);
+        assert!(changed);
+        let ids: Vec<&str> = sg
+            .children(sg.root)
+            .iter()
+            .map(|&i| sg.graph[i].id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["c", "a", "b"]);
+    }
+
+    #[test]
+    fn z_order_emitter_roundtrip() {
+        use crate::emitter::emit_document;
+        use crate::parser::parse_document;
+
+        let mut sg = SceneGraph::new();
+        let a = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("a"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _b = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("b"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+        let _c = sg.add_node(
+            sg.root,
+            SceneNode::new(
+                NodeId::intern("c"),
+                NodeKind::Rect {
+                    width: 50.0,
+                    height: 50.0,
+                },
+            ),
+        );
+
+        // Bring @a to front → [b, c, a]
+        sg.bring_to_front(a);
+
+        // Emit and re-parse
+        let text = emit_document(&sg);
+        let reparsed = parse_document(&text).unwrap();
+        let ids: Vec<&str> = reparsed
+            .children(reparsed.root)
+            .iter()
+            .map(|&i| reparsed.graph[i].id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["b", "c", "a"],
+            "Z-order should survive emit→parse roundtrip. Emitted:\n{}",
+            text
+        );
+    }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.104 — Fix Z-Order Operations (R3.41)
+
+- **FIX (R3.41)**: Z-order operations (Bring to Front, Send to Back) now work from context menu, properties panel, and keyboard shortcuts — root cause: JS handlers called `render()` + `syncTextToExtension()` but skipped `bumpGeneration()`, so the layers panel never refreshed and the animation loop didn't mark the canvas dirty for subsequent frames; all 5 z-order handlers across `context-menu.js`, `panels.js`, and `shortcuts.js` now call `bumpGeneration()` before `render()`
+- **FIX (R3.41)**: Keyboard shortcuts `⌘[` / `⌘]` / `⌘⇧[` / `⌘⇧]` now reach the canvas — VS Code intercepted these for Indent/Outdent Line and Fold/Unfold; added `keybindings` overrides in `package.json` with `when: activeCustomEditorId == 'fd.canvas'` to disable the default bindings when the FD canvas editor is focused
+- **TESTING**: 5 new z-order unit tests in `model.rs` — `z_order_bring_forward`, `z_order_send_backward`, `z_order_bring_to_front`, `z_order_send_to_back`, `z_order_emitter_roundtrip`
+
 ### v0.10.103 — Canvas Performance: Spatial Index + Bounds-Hash Skip (R5.9)
 
 - **PERF (R5.9)**: `SpatialIndex` in `fd-render/src/hit.rs` — sorted-bounds spatial index with O(log N + K) `query_point()` and `query_rect()` methods, replacing O(N) brute-force walk for hit testing; index rebuilt after layout resolve; cached in `FdCanvas` for use in `hit_test()`; falls back to brute-force when index unavailable

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.88",
+  "version": "0.10.104",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",
@@ -230,7 +230,29 @@
           "group": "navigation"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "key": "cmd+[",
+        "command": "-editor.action.outdentLines",
+        "when": "activeCustomEditorId == 'fd.canvas'"
+      },
+      {
+        "key": "cmd+]",
+        "command": "-editor.action.indentLines",
+        "when": "activeCustomEditorId == 'fd.canvas'"
+      },
+      {
+        "key": "cmd+shift+[",
+        "command": "-editor.fold",
+        "when": "activeCustomEditorId == 'fd.canvas'"
+      },
+      {
+        "key": "cmd+shift+]",
+        "command": "-editor.unfold",
+        "when": "activeCustomEditorId == 'fd.canvas'"
+      }
+    ]
   },
   "scripts": {
     "test": "vitest run",

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -490,7 +490,7 @@ function setupPointerEvents() {
     }
 
     const isAltMove = e.altKey || modAltHeld;
-    const changed = fdCanvas.handle_pointer_move(
+    const moveResult = JSON.parse(fdCanvas.handle_pointer_move(
       x,
       y,
       e.pressure || 1.0,
@@ -498,7 +498,8 @@ function setupPointerEvents() {
       e.ctrlKey,
       isAltMove,
       e.metaKey
-    );
+    ));
+    const changed = moveResult.changed;
     if (changed) render();
 
     // Read ghost origin bounds for Alt+drag preview
@@ -541,15 +542,10 @@ function setupPointerEvents() {
           showDimensionTooltip(e.clientX, e.clientY, `${Math.round(w)} × ${Math.round(h)}`);
         }
       } else if (tool === "select") {
-        // Moving: show (X, Y) of selected node
-        const selectedId = fdCanvas.get_selected_id();
-        if (selectedId && changed) {
-          try {
-            const b = JSON.parse(fdCanvas.get_node_bounds(selectedId));
-            if (b.x !== undefined) {
-              showDimensionTooltip(e.clientX, e.clientY, `(${Math.round(b.x)}, ${Math.round(b.y)})`);
-            }
-          } catch (_) { /* skip */ }
+        // Moving: show (X, Y) from bundled bounds (no extra WASM calls)
+        if (changed && moveResult.bounds) {
+          const b = moveResult.bounds;
+          showDimensionTooltip(e.clientX, e.clientY, `(${Math.round(b.x)}, ${Math.round(b.y)})`);
         }
       }
     }
@@ -1196,11 +1192,19 @@ window.addEventListener("message", (event) => {
     case "setText": {
       if (!fdCanvas) return;
       suppressTextSync = true;
-      fdCanvas.set_text(message.text);
+      const resultJson = fdCanvas.set_text(message.text);
       lastSyncedText = message.text; // Keep dedup in sync
       bumpGeneration(); // External text change — invalidate caches
-      measureAllTextNodes(); // Tight text bounds after code edit
-      render();
+      try {
+        const r = JSON.parse(resultJson);
+        if (r.layout_changed) {
+          measureAllTextNodes(); // Tight text bounds after code edit
+          render();
+        }
+      } catch (_) {
+        measureAllTextNodes();
+        render();
+      }
       suppressTextSync = false;
 
       break;
@@ -1489,6 +1493,7 @@ document.addEventListener("keydown", (e) => {
 
   // Handle graph changes
   if (result.changed) {
+    bumpGeneration();
     render();
     syncTextToExtension();
     closeContextMenu();
@@ -1913,9 +1918,10 @@ function nudgeSelected(arrowKey, step) {
     const dx = newX - b.x;
     const dy = newY - b.y;
     fdCanvas.handle_pointer_down(cx, cy, 1.0, false, false, false, false);
-    const changed = fdCanvas.handle_pointer_move(cx + dx, cy + dy, 1.0, false, false, false, false);
+    const moveResultJson = fdCanvas.handle_pointer_move(cx + dx, cy + dy, 1.0, false, false, false, false);
+    const moveResult = JSON.parse(moveResultJson);
     const upResult = JSON.parse(fdCanvas.handle_pointer_up(cx + dx, cy + dy, false, false, false, false));
-    if (upResult.changed || changed) {
+    if (upResult.changed || moveResult.changed) {
       render();
       syncTextToExtension();
       updatePropertiesPanel();
@@ -2531,6 +2537,7 @@ function setupContextMenu() {
       const resultJson = fdCanvas.handle_key("]", false, true, false, true);
       const result = JSON.parse(resultJson);
       if (result.changed) {
+        bumpGeneration();
         render();
         syncTextToExtension();
       }
@@ -2544,6 +2551,7 @@ function setupContextMenu() {
       const resultJson = fdCanvas.handle_key("[", false, true, false, true);
       const result = JSON.parse(resultJson);
       if (result.changed) {
+        bumpGeneration();
         render();
         syncTextToExtension();
       }
@@ -3018,13 +3026,13 @@ function setupPropsActions() {
       if (!fdCanvas) return;
       const resultJson = fdCanvas.handle_key("]", false, true, false, true);
       const result = JSON.parse(resultJson);
-      if (result.changed) { render(); syncTextToExtension(); }
+      if (result.changed) { bumpGeneration(); render(); syncTextToExtension(); }
     },
     "props-send-back": () => {
       if (!fdCanvas) return;
       const resultJson = fdCanvas.handle_key("[", false, true, false, true);
       const result = JSON.parse(resultJson);
-      if (result.changed) { render(); syncTextToExtension(); }
+      if (result.changed) { bumpGeneration(); render(); syncTextToExtension(); }
     },
     "props-copy-png": () => {
       if (!fdCanvas) return;
@@ -5692,7 +5700,7 @@ function renderMinimap() {
   minimapCtx.translate(offsetX, offsetY);
   minimapCtx.scale(scale, scale);
   minimapCtx.translate(-bounds.minX, -bounds.minY);
-  fdCanvas.render(minimapCtx, performance.now());
+  fdCanvas.render(minimapCtx, performance.now(), true);
   minimapCtx.restore();
 
   // Cache the scene image (without viewport rect) for smooth overlay
@@ -6291,7 +6299,7 @@ function exportToPng() {
 
   // Render scene centered in export canvas
   exportCtx.setTransform(dpr, 0, 0, dpr, (padding - minX) * dpr, (padding - minY) * dpr);
-  fdCanvas.render(exportCtx, performance.now());
+  fdCanvas.render(exportCtx, performance.now(), true);
 
   // Send to extension for save dialog
   const dataUrl = exportCanvas.toDataURL("image/png");
@@ -6996,7 +7004,7 @@ function render() {
   ctx.setTransform(z, 0, 0, z, panX * dpr, panY * dpr);
   // Draw grid below shapes
   if (gridEnabled) drawGrid();
-  fdCanvas.render(ctx, performance.now());
+  fdCanvas.render(ctx, performance.now(), gridEnabled);
 
   // ── Arrow tool: draw live preview line during drag ──
   const arrowPreviewJson = fdCanvas.get_arrow_preview();

--- a/fd-vscode/webview/src/context-menu.js
+++ b/fd-vscode/webview/src/context-menu.js
@@ -610,6 +610,7 @@ function setupContextMenu() {
       const resultJson = fdCanvas.handle_key("]", false, true, false, true);
       const result = JSON.parse(resultJson);
       if (result.changed) {
+        bumpGeneration();
         render();
         syncTextToExtension();
       }
@@ -623,6 +624,7 @@ function setupContextMenu() {
       const resultJson = fdCanvas.handle_key("[", false, true, false, true);
       const result = JSON.parse(resultJson);
       if (result.changed) {
+        bumpGeneration();
         render();
         syncTextToExtension();
       }

--- a/fd-vscode/webview/src/panels.js
+++ b/fd-vscode/webview/src/panels.js
@@ -200,13 +200,13 @@ function setupPropsActions() {
       if (!fdCanvas) return;
       const resultJson = fdCanvas.handle_key("]", false, true, false, true);
       const result = JSON.parse(resultJson);
-      if (result.changed) { render(); syncTextToExtension(); }
+      if (result.changed) { bumpGeneration(); render(); syncTextToExtension(); }
     },
     "props-send-back": () => {
       if (!fdCanvas) return;
       const resultJson = fdCanvas.handle_key("[", false, true, false, true);
       const result = JSON.parse(resultJson);
-      if (result.changed) { render(); syncTextToExtension(); }
+      if (result.changed) { bumpGeneration(); render(); syncTextToExtension(); }
     },
     "props-copy-png": () => {
       if (!fdCanvas) return;

--- a/fd-vscode/webview/src/shortcuts.js
+++ b/fd-vscode/webview/src/shortcuts.js
@@ -239,6 +239,7 @@ document.addEventListener("keydown", (e) => {
 
   // Handle graph changes
   if (result.changed) {
+    bumpGeneration();
     render();
     syncTextToExtension();
     closeContextMenu();


### PR DESCRIPTION
## Summary

Z-order operations (Bring to Front, Send to Back, Bring Forward, Send Backward) were silently succeeding in WASM but not refreshing the canvas UI.

## Root Causes

1. **Missing `bumpGeneration()`** — JS handlers in `context-menu.js`, `panels.js`, and `shortcuts.js` called `render()` + `syncTextToExtension()` but skipped `bumpGeneration()`, so the layers panel never updated and the animation loop didn't mark the canvas dirty for subsequent frames.

2. **VS Code key interception** — `⌘[`/`⌘]` were bound to Indent/Outdent Line and `⌘⇧[`/`⌘⇧]` to Fold/Unfold by default, preventing keyboard shortcuts from reaching the canvas keydown handler.

## Changes

- Add `bumpGeneration()` before `render()` in all 5 z-order handlers across 3 JS files
- Add `keybindings` overrides in `package.json` for `⌘[`, `⌘]`, `⌘⇧[`, `⌘⇧]` with `when: activeCustomEditorId == 'fd.canvas'`
- 5 new z-order unit tests in `fd-core/src/model.rs`
- Version bump to 0.10.104
- CHANGELOG entry for v0.10.104

## Test Results

- ✅ `cargo check --workspace` — clean
- ✅ `cargo clippy --workspace -- -D warnings` — clean
- ✅ `cargo test --workspace` — 222+ Rust tests pass (including 5 new z-order tests)
- ✅ `cargo fmt --all -- --check` — clean
- ✅ `pnpm test` — 241 TS tests pass
- ✅ `pnpm run build:webview` — 7209 lines