### PR TITLE
fix: rebuild spatial index after move/resize gesture

### DIFF
--- a/crates/fd-render/src/hit.rs
+++ b/crates/fd-render/src/hit.rs
@@ -733,4 +733,70 @@ rect @b {
         assert_eq!(index.query_point(100.0, 100.0), None);
         assert!(index.query_rect(0.0, 0.0, 800.0, 600.0).is_empty());
     }
+
+    /// Regression test: spatial index must be rebuilt after in-place bounds
+    /// mutation (e.g. MoveNode). Without rebuild, the index uses stale AABBs
+    /// and hit_test returns None at the node's new position.
+    /// This is the root cause of the "node can only be moved once" bug.
+    #[test]
+    fn spatial_index_stale_after_move() {
+        let input = r#"
+rect @movable {
+  w: 100
+  h: 100
+  x: 10
+  y: 10
+}
+"#;
+        let graph = parse_document(input).unwrap();
+        let viewport = Viewport {
+            width: 800.0,
+            height: 600.0,
+        };
+        let mut bounds = resolve_layout(&graph, viewport);
+        let idx = graph.index_of(NodeId::intern("movable")).unwrap();
+
+        // Build initial index — node at (10, 10)
+        let stale_index = SpatialIndex::build(&graph, &bounds);
+        assert_eq!(
+            stale_index.query_point(50.0, 50.0),
+            Some(NodeId::intern("movable")),
+            "should hit node at original position"
+        );
+
+        // Simulate MoveNode: update bounds in-place (dx=200, dy=200)
+        if let Some(b) = bounds.get_mut(&idx) {
+            b.x += 200.0;
+            b.y += 200.0;
+        }
+
+        // Stale index should MISS at the new position (this was the bug)
+        assert_eq!(
+            stale_index.query_point(250.0, 250.0),
+            None,
+            "stale index should miss node at new position"
+        );
+
+        // Stale index should still "hit" at the OLD position (phantom)
+        assert_eq!(
+            stale_index.query_point(50.0, 50.0),
+            Some(NodeId::intern("movable")),
+            "stale index still thinks node is at old position"
+        );
+
+        // Rebuild index — should find node at new position
+        let fresh_index = SpatialIndex::build(&graph, &bounds);
+        assert_eq!(
+            fresh_index.query_point(250.0, 250.0),
+            Some(NodeId::intern("movable")),
+            "rebuilt index should find node at new position"
+        );
+
+        // Rebuilt index should NOT hit at old position
+        assert_eq!(
+            fresh_index.query_point(50.0, 50.0),
+            None,
+            "rebuilt index should not find node at old position"
+        );
+    }
 }

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -634,6 +634,12 @@ impl FdCanvas {
             self.engine.flush_to_text();
         }
 
+        // Rebuild spatial index so hit testing uses updated positions.
+        // apply_mutations() skips this for MoveNode/ResizeNode batches
+        // (to avoid resolve() clobbering), but the cached bounds ARE
+        // updated in-place — so rebuild the index from those bounds now.
+        self.rebuild_spatial_index();
+
         let drill_changed = false;
 
         self.pointer_down_pos = None;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.107 — Fix Node Can Only Be Moved Once (R3.16)
