### PR TITLE
infra(site): auto cache-bust deploy pipeline + no-cache headers

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,12 @@ jobs:
             echo "Copied Pages Functions to site/"
           fi
 
+      - name: Auto-bust cache (replace ?v=X.Y.Z with git SHA)
+        run: |
+          SHA=$(git rev-parse --short=7 HEAD)
+          sed -i "s/?v=[0-9.]*/?v=$SHA/g" site/index.html
+          echo "Cache-bust: ?v=$SHA"
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.117 — Auto Cache-Bust Deploy Pipeline (DX)
+
+- **INFRA (DX)**: `pages.yml` auto-bust step — replaces `?v=X.Y.Z` query strings in `index.html` with `?v=<7-char-git-sha>` before deploying; every deploy produces unique asset URLs, eliminating stale browser cache forever; no manual version bumps needed
+- **INFRA (DX)**: `site/_headers` — added `Cache-Control: no-cache` for `/*.js` and `/*.css` files; browsers always revalidate (304 if unchanged), matching the existing WASM caching rule; belt-and-suspenders defense against stale assets
+- **FIX**: Bumped `playground.js?v=0.11.4` → `?v=0.11.5` and `style.css?v=0.11.3` → `?v=0.11.5` in `index.html` — previous deploy of v0.10.116 fix was invisible to users because the query string wasn't updated, causing browsers to serve 4-hour-cached stale JS
+
 ### v0.10.116 — Fix Canvas Blank After Clicking a Node (R6.9)
 
 - **FIX (R6.9)**: Canvas no longer goes blank after clicking a node — root cause: ResizeObserver/RAF race condition; clicking a node opens the Properties panel (`.visible`), changing wrapper layout → ResizeObserver fires `resizeCanvas()` → `canvas.width = newW` clears pixel buffer (HTML5 spec); the RAF loop already consumed `renderDirty=true` earlier in the same frame, so the cleared canvas was composited blank; fix: `resizeCanvas()` now calls `renderCanvas()` synchronously after clearing the buffer instead of relying on `renderDirty` + next RAF tick

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -33,6 +33,7 @@ Engineering lessons discovered through building FD.
   spatial-index, hit-test, stale, move → L391-403 (Spatial Index Must Be Rebuilt After Bounds Mutation)
   hover, click, press, pointer-down    → L405-417 (Pointer Down Must Not Set Hover State)
   resize-observer, raf, canvas-blank, click → L419-431 (ResizeObserver Must Repaint Synchronously)
+  deploy, cache-bust, stale, cdn, browser → L433-445 (Deploy Without Cache-Bust = Invisible Fix)
 -->
 
 
@@ -409,3 +410,16 @@ Browser subagents inherit the full parent conversation context. When context exc
 **Fix**: Call `renderCanvas()` synchronously at the end of `resizeCanvas()` when the buffer was cleared, instead of relying on `renderDirty` + RAF. Set `renderDirty = false` to prevent a redundant double-render on the next RAF tick.
 
 **Rule**: **Never rely on RAF `renderDirty` flags after `canvas.width/height` assignment.** The HTML5 spec clears the entire pixel buffer on any dimension assignment. Since ResizeObserver callbacks fire after RAF in Chrome's rendering pipeline, the cleared canvas will be composited before the next RAF can repaint. Always repaint synchronously after clearing.
+
+---
+
+## Deploy Without Cache-Bust = Invisible Fix
+
+**Date**: 2026-03-12
+**Context**: v0.10.116 deployed a critical canvas fix to Cloudflare Pages. CDN had the new `playground.js`, but users still saw the bug. `pages.yml` even purges the CF CDN cache — yet the fix was invisible.
+
+**Root cause**: `index.html` loads `playground.js?v=0.11.4`. The `?v=` query string wasn't bumped. Cloudflare's default `Cache-Control: public, max-age=14400` (4 hours) caused browsers to serve stale JS. The CDN purge only clears Cloudflare's edge cache — it cannot purge individual browser caches. The query string acts as the real cache key.
+
+**Fix**: (1) Bumped `?v=0.11.5` immediately. (2) Added `pages.yml` auto-bust step that replaces `?v=X.Y.Z` with `?v=<git-sha>` before every deploy. (3) Added `Cache-Control: no-cache` for `/*.js` and `/*.css` in `_headers` as belt-and-suspenders.
+
+**Rule**: **Every site deploy must produce unique asset URLs.** Content-hash or git-SHA query strings are the only reliable way to invalidate browser caches. CDN purge alone is insufficient — browsers own their cache independently. Automate this in CI; never rely on manual version bumps.

--- a/site/_headers
+++ b/site/_headers
@@ -4,6 +4,13 @@
 /wasm/*
   Cache-Control: no-cache
 
+# JS/CSS — also not content-hashed. Always revalidate so deploys
+# take effect immediately instead of waiting for max-age expiry.
+/*.js
+  Cache-Control: no-cache
+/*.css
+  Cache-Control: no-cache
+
 # All pages — security headers
 /*
   X-Content-Type-Options: nosniff

--- a/site/index.html
+++ b/site/index.html
@@ -17,7 +17,7 @@
   <!-- Preload WASM for instant playground -->
   <link rel="modulepreload" href="./wasm/fd_wasm.js" />
   <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
-  <link rel="stylesheet" href="style.css?v=0.11.3" />
+  <link rel="stylesheet" href="style.css?v=0.11.5" />
 
 </head>
 <body>
@@ -449,7 +449,7 @@
     </div>
   </footer>
 
-  <script type="module" src="playground.js?v=0.11.4"></script>
+  <script type="module" src="playground.js?v=0.11.5"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn').addEventListener('click', function() {


### PR DESCRIPTION
## Problem

v0.10.116 deployed a critical canvas fix, but users still saw the bug because `playground.js?v=0.11.4` query string wasn't bumped. Browser cached the old file for 4 hours.

## Changes

1. **Bump versions** — `playground.js?v=0.11.5`, `style.css?v=0.11.5` (immediate fix)
2. **Auto-bust in CI** — `pages.yml` step replaces `?v=X.Y.Z` with `?v=<git-sha>` before every deploy
3. **`no-cache` headers** — `site/_headers` adds `Cache-Control: no-cache` for `/*.js` and `/*.css`

## Files

- `site/index.html` — bumped query strings
- `site/_headers` — JS/CSS no-cache rules
- `.github/workflows/pages.yml` — auto-bust step
- `docs/CHANGELOG.md` — v0.10.117
- `docs/LESSONS.md` — cache-bust lesson

## Testing

- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo fmt --all -- --check`
- ✅ `cargo test --workspace`