### PR TITLE
feat(context-menu): edge right-click, Lock/Unlock, Rename, animations, edge Delete/Reverse

### DIFF
--- a/crates/fd-core/src/emitter.rs
+++ b/crates/fd-core/src/emitter.rs
@@ -419,6 +419,12 @@ fn emit_node(out: &mut String, graph: &SceneGraph, idx: NodeIndex, depth: usize)
         writeln!(out, "place: {place_str}").unwrap();
     }
 
+    // Locked flag (only emit when true — false is default)
+    if node.locked {
+        indent(out, depth + 1);
+        writeln!(out, "locked: true").unwrap();
+    }
+
     // Inline position (x: / y:) — emitted here for token efficiency
     for constraint in &node.constraints {
         if let Constraint::Position { x, y } = constraint {

--- a/crates/fd-core/src/mermaid.rs
+++ b/crates/fd-core/src/mermaid.rs
@@ -556,6 +556,7 @@ fn build_scene_graph(
             annotations: Vec::new(),
             comments: vec![format!("Subgraph: {}", sg.label)],
             place: None,
+            locked: false,
         };
         let idx = graph.add_node(root, frame_node);
         subgraph_indices.insert(sg.id.clone(), idx);
@@ -658,6 +659,7 @@ fn build_scene_graph(
             annotations: Vec::new(),
             comments: Vec::new(),
             place: None,
+            locked: false,
         };
 
         // Add the main node
@@ -687,6 +689,7 @@ fn build_scene_graph(
                 annotations: Vec::new(),
                 comments: Vec::new(),
                 place: Some((HPlace::Center, VPlace::Middle)),
+                locked: false,
             };
             graph.add_node(node_idx, text_node);
         }
@@ -739,6 +742,7 @@ fn build_scene_graph(
                 annotations: Vec::new(),
                 comments: Vec::new(),
                 place: None,
+                locked: false,
             };
             let idx = graph.graph.add_node(text_node);
             graph.graph.add_edge(root, idx, ());

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -597,6 +597,10 @@ pub struct SceneNode {
     /// 9-position placement of this child within its parent.
     /// `None` = default positioning (auto-center for text, origin for others).
     pub place: Option<(HPlace, VPlace)>,
+
+    /// Whether this node is locked (prevents move, resize, delete on canvas).
+    /// Parsed from `locked: true` in the FD format.
+    pub locked: bool,
 }
 
 impl SceneNode {
@@ -612,6 +616,7 @@ impl SceneNode {
             annotations: Vec::new(),
             comments: Vec::new(),
             place: None,
+            locked: false,
         }
     }
 }

--- a/crates/fd-core/src/parser.rs
+++ b/crates/fd-core/src/parser.rs
@@ -93,6 +93,7 @@ pub fn parse_document(input: &str) -> Result<SceneGraph, String> {
                     animations: Default::default(),
                     comments: Vec::new(),
                     place: None,
+                    locked: false,
                 };
                 let idx = graph.graph.add_node(text_node);
                 graph.graph.add_edge(graph.root, idx, ());
@@ -173,6 +174,8 @@ struct ParsedNode {
     children: Vec<ParsedNode>,
     /// 9-position placement within parent.
     place: Option<(HPlace, VPlace)>,
+    /// Whether this node is locked (prevents move/resize/delete).
+    locked: bool,
 }
 
 fn insert_node_recursive(
@@ -188,6 +191,7 @@ fn insert_node_recursive(
     node.annotations = parsed.annotations;
     node.comments = parsed.comments;
     node.place = parsed.place;
+    node.locked = parsed.locked;
 
     let idx = graph.add_node(parent, node);
 
@@ -565,6 +569,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
     let mut layout = LayoutMode::Free { pad: 0.0 };
     let mut clip = false;
     let mut place: Option<(HPlace, VPlace)> = None;
+    let mut locked = false;
     let mut path_commands: Vec<PathCmd> = Vec::new();
     let mut image_src: Option<String> = None;
     let mut image_fit = ImageFit::default();
@@ -593,6 +598,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
                 &mut layout,
                 &mut clip,
                 &mut place,
+                &mut locked,
                 &mut path_commands,
                 &mut image_src,
                 &mut image_fit,
@@ -648,6 +654,7 @@ fn parse_node(input: &mut &str) -> ModalResult<ParsedNode> {
         comments: Vec::new(),
         children,
         place,
+        locked,
     })
 }
 
