### PR TITLE
🎨 Palette: Add accessibility and hover labels to alignment grid

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-11 - Abstract Grid Controls Accessibility
+**Learning:** Custom structural UI controls (like a 3x3 alignment grid built from basic CSS shapes rather than standard icons) are easy to overlook for accessibility because they don't look like typical buttons. They lack semantic meaning for screen readers and miss out on native tooltip functionality.
+**Action:** Whenever building visual control grids or layouts using empty CSS shapes (`span.align-dot`), explicitly add `aria-label` and `title` attributes for both screen readers and mouse users.

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2734,15 +2734,15 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
         <div class="props-section" id="props-align-section" style="display:none">
           <div class="props-section-label">Alignment</div>
           <div class="align-grid" id="align-grid">
-            <button class="align-cell" data-h="left"   data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="top"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="middle"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="left"   data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="center" data-v="bottom"><span class="align-dot"></span></button>
-            <button class="align-cell" data-h="right"  data-v="bottom"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="top" aria-label="Align Top Left" title="Align Top Left"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="top" aria-label="Align Top Center" title="Align Top Center"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="top" aria-label="Align Top Right" title="Align Top Right"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="middle" aria-label="Align Middle Left" title="Align Middle Left"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="middle" aria-label="Align Middle Center" title="Align Middle Center"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="middle" aria-label="Align Middle Right" title="Align Middle Right"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="left"   data-v="bottom" aria-label="Align Bottom Left" title="Align Bottom Left"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="center" data-v="bottom" aria-label="Align Bottom Center" title="Align Bottom Center"><span class="align-dot"></span></button>
+            <button class="align-cell" data-h="right"  data-v="bottom" aria-label="Align Bottom Right" title="Align Bottom Right"><span class="align-dot"></span></button>
           </div>
         </div>
         <div class="props-section" id="props-actions-section">


### PR DESCRIPTION
### 💡 What
Added explicit `aria-label` and `title` attributes to all nine buttons in the 3x3 alignment grid component.

### 🎯 Why
The alignment grid is constructed from simple CSS shapes (`span.align-dot`) inside `<button>` tags without any text. This means screen readers announced them as empty/unlabelled buttons, and mouse users had no tooltip context for what each specific dot did. This change ensures every cell (e.g., "Align Top Left", "Align Middle Center") is fully accessible and understandable.

### 📸 Before/After
**Before:**
```html
<button class="align-cell" data-h="left" data-v="top"><span class="align-dot"></span></button>
```
*Screen reader:* "Button"
*Hover:* No tooltip

**After:**
```html
<button class="align-cell" data-h="left" data-v="top" aria-label="Align Top Left" title="Align Top Left"><span class="align-dot"></span></button>
```
*Screen reader:* "Align Top Left, Button"
*Hover:* Tooltip reads "Align Top Left"

### ♿ Accessibility
*   **Screen Readers:** All 9 buttons now have descriptive `aria-label`s.
*   **Mouse/Keyboard Hover:** All 9 buttons now have `title` tooltips for visual context.

---
*PR created automatically by Jules for task [13689772614230505282](https://jules.google.com/task/13689772614230505282) started by @khangnghiem*