### PR TITLE
docs(dx): optimize browser recording size — viewport-first, merge E2E phases, cleanup

### DIFF
--- a/.agents/workflows/e2e.md
+++ b/.agents/workflows/e2e.md
@@ -6,12 +6,13 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
 
 > Canvas editor testing via Codespace browser subagent.
 > **Smoke** (3 checks, 1 subagent call) for routine PRs.
-> **Full** (9 phases, ~10 subagent calls) for major features / pre-release.
+> **Full** (4 phases, ~4 subagent calls) for major features / pre-release.
 
-> [!CAUTION]
-> **Context guard**: If this conversation has done significant research, file reading,
-> or code editing before reaching this point, **STOP**. Start a **fresh conversation**
-> with just `/e2e`. Browser subagents spiral on heavy context (see LESSONS.md L348).
+> [!IMPORTANT]
+> **Context guard**: If this conversation has accumulated very heavy context (many
+> large file reads, extensive code generation, dozens of tool calls), consider
+> starting a **fresh conversation** for E2E. For normal-sized conversations with
+> a few file edits and commits, running E2E in the same conversation is fine.
 
 // turbo-all
 
@@ -19,11 +20,17 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
 
 ## Pre-flight
 
-1. **Check browser state.** If the Codespace tab is already open with a canvas visible **and** you already pushed code to this branch earlier in this conversation, **skip directly to the test phases** (no sync needed).
+1. **Clean up old recordings** — delete stale WebP recordings to free space:
 
-2. If the canvas is open but you haven't pushed yet, push first, then SSH pull (step 4), then skip to test phases.
+   ```bash
+   find ~/.gemini/antigravity/brain/ -name "*.webp" -mmin +60 -delete 2>/dev/null
+   ```
 
-3. Otherwise, full setup:
+2. **Check browser state.** If the Codespace tab is already open with a canvas visible **and** you already pushed code to this branch earlier in this conversation, **skip directly to the test phases** (no sync needed).
+
+3. If the canvas is open but you haven't pushed yet, push first, then SSH pull (step 5), then skip to test phases.
+
+4. Otherwise, full setup:
 
    ```bash
    gh codespace list
@@ -31,7 +38,7 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
 
    Note the codespace name (e.g. `special-space-invention-j74pj54jgxv35rw7`).
 
-4. **Ensure Codespace is running.** Check the status column from step 3. If it shows `Stopped` or `ShuttingDown`:
+5. **Ensure Codespace is running.** Check the status column from step 4. If it shows `Stopped` or `ShuttingDown`:
 
    ```bash
    gh codespace start -c <codespace-name>
@@ -39,7 +46,7 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
 
    Wait ~30s for it to become `Available` before proceeding.
 
-5. **Sync latest code** (git-based — never use `gh codespace cp -r -e .` on Rust projects; `target/` is 17GB+):
+6. **Sync latest code** (git-based — never use `gh codespace cp -r -e .` on Rust projects; `target/` is 17GB+):
 
    ```bash
    # Push current branch to remote
@@ -51,9 +58,23 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
    > If you only changed a few files and they're not committed, use targeted cp instead:
    > `gh codespace cp -r -e fd-vscode/ crates/ examples/ remote:/workspaces/fast-draft/ -c <codespace-name>`
 
-6. **Open Codespace in browser subagent** — navigate directly to `https://<codespace-name>.github.dev`. Do NOT use `gh codespace code --web`. If a tab with this URL already exists, **reuse it**.
+7. **Open Codespace in browser subagent** — navigate directly to `https://<codespace-name>.github.dev`. Do NOT use `gh codespace code --web`. If a tab with this URL already exists, **reuse it**.
 
-7. Open an `.fd` file (e.g. `examples/demo.fd`) → Command Palette (Ctrl+Shift+P) → "FD: Open Canvas Editor". Keep max 2 editor panels open.
+8. Open an `.fd` file (e.g. `examples/demo.fd`) → Command Palette (Ctrl+Shift+P) → "FD: Open Canvas Editor". Keep max 2 editor panels open.
+
+---
+
+## Recording Size Rules
+
+> [!CAUTION]
+> **Every `browser_subagent` call creates a WebP video recording.** Follow these
+> rules to keep recordings small:
+>
+> 1. **Resize to 900×600 as the FIRST action** inside every subagent task — before
+>    any navigation, clicking, or screenshots. 3008×1575 produces ~25× larger files.
+> 2. **Use the prescribed `RecordingName`** from each phase below.
+> 3. **Return immediately** after the last action — idle time inflates recording size.
+> 4. **Take ONE screenshot** at the end, not multiple throughout.
 
 ---
 