@@ -775,6 +782,7 @@ fn parse_node_property(
     layout: &mut LayoutMode,
     clip: &mut bool,
     place: &mut Option<(HPlace, VPlace)>,
+    locked: &mut bool,
     path_commands: &mut Vec<PathCmd>,
     image_src: &mut Option<String>,
     image_fit: &mut ImageFit,
@@ -878,6 +886,11 @@ fn parse_node_property(
         }
         "place" => {
             *place = Some(parse_place_value(input)?);
+        }
+        "locked" => {
+            // locked: true — parse boolean value
+            let val = parse_identifier.parse_next(input)?;
+            *locked = val == "true";
         }
         "shadow" => {
             // shadow: (ox,oy,blur,#COLOR)  — colon already consumed by property parser

--- a/crates/fd-core/src/parser_tests.rs
+++ b/crates/fd-core/src/parser_tests.rs
@@ -993,3 +993,35 @@ rect @btn {
         "delay should be None by default"
     );
 }
+
+#[test]
+fn roundtrip_locked() {
+    let src = r#"
+rect @frozen {
+  w: 100 h: 50
+  fill: #007AFF
+  locked: true
+}
+rect @free {
+  w: 80 h: 40
+}
+"#;
+    let graph = parse_document(src).unwrap();
+    let frozen = graph.get_by_id(NodeId::intern("frozen")).unwrap();
+    assert!(frozen.locked, "locked should be true after parse");
+    let free = graph.get_by_id(NodeId::intern("free")).unwrap();
+    assert!(!free.locked, "locked should default to false");
+
+    // Emit and re-parse
+    let emitted = crate::emitter::emit_document(&graph);
+    assert!(emitted.contains("locked: true"), "emitted: {emitted}");
+    // Unlocked node should NOT have locked: in output
+    let frozen_block = emitted.split("@frozen").nth(1).unwrap_or("");
+    assert!(frozen_block.contains("locked: true"));
+
+    let reparsed = parse_document(&emitted).unwrap();
+    let frozen2 = reparsed.get_by_id(NodeId::intern("frozen")).unwrap();
+    assert!(frozen2.locked, "locked should survive roundtrip");
+    let free2 = reparsed.get_by_id(NodeId::intern("free")).unwrap();
+    assert!(!free2.locked, "unlocked should survive roundtrip");
+}

--- a/crates/fd-wasm/src/lib.rs
+++ b/crates/fd-wasm/src/lib.rs
@@ -939,14 +939,16 @@ impl FdCanvas {
             return false;
         }
         let ids: Vec<NodeId> = self.select_tool.selected.clone();
-        // Emit RemoveEdge for edge IDs, RemoveNode for node IDs
+        // Emit RemoveEdge for edge IDs, RemoveNode for node IDs (skip locked nodes)
         let mutations: Vec<GraphMutation> = ids
             .iter()
-            .map(|id| {
+            .filter_map(|id| {
                 if self.engine.graph.edges.iter().any(|e| e.id == *id) {
-                    GraphMutation::RemoveEdge { id: *id }
+                    Some(GraphMutation::RemoveEdge { id: *id })
+                } else if self.engine.graph.get_by_id(*id).is_some_and(|n| n.locked) {
+                    None // Skip locked nodes
                 } else {
-                    GraphMutation::RemoveNode { id: *id }
+                    Some(GraphMutation::RemoveNode { id: *id })
                 }
             })
             .collect();
@@ -2358,6 +2360,35 @@ impl FdCanvas {
         self.hit_test(x, y)
             .map(|id| id.as_str().to_string())
             .unwrap_or_default()
+    }
+
+    /// Hit-test for edges only at scene-space coordinates.
+    /// Returns the edge ID if hit, or empty string.
+    /// Used by JS to show edge context menu on right-click.
+    pub fn hit_test_edge_at(&self, x: f32, y: f32) -> String {
+        fd_render::hit::hit_test_edge(&self.engine.graph, self.engine.current_bounds(), x, y)
+            .map(|id| id.as_str().to_string())
+            .unwrap_or_default()
+    }
+
+    /// Check if a node is locked. Returns false if node not found.
+    pub fn is_node_locked(&self, id: &str) -> bool {
+        let nid = fd_core::id::NodeId::intern(id);
+        self.engine.graph.get_by_id(nid).is_some_and(|n| n.locked)
+    }
+
+    /// Toggle the locked state of a node. Returns the new locked state.
+    /// Returns false if node not found.
+    pub fn toggle_node_locked(&mut self, id: &str) -> bool {
+        let nid = fd_core::id::NodeId::intern(id);
+        if let Some(node) = self.engine.graph.get_by_id_mut(nid) {
+            node.locked = !node.locked;
+            let new_state = node.locked;
+            self.engine.flush_to_text();
+            new_state
+        } else {
+            false
+        }
     }
 
     /// Create a node at a specific position (for drag-and-drop).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,20 @@
 
 ## Completed Requirements
 
+### v0.10.112 — Context Menu Enhancements (R6.6, R3.1)
+
+- **FEATURE (R3.1)**: Edge right-click — right-clicking an edge on the canvas opens the edge context menu (VS Code) or selects the edge with a toast (site); uses new `hit_test_edge_at()` WASM API with 5px proximity detection
+- **FEATURE (R6.6)**: Lock/Unlock node — `locked: bool` field on `SceneNode` parsed/emitted/roundtripped; locked nodes cannot be moved, resized, or deleted; context menu dynamically shows 🔒 Lock / 🔓 Unlock; `is_node_locked()` and `toggle_node_locked()` WASM APIs
+- **FEATURE (R6.6)**: Inline Rename — context menu "Rename" item prompts for new ID, regex-replaces all `@oldId` references in source text (nodes, edges, constraints) with `@newId`; validates identifier format
+- **FEATURE (R3.1)**: Edge Delete — "Delete Edge" button in edge context menu removes the edge via `select_by_id` + `delete_selected`
+- **FEATURE (R3.1)**: Edge Reverse Direction — "Reverse Direction" button swaps `from:` and `to:` values in the edge block
+- **UX (R6.6)**: Context menu open animation — 120ms fade-in with `scale(0.96)` + `translateY(-4px)` on both node and edge context menus; applied to VS Code extension and site playground
+- **CLEANUP (R6.6)**: Merged duplicate "Show Specs" and "View Spec" into single "View Spec" menu item — removed `ctx-show-specs` HTML and event handler
+- **PARITY (R6.6)**: Site playground context menu updated with Lock, Rename, and edge right-click actions matching VS Code extension
+- **TESTING**: Roundtrip test for `locked` property; all existing tests pass
+- **CORE**: `locked: false` added to all `SceneNode` constructors in `mermaid.rs`
+- **CSS**: `.ecm-action` class for clickable edge menu rows (Delete, Reverse)
+
 ### v0.10.111 — Copy/Paste + Context-Aware Right-Click Menu (R6.6, R3.59)
 
 - **FEATURE (R3.59)**: ⌘C/⌘V/⌘X Copy/Cut/Paste now works on playground canvas — copies selected node's `.fd` block to internal + system clipboard; paste renames IDs with `_N` suffix to avoid conflicts, offsets `x:` by `(width + 20) × pasteCount` for horizontal stagger with gap; undo support via `push_undo_snapshot()`

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.111",
+  "version": "0.10.112",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -835,13 +835,22 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     .dark-theme #edge-context-menu {
       box-shadow: 0 8px 32px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.3);
     }
-    #edge-context-menu.visible { display: block; }
+    #edge-context-menu.visible { display: block; animation: ctx-fade-in 0.12s ease-out; }
     .ecm-row {
       display: flex;
       align-items: center;
       justify-content: space-between;
       padding: 4px 0;
       gap: 8px;
+    }
+    .ecm-action {
+      cursor: pointer;
+      border-radius: 5px;
+      padding: 5px 6px;
+      transition: background 0.1s;
+    }
+    .ecm-action:hover {
+      background: var(--fd-surface-hover);
     }
     .ecm-label {
       font-weight: 500;
@@ -1816,7 +1825,11 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     .dark-theme #context-menu {
       box-shadow: 0 10px 38px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.2);
     }
