### PR TITLE
⚡ Bolt: Optimize clipboard paste text replacement

### DIFF
--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -6192,9 +6192,12 @@ async function pasteFromClipboard() {
     idMap.set(oldId, newId);
   }
 
-  // Replace all @id references with new names
-  for (const [oldId, newId] of idMap) {
-    pasteText = pasteText.replace(new RegExp(`@${oldId}\\b`, 'g'), `@${newId}`);
+  // Replace all @id references with new names using a single-pass regex
+  if (idMap.size > 0) {
+    const pattern = new RegExp(`@(${[...idMap.keys()].join('|')})\\b`, 'g');
+    pasteText = pasteText.replace(pattern, (match, oldId) => {
+      return `@${idMap.get(oldId)}`;
+    });
   }
   const newRootId = idMap.get(rootId) || rootId;
 

--- a/fd-vscode/webview/src/clipboard.js
+++ b/fd-vscode/webview/src/clipboard.js
@@ -125,9 +125,12 @@ async function pasteFromClipboard() {
     idMap.set(oldId, newId);
   }
 
-  // Replace all @id references with new names
-  for (const [oldId, newId] of idMap) {
-    pasteText = pasteText.replace(new RegExp(`@${oldId}\\b`, 'g'), `@${newId}`);
+  // Replace all @id references with new names using a single-pass regex
+  if (idMap.size > 0) {
+    const pattern = new RegExp(`@(${[...idMap.keys()].join('|')})\\b`, 'g');
+    pasteText = pasteText.replace(pattern, (match, oldId) => {
+      return `@${idMap.get(oldId)}`;
+    });
   }
   const newRootId = idMap.get(rootId) || rootId;
 


### PR DESCRIPTION
### 💡 What
Refactored the `idMap` string replacement logic in `pasteFromClipboard` within `fd-vscode/webview/src/clipboard.js`. Replaced an iterative `O(N)` string substitution pass with a single `RegExp` execution that uses alternation (e.g., `@(id1|id2|id3)\b`) and a replacer function to execute the substitution in a single `O(1)` pass over the document text.

### 🎯 Why
When pasting large blocks of `.fd` text with many nodes, the original logic created a new `RegExp` and executed a full string `.replace` sweep for *every* unique ID present in the text block. For `N` IDs and a document length `L`, this runs in `O(N * L)`. The single-pass approach builds one compound regex and scans the document exactly once, reducing complexity to `O(L)`.

### 📊 Impact
Drastically reduces CPU allocation and string reallocation blocking on the main thread during clipboard paste operations, scaling gracefully independent of the number of nodes pasted. It also eliminates the theoretical risk of "double replacements" where a newly injected ID happens to match an old ID evaluated later in the iteration order.

### 🔬 Measurement
1. Copy a large grouping of `node` items in the webview playground.
2. Paste them back into the workspace.
3. Observe faster render blocking and text insertion. The Playwright integration test confirms that multi-string substitution maps cleanly into the single-pass implementation.

---
*PR created automatically by Jules for task [16591005486347637885](https://jules.google.com/task/16591005486347637885) started by @khangnghiem*