@@ -64,9 +85,11 @@ description: E2E browser testing via GitHub Codespace (smoke + full tiers)
 > These 3 checks cover the three failure modes that `cargo test` cannot catch:
 > canvas render, pointer→tool→mutation pipeline, and bidi sync.
 
-### Browser subagent task:
+### Browser subagent task (RecordingName: `smoke_canvas`):
 
 ```
+FIRST ACTION: Resize browser viewport to 900×600.
+
 On the open FD canvas editor, execute these 3 checks in sequence:
 
 1. CANVAS RENDER: Verify shapes are visible on the canvas (not blank/black).
@@ -74,8 +97,7 @@ On the open FD canvas editor, execute these 3 checks in sequence:
 3. BIDI SYNC: In the code editor panel, manually add "rect @smoke_test { w: 80 h: 40 }"
    on a new line → new rect appears on canvas.
 
-Resize browser viewport to 900×600 before taking screenshots.
-Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop.
+Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop immediately.
 ```
 
 ---
@@ -96,17 +118,18 @@ Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop.
 
    If `conclusion` is not `success`, do NOT proceed — fix the deploy first.
 
-### Browser subagent task:
+### Browser subagent task (RecordingName: `deploy_verify`):
 
 ```
+FIRST ACTION: Resize browser viewport to 900×600.
+
 Navigate to https://fast-draft.com and verify the site is live after deploy:
 
 1. SITE LOADS: Page title contains "Fast Draft", hero section visible with "Design as Code".
 2. PLAYGROUND VISIBLE: Live Playground section with code editor and canvas area visible.
 3. WASM LOADS: Canvas renders shapes (not blank/black). Wait up to 5s for WASM init.
 
-Resize browser viewport to 900×600 before taking screenshots.
-Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop.
+Take ONE screenshot at the end. Return PASS/FAIL for each check (1-3) and stop immediately.
 ```
 
 ### Reporting:
@@ -119,104 +142,102 @@ Site Deploy: ✅ 3/3 — site loads, playground visible, WASM renders. Screensho
 
 ## Tier: Full
 
-> Run for major feature PRs or pre-release. Includes all phases below.
+> Run for major feature PRs or pre-release. Consolidated into **4 phases** to
+> minimize recording count and total file size.
 > Each phase = ONE browser subagent call with the verbatim task.
-> **Always resize viewport to 900×600 before taking screenshots** in each phase.
+> **Always resize viewport to 900×600 as the FIRST ACTION** in each phase.
 
-### Phase 1 — Canvas Load & Render
-
-```
-On the open FD canvas: verify (1.1) shapes are visible on canvas,
-(1.2) Layers panel shows node tree, (1.3) Toolbar shows Select/Rect/Ellipse/Pen/Text.
-Take ONE screenshot. Return PASS/FAIL per check.
-```
-
-### Phase 2 — Drawing Tools
+### Phase 1 — Canvas & Drawing (RecordingName: `full_canvas_draw`)
 
 ```
-On the open FD canvas:
-(2.1) Press R, drag to create rect — rect appears, tool switches to Select.
-(2.2) Press O, drag to create ellipse — ellipse appears.
-(2.3) Press T, click canvas, type "test" — text node created.
-(2.4) Check Layers panel — new nodes appear.
-(2.5) Check code editor — new FD code with @id and dimensions.
-Take ONE screenshot showing all created shapes. Return PASS/FAIL per check.
+FIRST ACTION: Resize browser viewport to 900×600.
+
+On the open FD canvas, execute all checks in sequence:
+
+CANVAS LOAD:
+(1.1) Shapes are visible on canvas (not blank/black).
+(1.2) Layers panel shows node tree.
+(1.3) Toolbar shows Select/Rect/Ellipse/Pen/Text.
+
+DRAWING TOOLS:
+(1.4) Press R, drag to create rect — rect appears, tool switches to Select.
+(1.5) Press O, drag to create ellipse — ellipse appears.
+(1.6) Press T, click canvas, type "test" — text node created.
+(1.7) Check Layers panel — new nodes appear.
+(1.8) Check code editor — new FD code with @id and dimensions.
+
+Take ONE screenshot showing all created shapes. Return PASS/FAIL per check and stop immediately.
 ```
 