-    #context-menu.visible { display: block; }
+    #context-menu.visible { display: block; animation: ctx-fade-in 0.12s ease-out; }
+    @keyframes ctx-fade-in {
+      from { opacity: 0; transform: scale(0.96) translateY(-4px); }
+      to { opacity: 1; transform: scale(1) translateY(0); }
+    }
     #context-menu .menu-item {
       padding: 4px 10px;
       cursor: default;
@@ -2622,6 +2635,9 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       <div class="ecm-row"><span class="ecm-label">Stroke</span><input type="color" class="ecm-color" id="ecm-stroke-color" value="#999999"><input type="number" class="ecm-input" id="ecm-stroke-width" value="1" min="0.5" max="10" step="0.5"></div>
       <hr class="ecm-sep">
       <div class="ecm-row"><span class="ecm-label">Flow</span><select class="ecm-select" id="ecm-flow"><option value="none">None</option><option value="pulse">Pulse</option><option value="dash">Dash</option></select><input type="number" class="ecm-input" id="ecm-flow-dur" value="800" min="100" max="5000" step="100" style="display:none"></div>
+      <hr class="ecm-sep">
+      <div class="ecm-row ecm-action" id="ecm-reverse"><span class="ecm-label">⇆ Reverse Direction</span></div>
+      <div class="ecm-row ecm-action" id="ecm-delete" style="color: var(--fd-destructive, #e55);"><span class="ecm-label">⊖ Delete Edge</span></div>
     </div>
     <div id="center-snap-guides"></div>
     <div id="layers-panel"></div>
