### PR TITLE
test: add coverage for R4.7-R4.11 AI spec view features

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -240,7 +240,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | R3.29       | E2E UX: animation tween engine                                                                                                                                                                                                                                     | ✅ 2 E2E tests                 |
 | R3.30       | _(JS-only, camera animation)_                                                                                                                                                                                                                                      | ⚠️ JS-only                     |
 | R4.1–R4.6   | Covered by R1/R2 tests                                                                                                                                                                                                                                             | ✅                             |
-| R4.7–R4.11  | _(extension-side, no test)_                                                                                                                                                                                                                                        | ❌                             |
+| R4.7–R4.11  | `exportSpec.test.ts`, `spec-view.test.ts`                                                                                                                                                                                                                          | ✅ 2 TS tests                  |
 | R3.36       | `layout_text_centered_in_rect`, `layout_text_in_ellipse_*`, `layout_text_explicit_pos_*`                                                                                                                                                                           | ✅ 4 tests                     |
 | R3.39–R3.44 | _(JS-only; floating toolbar, snap, edge context menu — no WASM-side tests)_                                                                                                                                                                                        | ⚠️ JS-only                     |
 | R3.45       | `sync_resize_child_expands_parent_on_finalize`, `sync_resize_child_within_bounds_no_expand`, `sync_cascade_expand_two_levels`, `sync_cascade_stops_at_clip_frame`                                                                                                  | ✅ 4 tests                     |
@@ -250,7 +250,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 | R3.48       | `eraser_tool_lifecycle`, `eraser_tool_clear_resets_state`, `eraser_tool_pointerdown_clears_previous_ids`, `erase_child_preserves_group`, `erase_last_child_leaves_empty_group`, `erase_nested_cascade`                                                             | ✅ 6 tests                     |
 | R5.1–R5.8   | `hit::tests::*`, `resolve::tests::*`, `render2d::tests::*`                                                                                                                                                                                                         | ✅ 3 hit + 6 layout + 3 render |
 
-**Total**: 186 Rust tests + 188 TypeScript tests = **374 tests**
+**Total**: 186 Rust tests + 190 TypeScript tests = **376 tests**
 
 ## Requirement Index
 

--- a/fd-vscode/src/exportSpec.test.ts
+++ b/fd-vscode/src/exportSpec.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildSpecMarkdown } from "./exportSpec";
+
+describe("exportSpec", () => {
+  it("builds spec markdown correctly", () => {
+    // In `buildSpecMarkdown`, `processSpecBlock` only checks if a line starts with "spec".
+    // It doesn't pick up `accept`, `status`, `priority`, etc. unless they are INSIDE a `spec { ... }` block!
+    // The previous test assumed `accept:` on its own line in a node block would be picked up, but looking at the code:
+    // `processNodeDecl` matches the node declaration.
+    // Inside the loop, it checks `processSpecBlock`. `processSpecBlock` checks if line starts with `spec ` or `spec{`.
+    // It does NOT process `accept:` on its own unless it's inside `spec { accept: ... }`!
+    // Let's write FD that matches what the parser actually expects: `spec { ... }`
+
+    const fdSource = `
+spec "Top level spec"
+
+rect @my_rect {
+  spec {
+    "Description of my_rect"
+    accept: "Acceptance criteria 1"
+    status: in_progress
+    priority: high
+    tag: UI, frontend
+  }
+}
+
+@generic_node {
+  spec {
+    "Generic description"
+  }
+}
+
+edge @e1 {
+  from: @my_rect
+  to: @generic_node
+  label: "Click"
+  spec {
+    "Triggers transition"
+    accept: "Must be smooth"
+  }
+}
+`;
+    const md = buildSpecMarkdown(fdSource, "my_file.fd");
+    expect(md).toContain("# Spec: my_file.fd");
+
+    expect(md).toContain("## @my_rect `rect`");
+    expect(md).toContain("> Description of my_rect");
+    expect(md).toContain("- [ ] Acceptance criteria 1");
+    expect(md).toContain("- **Status:** in_progress");
+    expect(md).toContain("- **Priority:** high");
+    expect(md).toContain("- **Tags:** UI, frontend");
+    expect(md).toContain("## @generic_node `spec`");
+    expect(md).toContain("> Generic description");
+    expect(md).toContain("## Flows");
+    expect(md).toContain("- **@my_rect** → **@generic_node** — Click");
+    expect(md).toContain("> Triggers transition");
+    expect(md).toContain("- [ ] Must be smooth");
+  });
+});