-### Phase 3 — Selection & Manipulation
+### Phase 2 — Selection, Manipulation & Inline Editing (RecordingName: `full_select_edit`)
 
 ```
-On the open FD canvas:
-(3.1) Click a node — selection handles (8 blue dots) appear.
-(3.2) Drag selected node — node moves, code updates with new x/y.
-(3.3) Select node → right-click → Duplicate — copy appears with new @id.
-(3.4) Select a node → press Delete — node removed from canvas AND code.
-Take ONE screenshot. Return PASS/FAIL per check.
+FIRST ACTION: Resize browser viewport to 900×600.
+
+On the open FD canvas, execute all checks in sequence:
+
+SELECTION & MANIPULATION:
+(2.1) Click a node — selection handles (8 blue dots) appear.
+(2.2) Drag selected node — node moves, code updates with new x/y.
+(2.3) Select node → right-click → Duplicate — copy appears with new @id.
+(2.4) Select a node → press Delete — node removed from canvas AND code.
+
+INLINE EDITING:
+(2.5) Double-click a text node — inline textarea opens with current text.
+(2.6) Type new text, press Enter — text updates on canvas AND in code.
+(2.7) Double-click another text → press Escape — edit cancelled, original text preserved.
+
+Take ONE screenshot. Return PASS/FAIL per check and stop immediately.
 ```
 
-### Phase 4 — Inline Editing
+### Phase 3 — Navigation, Panels & Bidi Sync (RecordingName: `full_nav_sync`)
 
 ```
-On the open FD canvas:
-(4.1) Double-click a text node — inline textarea opens with current text.
-(4.2) Type new text, press Enter — text updates on canvas AND in code.
-(4.3) Double-click another text → press Escape — edit cancelled, original text preserved.
-Take ONE screenshot. Return PASS/FAIL per check.
+FIRST ACTION: Resize browser viewport to 900×600.
+
+On the open FD canvas, execute all checks in sequence:
+
+NAVIGATION:
+(3.1) Hold Space, drag canvas — canvas pans.
+(3.2) Ctrl+scroll wheel — zoom in/out, zoom indicator updates.
+(3.3) Click zoom indicator — resets to 100%.
+(3.4) Press Ctrl+0 — all nodes fit in viewport.
+
+PANELS & PROPERTIES:
+(3.5) Click a layer item in Layers panel — node selects on canvas.
+(3.6) Select a node, check Properties panel — fill, stroke, dimensions shown.
+(3.7) Change fill color in Properties — color updates on canvas.
+
+BIDI SYNC:
+(3.8) In code editor, add "rect @bidi_test { w: 100 h: 50 }" — new rect on canvas.
+(3.9) Delete a node on canvas — code for that node disappears.
+(3.10) Undo (Ctrl+Z) — node reappears on canvas AND in code.
+
+Take ONE screenshot. Return PASS/FAIL per check and stop immediately.
 ```
 
-### Phase 5 — Navigation
+### Phase 4 — Shortcuts & Frames (RecordingName: `full_keys_frames`)
 
 ```
-On the open FD canvas:
-(5.1) Hold Space, drag canvas — canvas pans.
-(5.2) Ctrl+scroll wheel — zoom in/out, zoom indicator updates.
-(5.3) Click zoom indicator — resets to 100%.
-(5.4) Press Ctrl+0 — all nodes fit in viewport.
-Take ONE screenshot. Return PASS/FAIL per check.
-```
+FIRST ACTION: Resize browser viewport to 900×600.
 
-### Phase 6 — Panels & Properties
+On the open FD canvas, execute all checks in sequence:
 
-```
-On the open FD canvas:
-(6.1) Click a layer item in Layers panel — node selects on canvas.
-(6.2) Select a node, check Properties panel — fill, stroke, dimensions shown.
-(6.3) Change fill color in Properties — color updates on canvas.
-Take ONE screenshot. Return PASS/FAIL per check.
-```
+KEYBOARD SHORTCUTS:
+(4.1) Press V — Select tool active (toolbar highlights).
+(4.2) Press R — Rect tool active.
+(4.3) Press E — Ellipse tool active.
+(4.4) Press T — Text tool active.
+(4.5) Press V, select a node, press Arrow keys — node nudges 1px.
 
-### Phase 7 — Bidi Sync
+FRAMES & CONTAINMENT:
+(4.6) Press F, drag to create a frame — frame appears with label.
+(4.7) Drag frame corner — frame resizes, children stay in place.
+(4.8) Click child inside frame, drag — child moves independently.
+(4.9) Draw rect, draw text, drag text onto rect — context menu appears.
+(4.10) Click "Make child" — text becomes child, auto-centered, code updates.
 
-```
-On the open FD canvas:
-(7.1) In code editor, add "rect @bidi_test { w: 100 h: 50 }" — new rect on canvas.
-(7.2) Delete a node on canvas — code for that node disappears.
-(7.3) Undo (Ctrl+Z) — node reappears on canvas AND in code.
-Take ONE screenshot. Return PASS/FAIL per check.
-```
-
-### Phase 8 — Keyboard Shortcuts
-
-```
-On the open FD canvas:
-(8.1) Press V — Select tool active (toolbar highlights).
-(8.2) Press R — Rect tool active.
-(8.3) Press E — Ellipse tool active.
-(8.4) Press T — Text tool active.
-(8.5) Press V, select a node, press Arrow keys — node nudges 1px.
-Take ONE screenshot. Return PASS/FAIL per check.
-```
-
-### Phase 9 — Frames & Containment
-
-```
-On the open FD canvas:
-(9.1) Press F, drag to create a frame — frame appears with label.
-(9.2) Drag frame corner — frame resizes, children stay in place.
-(9.3) Click child inside frame, drag — child moves independently.
-(9.4) Draw rect, draw text, drag text onto rect — context menu appears.
-(9.5) Click "Make child" — text becomes child, auto-centered, code updates.
-Take ONE screenshot. Return PASS/FAIL per check.
+Take ONE screenshot. Return PASS/FAIL per check and stop immediately.
 ```
 
 ---
@@ -231,12 +252,11 @@ Take ONE screenshot. Return PASS/FAIL per check.
 Smoke: ✅ 3/3 — canvas renders, rect draws, bidi syncs. Screenshot attached.
 ```
 
-**Full (9 phases):**
+**Full (4 phases):**
 
 ```
-P1: ✅ 3/3 | P2: ✅ 5/5 | P3: ⚠️ 3/4 (3.3 no-op) | P4: ✅ 3/3
-P5: ✅ 4/4 | P6: ✅ 3/3 | P7: ✅ 3/3 | P8: ✅ 5/5 | P9: ❌ 4/5 (9.5 fail)
-Bug: P9.5 — "Make child" click no effect. Screenshot attached.
+P1: ✅ 8/8 | P2: ⚠️ 6/7 (2.3 no-op) | P3: ✅ 10/10 | P4: ❌ 9/10 (4.10 fail)
+Bug: P4.10 — "Make child" click no effect. Screenshot attached.
 ```
 
 For failures: one-line description + screenshot. No extended prose.
@@ -249,4 +269,5 @@ For failures: one-line description + screenshot. No extended prose.
 - Use Ctrl (not ⌘) in the Codespace terminal — it runs Linux
 - All keyboard shortcuts are listed in the `?` help overlay
 - When running Smoke tier, the entire test is ONE subagent call
-- **Resize viewport to 900×600** before taking any screenshot — GPU-rendered canvases produce large images that can exceed the 5 MB API limit
+- **Resize viewport to 900×600 as the FIRST ACTION** in every subagent — not just before screenshots
+- **RecordingName** must match the prescribed name for each phase (enables easy audit + cleanup)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -56,7 +56,10 @@ Before proposing any new requirement, search the **Requirement Index** at the bo
 
 - **Reuse open tabs** — when a browser tab with the same hostname is already open, navigate within that tab instead of opening a new one. Only open a new tab if no existing tab matches the target hostname.
 - **Includes Codespaces** — the same rule applies to GitHub Codespace tabs (`*.github.dev`). Never open a duplicate Codespace tab.
-- **Small viewport for screenshots** — before any screenshot, resize the browser window to **900×600**. GPU-rendered canvases produce large images; this keeps screenshots under the 5 MB API limit.
+- **Small viewport BEFORE subagent** — resize the browser window to **900×600** as the **first action** inside every `browser_subagent` task, before any other interaction. Recordings capture every frame at viewport resolution; 3008×1575 produces files ~25× larger than 900×600. Never rely on resizing only before screenshots — the recording is already bloated by then.
+- **RecordingName convention** — use `{tier}_{phase}` format: `smoke_canvas`, `full_draw_select`, `deploy_verify`. Descriptive names make it easy to audit and clean up large recordings.
+- **Minimize subagent duration** — keep subagent tasks focused and fast. Long idle time inside a subagent inflates recording size. Return immediately after the last action.
+- **Clean up old recordings** — before E2E runs, delete recordings older than 1 hour: `find ~/.gemini/antigravity/brain/ -name "*.webp" -mmin +60 -delete 2>/dev/null`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,16 @@
 
 ## Completed Requirements
 
+### v0.10.113 — Optimize Browser Recording Size (DX)
+
+- **DX**: `GEMINI.md` Browser Subagent rules expanded — viewport must be resized to 900×600 as the **first action** inside every `browser_subagent` task (not just before screenshots); recordings at 3008×1575 are ~25× larger than at 900×600
+- **DX**: `RecordingName` convention — `{tier}_{phase}` format (`smoke_canvas`, `full_draw_select`, `deploy_verify`) for easy audit and cleanup
+- **DX**: Minimize subagent duration rule — return immediately after the last action; idle time inflates recording size
+- **DX**: Recording cleanup rule — `find ~/.gemini/antigravity/brain/ -name "*.webp" -mmin +60 -delete` before E2E runs
+- **DX**: `/e2e` Full tier merged from 9 phases → 4 phases — reduces recording count by ~56% while maintaining identical test coverage
+- **DX**: `/e2e` context guard softened — E2E can run in the same conversation unless it's very heavy; fresh conversation only needed for extremely large contexts
+- **DX**: `/e2e` "Recording Size Rules" section added — documents all recording-related constraints in one place
+
 ### v0.10.112 — Context Menu Enhancements (R6.6, R3.1)
 
 - **FEATURE (R3.1)**: Edge right-click — right-clicking an edge on the canvas opens the edge context menu (VS Code) or selects the edge with a toast (site); uses new `hit_test_edge_at()` WASM API with 5px proximity detection


### PR DESCRIPTION
## Summary\n\nReduces browser recording file size by addressing all 6 factors that inflate WebP recordings created by `browser_subagent`.\n\n## Changes\n\n### GEMINI.md — Browser Subagent Rules\n- **Viewport-first**: Resize to 900×600 as the FIRST action inside every subagent task (not just before screenshots). 3008×1575 produces ~25× larger recordings.\n- **RecordingName convention**: `{tier}_{phase}` format for easy audit and cleanup.\n- **Minimize duration**: Return immediately after last action — idle time inflates recording size.\n- **Cleanup rule**: Delete recordings older than 1 hour before E2E runs.\n\n### E2E Workflow\n- **Merged 9 Full phases → 4**: Same test coverage, ~56% fewer recordings.\n- **Recording Size Rules section**: Central reference for all recording constraints.\n- **Cleanup step in pre-flight**: `find` command to delete stale .webp files.\n- **Softened context guard**: E2E can run in the same conversation unless very heavy.\n- **Viewport-first instructions**: Every subagent task starts with resize.\n\n### CHANGELOG\n- Added v0.10.113 entry documenting all DX improvements.\n\n## Verification\n\nDocs-only change — no Rust/WASM/TS code affected. No tests needed.