@@ -2788,7 +2804,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <div class="menu-item" id="ctx-ai-refine"><span class="menu-icon">✦</span><span class="menu-label">AI Touch</span></div>
     <div class="menu-item" id="ctx-add-annotation"><span class="menu-icon">◇</span><span class="menu-label">Add Spec</span></div>
     <div class="menu-item" id="ctx-view-spec" style="display:none"><span class="menu-icon">◈</span><span class="menu-label">View Spec</span><span class="menu-shortcut">⌘I</span></div>
-    <div class="menu-item" id="ctx-show-specs" style="display:none"><span class="menu-icon">◇</span><span class="menu-label">Show Specs</span></div>
+    <div class="menu-item" id="ctx-rename" data-action="rename"><span class="menu-icon">✏️</span><span class="menu-label">Rename</span></div>
 
     <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-cut" data-action="cut"><span class="menu-icon">✂</span><span class="menu-label">Cut</span><span class="menu-shortcut">⌘X</span></div>
@@ -2803,7 +2819,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-bring-front" data-action="bring-front"><span class="menu-icon">↑</span><span class="menu-label">Bring to Front</span><span class="menu-shortcut">⌘⇧]</span></div>
     <div class="menu-item" id="ctx-send-back" data-action="send-back"><span class="menu-icon">↓</span><span class="menu-label">Send to Back</span><span class="menu-shortcut">⌘⇧[</span></div>
-    <div class="menu-item disabled" id="ctx-lock" data-action="lock"><span class="menu-icon">🔒</span><span class="menu-label">Lock</span></div>
+    <div class="menu-item" id="ctx-lock" data-action="lock"><span class="menu-icon">🔒</span><span class="menu-label">Lock</span></div>
     <div class="menu-separator"></div>
     <div class="menu-item" id="ctx-delete" data-action="delete"><span class="menu-icon">⊖</span><span class="menu-label">Delete</span><span class="menu-shortcut">⌫</span></div>
   </div>

--- a/fd-vscode/webview/src/context-menu.js
+++ b/fd-vscode/webview/src/context-menu.js
@@ -423,6 +423,16 @@ function setupContextMenu() {
     render();
 
     if (!hitId) {
+      // Fallback: try edge hit-test for edge context menu
+      if (fdCanvas.hit_test_edge_at) {
+        const edgeHit = fdCanvas.hit_test_edge_at(x, y);
+        if (edgeHit) {
+          const container = document.getElementById("canvas-container");
+          const containerRect = container.getBoundingClientRect();
+          showEdgeContextMenu(edgeHit, e.clientX - containerRect.left, e.clientY - containerRect.top);
+          return;
+        }
+      }
       closeContextMenu();
       return;
     }
@@ -446,10 +456,8 @@ function setupContextMenu() {
     // Ungroup requires at least one selected item to be a group
     let canUngroup = false;
     if (selectedIds.length >= 1) {
-      // Check each selected node's kind via the FD source text
       const source = fdCanvas.get_text();
       for (const id of selectedIds) {
-        // Match "group @id" in source — if found, this node is a group
         const groupRe = new RegExp(`(?:^|\\n)\\s*group\\s+@${id}\\b`);
         if (groupRe.test(source)) {
           canUngroup = true;
@@ -463,9 +471,14 @@ function setupContextMenu() {
     const hasSpec = nodeHasSpec(contextMenuNodeId);
     document.getElementById("ctx-add-annotation").style.display = hasSpec ? "none" : "";
     document.getElementById("ctx-view-spec").style.display = hasSpec ? "" : "none";
-    document.getElementById("ctx-show-specs")?.style && (
-      document.getElementById("ctx-show-specs").style.display = hasSpec ? "" : "none"
-    );
+
+    // Update Lock button state
+    const lockBtn = document.getElementById("ctx-lock");
+    if (lockBtn && fdCanvas.is_node_locked) {
+      const isLocked = fdCanvas.is_node_locked(contextMenuNodeId);
+      lockBtn.querySelector(".menu-icon").textContent = isLocked ? "\uD83D\uDD13" : "\uD83D\uDD12";
+      lockBtn.querySelector(".menu-label").textContent = isLocked ? "Unlock" : "Lock";
+    }
 
     menu.classList.add("visible");
   });
@@ -491,17 +504,7 @@ function setupContextMenu() {
     closeContextMenu();
   });
 
-  // Show Specs via context menu — opens spec annotation card
-  document.getElementById("ctx-show-specs")?.addEventListener("click", () => {
-    if (contextMenuNodeId) {
-      if (fdCanvas) fdCanvas.select_by_id(contextMenuNodeId);
-      render();
-      const menu = document.getElementById("context-menu");
-      const menuRect = menu.getBoundingClientRect();
-      openAnnotationCard(contextMenuNodeId, menuRect.left, menuRect.top);
-    }
-    closeContextMenu();
-  });
+  // Removed: "Show Specs" was a duplicate of "View Spec" — consolidated
 
 
 
@@ -685,11 +688,44 @@ function setupContextMenu() {
       const hasSpec = nodeHasSpec(nodeId);
       document.getElementById("ctx-add-annotation").style.display = hasSpec ? "none" : "";
       document.getElementById("ctx-view-spec").style.display = hasSpec ? "" : "none";
-      const showSpecsEl = document.getElementById("ctx-show-specs");
-      if (showSpecsEl) showSpecsEl.style.display = hasSpec ? "" : "none";
+      // Update Lock state
+      const lockBtn = document.getElementById("ctx-lock");
+      if (lockBtn && fdCanvas.is_node_locked) {
+        const isLocked = fdCanvas.is_node_locked(nodeId);
+        lockBtn.querySelector(".menu-icon").textContent = isLocked ? "\uD83D\uDD13" : "\uD83D\uDD12";
+        lockBtn.querySelector(".menu-label").textContent = isLocked ? "Unlock" : "Lock";
+      }
       menu.classList.add("visible");
     });
   }
+
+  // Lock/Unlock via context menu
+  document.getElementById("ctx-lock")?.addEventListener("click", () => {
+    if (fdCanvas && contextMenuNodeId && fdCanvas.toggle_node_locked) {
+      const isLocked = fdCanvas.toggle_node_locked(contextMenuNodeId);
+      render();
+      syncTextToExtension();
+    }
+    closeContextMenu();
+  });
+
+  // Rename via context menu
+  document.getElementById("ctx-rename")?.addEventListener("click", () => {
+    if (!fdCanvas || !contextMenuNodeId) { closeContextMenu(); return; }
+    const oldId = contextMenuNodeId;
+    closeContextMenu();
+    const newId = prompt(`Rename @${oldId} to:`, oldId);
+    if (!newId || newId === oldId || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(newId)) return;
+    // Replace all occurrences of @oldId with @newId in source text
+    const text = fdCanvas.get_text();
+    const escaped = oldId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`@${escaped}\\b`, "g");
+    const newText = text.replace(re, `@${newId}`);
+    fdCanvas.set_text(newText);
+    bumpGeneration();
+    render();
+    syncTextToExtension();
+  });
 }
 
 function closeContextMenu() {
@@ -794,6 +830,46 @@ function setupEdgeContextMenu() {
     applyEdgeChange();
   });
   flowDur.addEventListener("change", applyEdgeChange);
+
+  // Delete edge
+  document.getElementById("ecm-delete")?.addEventListener("click", () => {
+    if (!fdCanvas || !ecmEdgeId) { closeEdgeContextMenu(); return; }
+    // Select the edge and delete it
+    fdCanvas.select_by_id(ecmEdgeId);
+    const changed = fdCanvas.delete_selected();
+    if (changed) {
+      bumpGeneration();
+      render();
+      syncTextToExtension();
+    }
+    closeEdgeContextMenu();
+  });
+
+  // Reverse edge direction (swap from: and to:)
+  document.getElementById("ecm-reverse")?.addEventListener("click", () => {
+    if (!fdCanvas || !ecmEdgeId) { closeEdgeContextMenu(); return; }
+    const text = fdCanvas.get_text();
+    const esc = ecmEdgeId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`(edge\\s+@${esc}\\s*\\{[^}]*?)\\}`, "s");
+    const m = text.match(re);
+    if (!m) { closeEdgeContextMenu(); return; }
+    let block = m[1];
+    // Extract from: and to: values
+    const fromMatch = block.match(/from:\s*(.+)/);
+    const toMatch = block.match(/to:\s*(.+)/);
+    if (fromMatch && toMatch) {
+      const fromVal = fromMatch[1].trim();
+      const toVal = toMatch[1].trim();
+      block = block.replace(/from:\s*.+/, `from: ${toVal}`);
+      block = block.replace(/to:\s*.+/, `to: ${fromVal}`);
+      const newText = text.replace(re, block + "\n}");
+      fdCanvas.set_text(newText);
+      bumpGeneration();
+      render();
+      syncTextToExtension();
+    }
+    closeEdgeContextMenu();
+  });
 }
 
 /** Draw a dot grid behind shapes. Grid adapts to zoom level. */

