### PR TITLE
fix(site): canvas blank after clicking node — ResizeObserver/RAF race

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.116 — Fix Canvas Blank After Clicking a Node (R6.9)
+
+- **FIX (R6.9)**: Canvas no longer goes blank after clicking a node — root cause: ResizeObserver/RAF race condition; clicking a node opens the Properties panel (`.visible`), changing wrapper layout → ResizeObserver fires `resizeCanvas()` → `canvas.width = newW` clears pixel buffer (HTML5 spec); the RAF loop already consumed `renderDirty=true` earlier in the same frame, so the cleared canvas was composited blank; fix: `resizeCanvas()` now calls `renderCanvas()` synchronously after clearing the buffer instead of relying on `renderDirty` + next RAF tick
+- **DOCS**: New LESSONS.md entry — "ResizeObserver Must Repaint Synchronously After canvas.width Assignment"
+
 ### v0.10.115 — Web Canvas Consistency Audit (R6.6)
 
 - **FEATURE (R6.6)**: Inline text editing on double-click — double-click text/shape to edit in-place via floating textarea; double-click empty canvas to create new text node with immediate editor; Enter commits, Escape cancels; undo snapshot on commit

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -32,6 +32,7 @@ Engineering lessons discovered through building FD.
   text, metrics, center, bounds   → L377-389 (Text Metrics Update Must Re-Center)
   spatial-index, hit-test, stale, move → L391-403 (Spatial Index Must Be Rebuilt After Bounds Mutation)
   hover, click, press, pointer-down    → L405-417 (Pointer Down Must Not Set Hover State)
+  resize-observer, raf, canvas-blank, click → L419-431 (ResizeObserver Must Repaint Synchronously)
 -->
 
 
@@ -395,3 +396,16 @@ Browser subagents inherit the full parent conversation context. When context exc
 **Fix**: Removed `hovered_id` assignment from both `handle_pointer_down` and `handle_pointer_up`. Only `handle_pointer_move` manages `hovered_id`, aligning with CSS behavior where `:hover` is cursor-proximity based, not click-based. Also added base fill to affected `demo.fd` nav items.
 
 **Rule**: **Hover and press/click are independent pointer states.** `hovered_id` should only be set by `pointer_move`; `pressed_id` should only be set by `pointer_down`/`pointer_up`. Conflating them causes `:hover` animations to fire on click, which is incorrect behavior.
+
+---
+
+## ResizeObserver Must Repaint Synchronously After canvas.width Assignment
+
+**Date**: 2026-03-12
+**Context**: Clicking any node on fast-draft.com caused the entire canvas to go blank. Scene graph intact (Layers/Properties panels worked), but nothing was painted.
+
+**Root cause**: ResizeObserver / RAF race condition. When clicking a node, `updatePropertiesPanel()` adds `.visible` → wrapper layout changes → ResizeObserver fires `resizeCanvas()` → `canvas.width = newW` clears all pixels (HTML5 spec). The RAF-based render loop had already consumed `renderDirty=true` from the `pointerup` handler earlier in the same frame, so the cleared canvas was painted blank. Setting `renderDirty=true` inside `resizeCanvas()` deferred the repaint to the NEXT RAF tick, but by then the browser had already composited and displayed the blank frame.
+
+**Fix**: Call `renderCanvas()` synchronously at the end of `resizeCanvas()` when the buffer was cleared, instead of relying on `renderDirty` + RAF. Set `renderDirty = false` to prevent a redundant double-render on the next RAF tick.
+
+**Rule**: **Never rely on RAF `renderDirty` flags after `canvas.width/height` assignment.** The HTML5 spec clears the entire pixel buffer on any dimension assignment. Since ResizeObserver callbacks fire after RAF in Chrome's rendering pipeline, the cleared canvas will be composited before the next RAF can repaint. Always repaint synchronously after clearing.

--- a/site/playground.js
+++ b/site/playground.js
@@ -2249,16 +2249,25 @@ async function initPlayground() {
       // Only reassign if dimensions actually changed —
       // canvas.width = X clears the pixel buffer (HTML5 spec),
       // causing a 1-frame blank flash on every ResizeObserver tick.
+      let bufferCleared = false;
       if (canvas.width !== newW || canvas.height !== newH) {
         canvas.width = newW;
         canvas.height = newH;
         canvas.style.width = canvasWidth + 'px';
         canvas.style.height = rect.height + 'px';
-        // Buffer was cleared — schedule repaint so we don't show a blank frame
-        renderDirty = true; uiDirty = true;
+        bufferCleared = true;
+        uiDirty = true;
       }
       if (fdCanvas) {
         fdCanvas.resize(canvasWidth, rect.height);
+      }
+      // Repaint synchronously after resize — do NOT rely on renderDirty + RAF.
+      // ResizeObserver fires after RAF in Chrome's rendering pipeline, so
+      // canvas.width = X clears pixels AFTER the RAF has already rendered.
+      // Without an immediate repaint here, the browser paints a blank canvas.
+      if (bufferCleared) {
+        renderCanvas();
+        renderDirty = false; // prevent redundant double-render on next RAF
       }
     };
 


### PR DESCRIPTION
## Problem

Clicking any node on [fast-draft.com](https://fast-draft.com) causes the canvas to go completely blank. Scene graph intact (Layers/Properties panels work), but nothing is painted.

## Root Cause

**ResizeObserver / RAF race condition** when the Properties panel opens after click:

1. `pointerup` → `renderDirty=true` → `updatePropertiesPanel()` adds `.visible` to props panel
2. RAF fires → renders → `renderDirty=false`
3. ResizeObserver fires (wrapper width changed by ~1px) → `canvas.width = newW` **clears pixel buffer** (HTML5 spec)
4. `renderDirty = true` set but browser composites the blank canvas before next RAF

## Fix

`resizeCanvas()` now calls `renderCanvas()` **synchronously** after `canvas.width/height` assignment, instead of relying on `renderDirty` + next RAF tick.

## Changes

- `site/playground.js` — synchronous repaint after resize
- `docs/LESSONS.md` — new lesson on ResizeObserver/RAF race
- `docs/CHANGELOG.md` — v0.10.116 entry

## Testing

- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace`