### PR TITLE
fix(site): layers panel empty on init — add explicit refreshLayersPanel() call

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.11.3"></script>
+  <script type="module" src="playground.js?v=0.11.4"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {

--- a/site/playground.js
+++ b/site/playground.js
@@ -2437,7 +2437,13 @@ async function initPlayground() {
 
     // Auto-center scene content in viewport on init (deferred for layout)
     // Defer fit-to-content — WASM layout resolve needs a frame to settle.
-    setTimeout(() => { fitToContent(canvas); renderCanvas(); }, 100);
+    setTimeout(() => {
+      fitToContent(canvas);
+      renderCanvas();
+      refreshLayersPanel();
+      renderMinimap(canvas);
+      uiDirty = false; // first render done
+    }, 100);
 
     // Hide loading overlay
     loading.classList.add('hidden');


### PR DESCRIPTION
Fix layers panel not populating on initial page load.\n\n## Root Cause\nThe render loop's `refreshLayersPanel()` call was gated by `uiDirty && time - minimapLastRender > MINIMAP_INTERVAL`. While `uiDirty` starts as `true`, the interval check could prevent the first call. The panel remained empty until a user interaction set `uiDirty = true` again.\n\n## Fix\n- Add explicit `refreshLayersPanel()` + `renderMinimap()` calls in the deferred init timeout (100ms after WASM init)\n- Bump cache-bust to v0.11.4 to ensure fix is served immediately