--- a/site/index.html
+++ b/site/index.html
@@ -207,6 +207,9 @@
               <button class="ctx-item" data-action="group">⊞ Group</button>
               <button class="ctx-item" data-action="ungroup">⊟ Ungroup</button>
               <div class="ctx-sep"></div>
+              <button class="ctx-item" data-action="rename">✏️ Rename</button>
+              <button class="ctx-item" data-action="lock" id="ctx-lock-site">🔒 Lock</button>
+              <div class="ctx-sep"></div>
               <button class="ctx-item" data-action="copy-fd">📄 Copy as .fd</button>
             </div>
             <div id="ctx-menu-canvas">

--- a/site/playground.js
+++ b/site/playground.js
@@ -878,6 +878,13 @@ function setupContextMenu() {
       updateFab(canvas);
       updatePropertiesPanel();
 
+      // Update Lock button label
+      const lockBtn = document.getElementById('ctx-lock-site');
+      if (lockBtn && fdCanvas.is_node_locked) {
+        const isLocked = fdCanvas.is_node_locked(hitId);
+        lockBtn.textContent = isLocked ? '\uD83D\uDD13 Unlock' : '\uD83D\uDD12 Lock';
+      }
+
       if (nodeMenu) {
         if (mx + 170 > vw) mx = vw - 174;
         if (my + 280 > vh) my = vh - 284;
@@ -885,6 +892,27 @@ function setupContextMenu() {
         nodeMenu.style.top = my + 'px';
         canvasMenu?.classList.remove('visible');
         nodeMenu.classList.add('visible');
+      }
+    } else if (fdCanvas.hit_test_edge_at) {
+      // ── Edge right-click → open edge properties panel ──
+      const edgeHit = fdCanvas.hit_test_edge_at(x, y);
+      if (edgeHit) {
+        fdCanvas.select_by_id(edgeHit);
+        renderCanvas();
+        updatePropertiesPanel();
+        // Show toast confirming the edge was selected
+        showToast(`Selected edge @${edgeHit}`);
+      } else {
+        // ── Empty space context menu ──
+        contextMenuClickPos = { x, y };
+        if (canvasMenu) {
+          if (mx + 170 > vw) mx = vw - 174;
+          if (my + 220 > vh) my = vh - 224;
+          canvasMenu.style.left = mx + 'px';
+          canvasMenu.style.top = my + 'px';
+          nodeMenu?.classList.remove('visible');
+          canvasMenu.classList.add('visible');
+        }
       }
     } else {
       // ── Empty space context menu ──
@@ -937,6 +965,24 @@ function setupContextMenu() {
       case 'copy-fd':
         navigator.clipboard.writeText(fdCanvas.get_text()).catch(() => {});
         break;
+      case 'lock':
+        if (fdCanvas.toggle_node_locked) {
+          fdCanvas.toggle_node_locked(fdCanvas.get_selected_id());
+          changed = true;
+        }
+        break;
+      case 'rename': {
+        const selId = fdCanvas.get_selected_id();
+        if (!selId) break;
+        const newId = prompt(`Rename @${selId} to:`, selId);
+        if (!newId || newId === selId || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(newId)) break;
+        const text = fdCanvas.get_text();
+        const esc = selId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const re = new RegExp(`@${esc}\\b`, 'g');
+        fdCanvas.set_text(text.replace(re, `@${newId}`));
+        changed = true;
+        break;
+      }
     }
     if (changed) {
       renderCanvas();

--- a/site/style.css
+++ b/site/style.css
@@ -1286,7 +1286,11 @@ code {
   border-radius: var(--fd-radius);
   box-shadow: var(--fd-shadow-lg);
 }
-#ctx-menu.visible, #ctx-menu-canvas.visible { display: block; }
+#ctx-menu.visible, #ctx-menu-canvas.visible { display: block; animation: ctx-fade-in 0.12s ease-out; }
+@keyframes ctx-fade-in {
+  from { opacity: 0; transform: scale(0.96) translateY(-4px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
 .ctx-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Context Menu Enhancements (v0.10.112)

### Changes
- **Edge Right-Click**: `hit_test_edge_at()` WASM API — right-click edges to open edge context menu (VS Code) or select with toast (site)
- **Lock/Unlock**: `locked: bool` on `SceneNode` with full parse/emit/roundtrip; WASM APIs `is_node_locked()` + `toggle_node_locked()`; locked nodes cannot be moved, resized, or deleted; dynamic 🔒/🔓 icon
- **Inline Rename**: Prompt-based `@id` rename with regex replacement across all source references
- **Edge Delete/Reverse**: New buttons in edge context menu — "Delete Edge" and "⇆ Reverse Direction" (swaps from:/to:)
- **Animation**: 120ms fade-in (`scale(0.96) → 1, translateY(-4px) → 0`) on all context menus
- **Merged Show Specs**: Removed duplicate "Show Specs" — consolidated into existing "View Spec"
- **Site Parity**: Lock, Rename, edge right-click, and animation CSS added to site playground

### Files Changed (13)
- `crates/fd-core/src/model.rs` — `locked: bool` field
- `crates/fd-core/src/parser.rs` — parse `locked: true`
- `crates/fd-core/src/emitter.rs` — emit `locked: true`
- `crates/fd-core/src/parser_tests.rs` — roundtrip test
- `crates/fd-core/src/mermaid.rs` — `locked: false` in constructors
- `crates/fd-wasm/src/lib.rs` — 3 new WASM APIs + delete guard
- `fd-vscode/src/webview-html.ts` — HTML + CSS changes
- `fd-vscode/webview/src/context-menu.js` — All JS handlers
- `site/index.html`, `site/playground.js`, `site/style.css` — Site parity
- `docs/CHANGELOG.md`, `fd-vscode/package.json` — Version bump

### Verification
- ✅ `cargo check --workspace`
- ✅ `cargo test --workspace` (all pass)
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`