--- a/fd-vscode/src/panels/spec-view.test.ts
+++ b/fd-vscode/src/panels/spec-view.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { FdSpecViewPanel } from "./spec-view";
+
+describe("FdSpecViewPanel.parseSpec", () => {
+  it("parses spec block and node annotations to HTML", () => {
+    // FdSpecViewPanel.parseSpec uses `lines.indexOf(line)` to find the line index.
+    // If there are identical lines (like `spec {`), `indexOf` finds the FIRST one!
+    // That means the second `spec {` block will parse the FIRST one's contents again!
+    // To avoid this bug in the test, we must make sure each `spec {` line is unique or we add trailing spaces to make them unique.
+
+    const fdSource = `
+rect @my_rect {
+  spec {
+    "Description of my_rect"
+    accept: "Acceptance criteria 1"
+    status: in_progress
+    priority: high
+    tag: UI, frontend
+  }
+}
+
+@generic_node {
+  spec {
+    "Generic description"
+  }
+}
+
+edge @e1 {
+  from: @my_rect
+  to: @generic_node
+  label: "Click"
+  spec {
+    "Triggers transition"
+  }
+}
+`;
+
+    // To call a method, we can cast the prototype.
+    // Since `parseSpec` calls `this.parseAnnotation(specLine)`, we need to provide `parseAnnotation` on the `this` context.
+    const context = {
+      parseAnnotation: (FdSpecViewPanel.prototype as any).parseAnnotation,
+      renderSpecNode: (FdSpecViewPanel.prototype as any).renderSpecNode
+    };
+    const parseSpec = FdSpecViewPanel.prototype.parseSpec.bind(context);
+    const html = parseSpec(fdSource);
+
+    expect(html).toContain("Description of my_rect");
+    expect(html).toContain("Acceptance criteria 1");
+    expect(html).toContain("in_progress");
+    expect(html).toContain("high");
+    expect(html).toContain("UI");
+    expect(html).toContain("frontend");
+    expect(html).toContain("Generic description");
+    expect(html).toContain("Flows");
+    expect(html).toContain("my_rect");
+    expect(html).toContain("generic_node");
+    expect(html).toContain("Click");
+    expect(html).toContain("Triggers transition");
+  });
+});

--- a/fd-vscode/src/panels/spec-view.ts
+++ b/fd-vscode/src/panels/spec-view.ts
@@ -218,7 +218,7 @@ export class FdSpecViewPanel {
 </html>`;
   }
 
-  private parseSpec(source: string): string {
+  public parseSpec(source: string): string {
     const lines = source.split("\n");
     let html = "";
     const nodeStack: { indent: number; hasAnnotations: boolean }[] = [];
@@ -233,7 +233,8 @@ export class FdSpecViewPanel {
     let currentEdge: { from: string; to: string; label: string; annotations: { type: string; value: string }[] } | null = null;
     let insideEdge = false;
 
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
       const trimmed = line.trim();
       if (!trimmed) continue;
 
@@ -259,8 +260,7 @@ export class FdSpecViewPanel {
         if (trimmed.includes("{")) {
           let specDepth = (trimmed.match(/\{/g) || []).length;
           specDepth -= (trimmed.match(/\}/g) || []).length;
-          const lineIdx = lines.indexOf(line);
-          let j = lineIdx + 1;
+          let j = i + 1;
           while (j < lines.length && specDepth > 0) {
             const specLine = lines[j].trim();
             specDepth += (specLine.match(/\{/g) || []).length;


### PR DESCRIPTION
- Fix bug in `fd-vscode/src/panels/spec-view.ts` where `lines.indexOf(line)` mistakenly skipped duplicate lines (like multiple `spec {`) instead of using loop index.
- Add test `fd-vscode/src/exportSpec.test.ts` to verify `buildSpecMarkdown`.
- Add test `fd-vscode/src/panels/spec-view.test.ts` to verify `parseSpec` logic.
- Update `docs/REQUIREMENTS.md` to reflect new test count and coverage for AI features R4.7-R4.11.

---
*PR created automatically by Jules for task [14416457601566865863](https://jules.google.com/task/14416457601566865863) started by @khangnghiem*