+
+- **FIX (R3.16)**: Nodes can now be moved repeatedly on the canvas — root cause: `SpatialIndex` for O(log N) hit testing was never rebuilt after move/resize operations; `apply_mutations()` skipped `rebuild_spatial_index()` for MoveNode/ResizeNode batches (to avoid `resolve()` → bounds clobbering); cached bounds were updated in-place but the spatial index still held pre-move AABBs; on the next `pointerdown`, `hit_test()` queried the stale index and returned `None` at the node's new position
+- **FIX (R3.16)**: Added `self.rebuild_spatial_index()` in `handle_pointer_up()` after `flush_to_text()` — spatial index is rebuilt once per gesture using already-updated cached bounds; O(N log N) but only once per pointer-up, not per frame
+- **TESTING**: New `spatial_index_stale_after_move` regression test — builds index, moves bounds in-place, verifies stale index misses at new position, rebuilds index, verifies hit at new position and miss at old position
+- **DOCS**: New LESSONS.md entry — "Spatial Index Must Be Rebuilt After Bounds Mutation"
+
 ### v0.10.106 — Fix Text Alignment Shift in Managed Layouts (R3.46)
 
 - **FIX (R3.46)**: Text inside column/row/grid frames no longer shifts from centered to left-aligned after clicking the frame — root cause: `update_text_metrics()` overwrote the layout-stretched text width with the narrower measured text width (e.g. 420px → 184px), destroying the column layout stretch; `draw_text()` then centered within the shrunken bounds, which appeared left-aligned relative to the frame; fix: `update_text_metrics` now preserves the wider of measured vs layout-assigned width when the text node is inside a managed layout (`is_parent_managed` guard)

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -30,6 +30,7 @@ Engineering lessons discovered through building FD.
   native-drag, svg, preventDefault → L347-355 (Native Drag Hijacks SVG Pointerdown)
   undo, batch, snapshot, resolve  → L358-375 (Snapshot Undo Clobbers Bounds)
   text, metrics, center, bounds   → L377-389 (Text Metrics Update Must Re-Center)
+  spatial-index, hit-test, stale, move → L391-403 (Spatial Index Must Be Rebuilt After Bounds Mutation)
 -->
 
 
@@ -376,3 +377,16 @@ Engineering lessons discovered through building FD.
 **Fix**: After updating bounds dimensions in `update_text_metrics()`, re-center text within parent shape — matching the layout solver's auto-center behavior for text children without explicit Position or place constraints.
 
 **Rule**: **Any function that modifies a node's bounds dimensions must also re-resolve or re-center position when the node participates in auto-centering.** The layout solver's centering is position-dependent on size — shrinking without re-centering breaks the invariant.
+
+---
+
+## Spatial Index Must Be Rebuilt After Bounds Mutation
+
+**Date**: 2026-03-11
+**Context**: Nodes could only be moved once on the canvas — after the first drag, the node became un-selectable and un-movable.
+
+**Root cause**: `apply_mutations()` in `lib.rs` deliberately skips `rebuild_spatial_index()` for MoveNode/ResizeNode batches (to avoid `resolve()` → bounds clobbering). The cached bounds ARE updated in-place, but the `SpatialIndex` still holds the node's **pre-move AABB**. On the next `pointerdown`, `hit_test()` queries the stale spatial index and returns `None` at the node's new visual position.
+
+**Fix**: Added `self.rebuild_spatial_index()` in `handle_pointer_up()` after `flush_to_text()` — the spatial index is rebuilt once per gesture, using the already-updated cached bounds. O(N log N) but only once per pointer-up, not per frame.
+
+**Rule**: **Any optimization cache derived from bounds must be invalidated/rebuilt whenever bounds change.** The spatial index, like cached bounds themselves (L249), is a derived data structure — when the authoritative data (bounds HashMap) changes in-place, all caches must follow.


### PR DESCRIPTION
## Problem

Nodes could only be moved once on the canvas. After dragging a node to a new position, it became un-selectable and un-movable.

## Root Cause

`apply_mutations()` in `lib.rs` deliberately skips `rebuild_spatial_index()` for MoveNode/ResizeNode batches (to avoid `resolve()` → bounds clobbering). The cached bounds ARE updated in-place, but the `SpatialIndex` still holds the node's **pre-move AABB**. On the next `pointerdown`, `hit_test()` queries the stale spatial index and returns `None` at the node's new visual position.

## Fix

Added `self.rebuild_spatial_index()` in `handle_pointer_up()` after `flush_to_text()` — the spatial index is rebuilt once per gesture, using the already-updated cached bounds. O(N log N) but only once per pointer-up, not per frame.

## Changes

- `crates/fd-wasm/src/lib.rs` — `rebuild_spatial_index()` call in `handle_pointer_up()`
- `crates/fd-render/src/hit.rs` — regression test `spatial_index_stale_after_move`
- `docs/LESSONS.md` — new entry
- `docs/CHANGELOG.md` — v0.10.107

## Testing

- `cargo test --workspace` ✅ (all tests pass including new regression test)
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