### PR TITLE
docs(site): add documentation pages — language reference, shortcuts, changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,16 @@
 
 ## Completed Requirements
 
+### v0.10.119 — Documentation Pages (R6.15)
+
+- **SITE (R6.15)**: New `/docs/` section on fast-draft.com — three static pages served from `site/docs/`:
+  - **Language Reference** (`/docs/`) — complete `.fd` format guide: node types, styles, edges, animations, constraints, layout, annotations, colors, property aliases, imports; syntax-highlighted code examples with Atom One Dark palette
+  - **Keyboard Shortcuts** (`/docs/shortcuts.html`) — 8-section reference: tools, edit, transform, z-order, view, modifiers, floating toolbar, zen mode, mobile/touch
+  - **Changelog** (`/docs/changelog.html`) — curated release notes for recent versions with category tags (FEATURE, FIX, UX, PERF, INFRA, DOCS); links to full CHANGELOG.md on GitHub
+- **SITE (R6.15)**: Shared docs stylesheet (`site/docs/style.css`) — dark theme matching main site, fixed sidebar navigation with scroll-spy, responsive layout (collapsible sidebar on mobile), code blocks, tables, callouts, keyboard badges, prev/next page navigation
+- **SITE (R6.15)**: "Docs" link added to main site navbar and footer
+- **INFRA**: `site/_headers` — added `no-cache` for `/docs/*.html` and `/docs/*.css`
+
 ### v0.10.118 — Website Theme Polish Batch 1 (R6.5)
 
 - **UX (R6.5)**: Canvas now defaults to dark theme on marketing site — matches the dark `#0D1117` page background; calls `set_theme(true)` on WASM init + adds `.dark-canvas` class to wrapper; eliminates the jarring light/dark visual disconnect

--- a/site/_headers
+++ b/site/_headers
@@ -11,6 +11,12 @@
 /*.css
   Cache-Control: no-cache
 
+# Docs — always revalidate so updates appear immediately
+/docs/*.html
+  Cache-Control: no-cache
+/docs/*.css
+  Cache-Control: no-cache
+
 # All pages — security headers
 /*
   X-Content-Type-Options: nosniff

--- a/site/docs/changelog.html
+++ b/site/docs/changelog.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Changelog — Fast Draft Docs</title>
+  <meta name="description" content="What's new in Fast Draft — release notes, new features, bug fixes, and improvements." />
+  <meta property="og:title" content="Changelog — Fast Draft Docs" />
+  <meta property="og:description" content="What's new in Fast Draft — release notes, new features, bug fixes, and improvements." />
+  <link rel="canonical" href="https://fast-draft.com/docs/changelog.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <!-- ─── Nav ─── -->
+  <nav class="docs-nav">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">
+        <span class="logo-icon">⚡</span>
+        <span class="logo-text">Fast Draft</span>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/">Docs</a>
+        <a href="/docs/shortcuts.html">Shortcuts</a>
+        <a href="/docs/changelog.html" class="active">Changelog</a>
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install</a>
+      </div>
+      <button class="mobile-menu-btn" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open');this.classList.toggle('open')">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <!-- ─── Sidebar ─── -->
+    <aside class="docs-sidebar" id="docs-sidebar">
+      <div class="sidebar-section">
+        <div class="sidebar-title">Pages</div>
+        <ul class="sidebar-links">
+          <li><a href="/docs/" class="sidebar-page-link"><span class="page-icon">📖</span> Language Reference</a></li>
+          <li><a href="/docs/shortcuts.html" class="sidebar-page-link"><span class="page-icon">⌨️</span> Shortcuts</a></li>
+          <li><a href="/docs/changelog.html" class="sidebar-page-link active"><span class="page-icon">📋</span> Changelog</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-section">
+        <div class="sidebar-title">Recent Versions</div>
+        <ul class="sidebar-links">
+          <li><a href="#v0.10.118">v0.10.118</a></li>
+          <li><a href="#v0.10.117">v0.10.117</a></li>
+          <li><a href="#v0.10.116">v0.10.116</a></li>
+          <li><a href="#v0.10.115">v0.10.115</a></li>
+          <li><a href="#v0.10.114">v0.10.114</a></li>
+          <li><a href="#v0.10.112">v0.10.112</a></li>
+          <li><a href="#v0.10.111">v0.10.111</a></li>
+          <li><a href="#v0.10.108">v0.10.108</a></li>
+          <li><a href="#v0.10.107">v0.10.107</a></li>
+          <li><a href="#v0.10.103">v0.10.103</a></li>
+          <li><a href="#v0.10.100">v0.10.100</a></li>
+          <li><a href="#older">Older versions</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- ─── Content ─── -->
+    <main class="docs-content">
+      <h1>What's <span class="gradient-text">New</span></h1>
+      <p class="subtitle">Release notes for Fast Draft. Each version documents new features, bug fixes, and improvements across all platforms.</p>
+
+      <div class="callout callout-info">
+        <strong>ℹ️ Full changelog</strong> — for the complete changelog with 100+ versions, see <a href="https://github.com/khangnghiem/fast-draft/blob/main/docs/CHANGELOG.md" target="_blank">CHANGELOG.md on GitHub</a>.
+      </div>
+
+      <!-- v0.10.118 -->
+      <div class="changelog-version" id="v0.10.118">
+        <h3>v0.10.118 <span class="version-badge">Latest</span></h3>
+        <h4>Website Theme Polish — Batch 1</h4>
+        <ul>
+          <li><span class="changelog-tag tag-ux">UX</span> Canvas defaults to dark theme on marketing site — matches the dark page background</li>
+          <li><span class="changelog-tag tag-docs">SEO</span> Added OG social card for rich previews when shared on social platforms</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Accent evolved to purple→blue gradient (<code>#6C5CE7</code> → <code>#0A84FF</code>) across hero, CTAs, and cards</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Typography upgraded to Geist Sans + Geist Mono (Inter + JetBrains Mono as fallbacks)</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Feature card micro-interactions — icon bounces, gradient overlays, staggered scroll-reveal</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.117 -->
+      <div class="changelog-version" id="v0.10.117">
+        <h3>v0.10.117</h3>
+        <h4>Auto Cache-Bust Deploy Pipeline</h4>
+        <ul>
+          <li><span class="changelog-tag tag-infra">INFRA</span> <code>pages.yml</code> auto-bust — replaces <code>?v=X.Y.Z</code> with <code>?v=&lt;git-sha&gt;</code> before deploy; no manual version bumps needed</li>
+          <li><span class="changelog-tag tag-infra">INFRA</span> <code>site/_headers</code> — added <code>no-cache</code> for JS/CSS files; browsers always revalidate</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.116 -->
+      <div class="changelog-version" id="v0.10.116">
+        <h3>v0.10.116</h3>
+        <h4>Fix Canvas Blank After Clicking a Node</h4>
+        <ul>
+          <li><span class="changelog-tag tag-fix">FIX</span> Canvas no longer goes blank after clicking a node — ResizeObserver/RAF race condition fixed</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.115 -->
+      <div class="changelog-version" id="v0.10.115">
+        <h3>v0.10.115</h3>
+        <h4>Web Canvas Consistency Audit</h4>
+        <ul>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Inline text editing on double-click</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Frame tool shortcut (<kbd>F</kbd>)</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Arrow-key nudge (1px, Shift+10px)</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Zoom keyboard shortcuts (<kbd>⌘+</kbd> / <kbd>⌘-</kbd> / <kbd>⌘0</kbd>)</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Select All (<kbd>⌘A</kbd>)</li>
+          <li><span class="changelog-tag tag-fix">FIX</span> Context menu undo — all mutations now push undo snapshots</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.114 -->
+      <div class="changelog-version" id="v0.10.114">
+        <h3>v0.10.114</h3>
+        <h4>Fix Canvas Background Fill</h4>
+        <ul>
+          <li><span class="changelog-tag tag-fix">FIX</span> Canvas background no longer shifts when panning/zooming — background fill moved to identity transform space</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.112 -->
+      <div class="changelog-version" id="v0.10.112">
+        <h3>v0.10.112</h3>
+        <h4>Context Menu Enhancements</h4>
+        <ul>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Edge right-click with <code>hit_test_edge_at()</code> WASM API</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Lock/Unlock node — <code>locked</code> property parsed, emitted, and enforced</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Inline Rename — regex-replaces all <code>@oldId</code> references</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> Edge Delete and Reverse Direction</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Context menu 120ms fade-in animation</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.111 -->
+      <div class="changelog-version" id="v0.10.111">
+        <h3>v0.10.111</h3>
+        <h4>Copy/Paste + Context-Aware Right-Click Menu</h4>
+        <ul>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> <kbd>⌘C</kbd>/<kbd>⌘V</kbd>/<kbd>⌘X</kbd> Copy/Cut/Paste on canvas</li>
+          <li><span class="changelog-tag tag-feature">FEATURE</span> <kbd>⌘D</kbd> Duplicate shortcut</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Context-aware right-click — node menu vs. canvas menu</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Keyboard shortcut badges in context menu items</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.108 -->
+      <div class="changelog-version" id="v0.10.108">
+        <h3>v0.10.108</h3>
+        <h4>Fix Drawing Tools + Playground UI</h4>
+        <ul>
+          <li><span class="changelog-tag tag-fix">FIX</span> Drawing tools now work — shapes appear on canvas AND sync to code editor</li>
+          <li><span class="changelog-tag tag-fix">FIX</span> Layers panel no longer auto-collapses from stale localStorage</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Property panel inputs auto-select all text on focus</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.107 -->
+      <div class="changelog-version" id="v0.10.107">
+        <h3>v0.10.107</h3>
+        <h4>Fix Node Can Only Be Moved Once</h4>
+        <ul>
+          <li><span class="changelog-tag tag-fix">FIX</span> Nodes can now be moved repeatedly — spatial index rebuilt after move/resize</li>
+          <li><span class="changelog-tag tag-perf">PERF</span> Spatial index rebuild is O(N log N) but only once per pointer-up</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.103 -->
+      <div class="changelog-version" id="v0.10.103">
+        <h3>v0.10.103</h3>
+        <h4>Canvas Performance: Spatial Index + Bounds-Hash Skip</h4>
+        <ul>
+          <li><span class="changelog-tag tag-perf">PERF</span> O(log N) spatial index for hit testing</li>
+          <li><span class="changelog-tag tag-perf">PERF</span> Bounds-hash skip — identical layouts skip re-render</li>
+          <li><span class="changelog-tag tag-perf">PERF</span> Cached <code>CanvasTheme</code> — no per-frame allocation</li>
+          <li><span class="changelog-tag tag-perf">PERF</span> Bundled <code>handle_pointer_move()</code> — single WASM call</li>
+        </ul>
+      </div>
+
+      <!-- v0.10.100 -->
+      <div class="changelog-version" id="v0.10.100">
+        <h3>v0.10.100</h3>
+        <h4>Mobile Touch Interactions</h4>
+        <ul>
+          <li><span class="changelog-tag tag-fix">FIX</span> Canvas touch interactions work on mobile — single-finger tap, drag, draw</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Two-finger pan on mobile</li>
+          <li><span class="changelog-tag tag-ux">UX</span> Pinch-to-zoom centered on pinch midpoint</li>
+          <li><span class="changelog-tag tag-fix">FIX</span> Dirty-flag rendering eliminates node flashing</li>
+        </ul>
+      </div>
+
+      <!-- Older -->
+      <div class="changelog-version" id="older">
+        <h3>Older Versions</h3>
+        <p>For the complete changelog history (v0.10.0–v0.10.99 and earlier), see the <a href="https://github.com/khangnghiem/fast-draft/blob/main/docs/CHANGELOG.md" target="_blank">full CHANGELOG.md on GitHub</a>.</p>
+        <p>Key milestones:</p>
+        <ul>
+          <li><strong>v0.10.94</strong> — Apple HIG canvas toolbar, AI Touch + Renamify</li>
+          <li><strong>v0.10.85</strong> — Edge selection on canvas</li>
+          <li><strong>v0.10.80</strong> — Migrate to Cloudflare Pages</li>
+          <li><strong>v0.10.77</strong> — Apple HIG canvas parity</li>
+          <li><strong>v0.10.66</strong> — Interactive playground with tools and undo</li>
+          <li><strong>v0.10.65</strong> — Playground-first landing page</li>
+          <li><strong>v0.10.60</strong> — AI comprehensibility score, auto-comments</li>
+          <li><strong>v0.10.58</strong> — Mermaid import, detach snap</li>
+        </ul>
+      </div>
+
+      <!-- Prev/Next -->
+      <div class="page-nav">
+        <a href="/docs/shortcuts.html" class="page-nav-link">
+          <span class="page-nav-label">← Previous</span>
+          <span class="page-nav-title">Keyboard Shortcuts</span>
+        </a>
+        <div></div>
+      </div>
+    </main>
+  </div>
+
+  <!-- Footer -->
+  <footer class="docs-footer">
+    <div class="footer-links">
+      <a href="/">Home</a>
+      <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener">VS Code Marketplace</a>
+      <a href="https://github.com/khangnghiem/fast-draft/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+    </div>
+    <p>Made with Rust, WASM, and ❤️ by <a href="https://github.com/khangnghiem" target="_blank" rel="noopener">Khang Nghiêm</a></p>
+  </footer>
+
+  <script>
+    document.querySelector('.mobile-menu-btn')?.addEventListener('click', function() {
+      document.getElementById('docs-sidebar')?.classList.toggle('open');
+    });
+    const headings = document.querySelectorAll('h3[id]');
+    const sidebarLinks = document.querySelectorAll('.sidebar-links a[href^="#"]');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          sidebarLinks.forEach(l => l.classList.remove('active'));
+          const link = document.querySelector(`.sidebar-links a[href="#${entry.target.id}"]`);
+          if (link) link.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-80px 0px -70% 0px' });
+    headings.forEach(h => observer.observe(h));
+  </script>
+</body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FD Language Reference — Fast Draft Docs</title>
+  <meta name="description" content="Complete language reference for the .fd file format — node types, styles, edges, animations, constraints, layout, and annotations." />
+  <meta property="og:title" content="FD Language Reference — Fast Draft Docs" />
+  <meta property="og:description" content="Complete language reference for the .fd file format." />
+  <link rel="canonical" href="https://fast-draft.com/docs/" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <!-- ─── Nav ─── -->
+  <nav class="docs-nav">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">
+        <span class="logo-icon">⚡</span>
+        <span class="logo-text">Fast Draft</span>
+      </a>
+      <div class="nav-links">
+        <a href="/" >Home</a>
+        <a href="/docs/" class="active">Docs</a>
+        <a href="/docs/shortcuts.html">Shortcuts</a>
+        <a href="/docs/changelog.html">Changelog</a>
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install</a>
+      </div>
+      <button class="mobile-menu-btn" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open');this.classList.toggle('open')">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <!-- ─── Sidebar ─── -->
+    <aside class="docs-sidebar" id="docs-sidebar">
+      <div class="sidebar-section">
+        <div class="sidebar-title">Pages</div>
+        <ul class="sidebar-links">
+          <li><a href="/docs/" class="sidebar-page-link active"><span class="page-icon">📖</span> Language Reference</a></li>
+          <li><a href="/docs/shortcuts.html" class="sidebar-page-link"><span class="page-icon">⌨️</span> Shortcuts</a></li>
+          <li><a href="/docs/changelog.html" class="sidebar-page-link"><span class="page-icon">📋</span> Changelog</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-section">
+        <div class="sidebar-title">Reference</div>
+        <ul class="sidebar-links">
+          <li><a href="#getting-started">Getting Started</a></li>
+          <li><a href="#node-types">Node Types</a></li>
+          <li class="nested"><a href="#rect">Rect</a></li>
+          <li class="nested"><a href="#ellipse">Ellipse</a></li>
+          <li class="nested"><a href="#text">Text</a></li>
+          <li class="nested"><a href="#group">Group</a></li>
+          <li class="nested"><a href="#frame">Frame</a></li>
+          <li class="nested"><a href="#path">Path</a></li>
+          <li class="nested"><a href="#generic">Generic</a></li>
+          <li><a href="#styles">Styles</a></li>
+          <li><a href="#edges">Edges</a></li>
+          <li><a href="#animations">Animations</a></li>
+          <li><a href="#constraints">Constraints</a></li>
+          <li><a href="#layout">Layout</a></li>
+          <li><a href="#annotations">Annotations</a></li>
+          <li><a href="#colors">Colors</a></li>
+          <li><a href="#property-aliases">Property Aliases</a></li>
+          <li><a href="#imports">Imports</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- ─── Content ─── -->
+    <main class="docs-content">
+      <h1>FD Language <span class="gradient-text">Reference</span></h1>
+      <p class="subtitle">Complete guide to the <code>.fd</code> file format — a human- and AI-readable text DSL for 2D graphics, layout, and animation.</p>
+
+      <!-- Getting Started -->
+      <h2 id="getting-started">Getting Started</h2>
+      <p>An <code>.fd</code> file describes a 2D design using plain text. Every visual element is a <strong>node</strong> with an optional <code>@id</code>, properties (fill, size, font), and optional children.</p>
+
+      <div class="callout callout-tip">
+        <strong>💡 Try it live</strong> — open the <a href="/">playground</a> on fast-draft.com or install the <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank">VS Code extension</a>.
+      </div>
+
+      <p>Here's a complete card component in 20 lines:</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-comment"># A card with hover animation</span>
+
+<span class="hl-keyword">style</span> <span class="hl-id">accent</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-keyword">frame</span> <span class="hl-id">@card</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">layout:</span> column gap=<span class="hl-number">16</span> pad=<span class="hl-number">24</span>
+  <span class="hl-prop">bg:</span> <span class="hl-color">#FFF</span> corner=<span class="hl-number">12</span> shadow=(<span class="hl-number">0</span>,<span class="hl-number">4</span>,<span class="hl-number">20</span>,<span class="hl-color">#0002</span>)
+
+  <span class="hl-keyword">text</span> <span class="hl-id">@title</span> <span class="hl-string">"Hello World"</span> <span class="hl-punct">{</span>
+    <span class="hl-prop">font:</span> <span class="hl-string">"Inter"</span> <span class="hl-number">600</span> <span class="hl-number">24</span>
+    <span class="hl-prop">fill:</span> <span class="hl-color">#1A1A2E</span>
+  <span class="hl-punct">}</span>
+
+  <span class="hl-keyword">rect</span> <span class="hl-id">@button</span> <span class="hl-punct">{</span>
+    <span class="hl-prop">w:</span> <span class="hl-number">200</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+    <span class="hl-prop">corner:</span> <span class="hl-number">10</span>
+    <span class="hl-prop">use:</span> accent
+    <span class="hl-keyword">when</span> <span class="hl-trigger">:hover</span> <span class="hl-punct">{</span> <span class="hl-prop">fill:</span> <span class="hl-color">#5A4BD1</span>  <span class="hl-prop">scale:</span> <span class="hl-number">1.02</span>  <span class="hl-prop">ease:</span> spring <span class="hl-number">300</span>ms <span class="hl-punct">}</span>
+  <span class="hl-punct">}</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-id">@card</span> -> <span class="hl-prop">center_in:</span> canvas</code></pre>
+      </div>
+
+      <!-- Node Types -->
+      <h2 id="node-types">Node Types</h2>
+      <p>Every visual element is a node. Nodes have an optional <code>@id</code> (semantic name) and visual properties.</p>
+
+      <h3 id="rect">rect</h3>
+      <p>A rectangle with optional corner radius, fill, and stroke.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">rect</span> <span class="hl-id">@login_btn</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">280</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span>
+  <span class="hl-prop">stroke:</span> <span class="hl-color">#333</span> <span class="hl-number">2</span>
+  <span class="hl-prop">corner:</span> <span class="hl-number">10</span>
+  <span class="hl-prop">opacity:</span> <span class="hl-number">0.9</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <h3 id="ellipse">ellipse</h3>
+      <p>An ellipse (or circle when <code>w</code> equals <code>h</code>).</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">ellipse</span> <span class="hl-id">@avatar</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">64</span> <span class="hl-prop">h:</span> <span class="hl-number">64</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#0A84FF</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <h3 id="text">text</h3>
+      <p>A text element with inline content. Supports font family, weight, size, and alignment.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">text</span> <span class="hl-id">@heading</span> <span class="hl-string">"Dashboard"</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">font:</span> <span class="hl-string">"Inter"</span> <span class="hl-number">700</span> <span class="hl-number">28</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#1A1A2E</span>
+  <span class="hl-prop">align:</span> center middle
+<span class="hl-punct">}</span></code></pre>
+      </div>
+      <p>Font weight accepts numbers (<code>700</code>) or names (<code>bold</code>, <code>semibold</code>, <code>regular</code>, etc.).</p>
+
+      <h3 id="group">group</h3>
+      <p>A container that auto-sizes to fit its children. Supports managed layouts.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">group</span> <span class="hl-id">@sidebar</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">layout:</span> column gap=<span class="hl-number">8</span> pad=<span class="hl-number">16</span>
+
+  <span class="hl-keyword">text</span> <span class="hl-id">@nav_home</span> <span class="hl-string">"Home"</span> <span class="hl-punct">{</span> <span class="hl-prop">font:</span> <span class="hl-string">"Inter"</span> <span class="hl-number">500</span> <span class="hl-number">14</span> <span class="hl-punct">}</span>
+  <span class="hl-keyword">text</span> <span class="hl-id">@nav_settings</span> <span class="hl-string">"Settings"</span> <span class="hl-punct">{</span> <span class="hl-prop">font:</span> <span class="hl-string">"Inter"</span> <span class="hl-number">500</span> <span class="hl-number">14</span> <span class="hl-punct">}</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <h3 id="frame">frame</h3>
+      <p>Like a group but with declared dimensions. Can optionally clip children to its bounds.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">frame</span> <span class="hl-id">@card</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">320</span> <span class="hl-prop">h:</span> <span class="hl-number">200</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#FFF</span>
+  <span class="hl-prop">corner:</span> <span class="hl-number">12</span>
+  <span class="hl-prop">clip:</span> true
+  <span class="hl-prop">padding:</span> <span class="hl-number">16</span>
+  <span class="hl-prop">layout:</span> column gap=<span class="hl-number">12</span>
+
+  <span class="hl-comment"># Children go here</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@banner</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">288</span> <span class="hl-prop">h:</span> <span class="hl-number">80</span> <span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span> <span class="hl-punct">}</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <h3 id="path">path</h3>
+      <p>A freehand or bezier path using SVG-like <code>d:</code> commands.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">path</span> <span class="hl-id">@arrow</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">d:</span> M <span class="hl-number">0</span> <span class="hl-number">0</span> L <span class="hl-number">100</span> <span class="hl-number">50</span> Q <span class="hl-number">120</span> <span class="hl-number">60</span> <span class="hl-number">140</span> <span class="hl-number">50</span> Z
+  <span class="hl-prop">stroke:</span> <span class="hl-color">#333</span> <span class="hl-number">2</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+      <p>Commands: <code>M</code> (move to), <code>L</code> (line to), <code>Q</code> (quadratic curve), <code>C</code> (cubic curve), <code>Z</code> (close).</p>
+
+      <h3 id="generic">generic</h3>
+      <p>A node without a shape type — useful for spec-only requirements and wireframing.</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-id">@login_btn</span> <span class="hl-punct">{</span>
+  <span class="hl-keyword">spec</span> <span class="hl-punct">{</span>
+    <span class="hl-string">"Primary CTA — triggers login API call"</span>
+    <span class="hl-prop">accept:</span> <span class="hl-string">"disabled when fields empty"</span>
+    <span class="hl-prop">status:</span> in_progress
+  <span class="hl-punct">}</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#FFFFFF</span>
+  <span class="hl-prop">corner:</span> <span class="hl-number">8</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+      <p>On canvas, generic nodes render as dashed placeholder boxes. Add a keyword prefix (e.g., <code>rect @login_btn</code>) to upgrade to a concrete type.</p>
+
+      <!-- Styles -->
+      <h2 id="styles">Styles</h2>
+      <p>Named, reusable sets of visual properties. Reference them with <code>use:</code> on any node.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">style</span> <span class="hl-id">accent</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span>
+  <span class="hl-prop">corner:</span> <span class="hl-number">8</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-keyword">style</span> <span class="hl-id">body_text</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">font:</span> <span class="hl-string">"Inter"</span> <span class="hl-number">400</span> <span class="hl-number">14</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#333</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-keyword">rect</span> <span class="hl-id">@button</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">200</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+  <span class="hl-prop">use:</span> accent
+<span class="hl-punct">}</span>
+
+<span class="hl-keyword">text</span> <span class="hl-id">@desc</span> <span class="hl-string">"Overview"</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">use:</span> body_text
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <div class="callout callout-info">
+        <strong>ℹ️ Legacy support</strong> — the parser also accepts <code>theme</code> as a keyword. <code>style</code> is the canonical form.
+      </div>
+
+      <!-- Edges -->
+      <h2 id="edges">Edges</h2>
+      <p>Visual connections between nodes — lines, curves, arrows, and labels for flowcharts and diagrams.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">edge</span> <span class="hl-id">@login_to_dashboard</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">from:</span> <span class="hl-id">@login_screen</span>
+  <span class="hl-prop">to:</span> <span class="hl-id">@dashboard</span>
+  <span class="hl-prop">label:</span> <span class="hl-string">"on success"</span>
+  <span class="hl-prop">stroke:</span> <span class="hl-color">#10B981</span> <span class="hl-number">2</span>
+  <span class="hl-prop">arrow:</span> end          <span class="hl-comment"># none | start | end | both</span>
+  <span class="hl-prop">curve:</span> smooth        <span class="hl-comment"># straight | smooth | step</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <h4>Edge properties</h4>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Property</th><th>Values</th><th>Default</th></tr></thead>
+          <tbody>
+            <tr><td><code>from:</code></td><td><code>@node_id</code> or <code>x y</code></td><td>—</td></tr>
+            <tr><td><code>to:</code></td><td><code>@node_id</code> or <code>x y</code></td><td>—</td></tr>
+            <tr><td><code>arrow:</code></td><td><code>none</code>, <code>start</code>, <code>end</code>, <code>both</code></td><td><code>none</code></td></tr>
+            <tr><td><code>curve:</code></td><td><code>straight</code>, <code>smooth</code>, <code>step</code></td><td><code>straight</code></td></tr>
+            <tr><td><code>label:</code></td><td>String</td><td>—</td></tr>
+            <tr><td><code>stroke:</code></td><td><code>#hex width</code></td><td><code>#888 1</code></td></tr>
+            <tr><td><code>flow:</code></td><td><code>pulse Nms</code>, <code>dash Nms</code></td><td>—</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h4>Flow animations</h4>
+      <p>Edges can have continuous flow effects:</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">edge</span> <span class="hl-id">@data_flow</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">from:</span> <span class="hl-id">@api</span>  <span class="hl-prop">to:</span> <span class="hl-id">@db</span>
+  <span class="hl-prop">flow:</span> pulse <span class="hl-number">800</span>ms    <span class="hl-comment"># traveling dot</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-keyword">edge</span> <span class="hl-id">@sync_line</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">from:</span> <span class="hl-id">@a</span>  <span class="hl-prop">to:</span> <span class="hl-id">@b</span>
+  <span class="hl-prop">flow:</span> dash <span class="hl-number">500</span>ms     <span class="hl-comment"># marching dashes</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <!-- Animations -->
+      <h2 id="animations">Animations</h2>
+      <p>Trigger-based animations with easing functions. Attach to any node or edge.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">rect</span> <span class="hl-id">@button</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">200</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+  <span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span>
+
+  <span class="hl-keyword">when</span> <span class="hl-trigger">:hover</span> <span class="hl-punct">{</span>
+    <span class="hl-prop">fill:</span> <span class="hl-color">#5A4BD1</span>
+    <span class="hl-prop">scale:</span> <span class="hl-number">1.05</span>
+    <span class="hl-prop">ease:</span> spring <span class="hl-number">300</span>ms
+  <span class="hl-punct">}</span>
+
+  <span class="hl-keyword">when</span> <span class="hl-trigger">:press</span> <span class="hl-punct">{</span>
+    <span class="hl-prop">scale:</span> <span class="hl-number">0.95</span>
+    <span class="hl-prop">ease:</span> ease_out <span class="hl-number">150</span>ms
+  <span class="hl-punct">}</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Trigger</th><th>Default Duration</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>:hover</code></td><td>300ms</td><td>Cursor enters the node</td></tr>
+            <tr><td><code>:press</code></td><td>150ms</td><td>Pointer is pressed on the node</td></tr>
+            <tr><td><code>:enter</code></td><td>500ms</td><td>Node enters the viewport</td></tr>
+            <tr><td><code>:custom</code></td><td>300ms</td><td>Any custom trigger name</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h4>Animatable properties</h4>
+      <p><code>fill</code>, <code>opacity</code>, <code>scale</code>, <code>rotate</code>, <code>x</code>, <code>y</code></p>
+
+      <h4>Easing functions</h4>
+      <p><code>linear</code>, <code>ease_in</code>, <code>ease_out</code>, <code>ease_in_out</code>, <code>spring</code></p>
+
+      <!-- Constraints -->
+      <h2 id="constraints">Constraints</h2>
+      <p>Position nodes relative to other nodes or the canvas. Use constraints over absolute coordinates.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-comment"># Center in the canvas</span>
+<span class="hl-id">@card</span> -> <span class="hl-prop">center_in:</span> canvas
+
+<span class="hl-comment"># Center inside another node</span>
+<span class="hl-id">@label</span> -> <span class="hl-prop">center_in:</span> <span class="hl-id">@card</span>
+
+<span class="hl-comment"># Offset from a reference node</span>
+<span class="hl-id">@tooltip</span> -> <span class="hl-prop">offset:</span> <span class="hl-id">@button</span> <span class="hl-number">0</span>, <span class="hl-number">-40</span>
+
+<span class="hl-comment"># Fill parent with 16px padding</span>
+<span class="hl-id">@bg</span> -> <span class="hl-prop">fill_parent:</span> <span class="hl-number">16</span></code></pre>
+      </div>
+
+      <p>For absolute positioning (e.g., after dragging), use inline <code>x:</code> / <code>y:</code>:</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">rect</span> <span class="hl-id">@box</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">x:</span> <span class="hl-number">100</span>  <span class="hl-prop">y:</span> <span class="hl-number">200</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">50</span>   <span class="hl-prop">h:</span> <span class="hl-number">50</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <!-- Layout -->
+      <h2 id="layout">Layout</h2>
+      <p>Groups and frames support managed layouts for automatic child positioning.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-comment"># Vertical stack</span>
+<span class="hl-keyword">group</span> <span class="hl-id">@stack</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">layout:</span> column gap=<span class="hl-number">12</span> pad=<span class="hl-number">16</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@a</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">100</span> <span class="hl-prop">h:</span> <span class="hl-number">40</span> <span class="hl-punct">}</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@b</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">100</span> <span class="hl-prop">h:</span> <span class="hl-number">40</span> <span class="hl-punct">}</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-comment"># Horizontal row</span>
+<span class="hl-keyword">group</span> <span class="hl-id">@row</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">layout:</span> row gap=<span class="hl-number">8</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@c</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">60</span> <span class="hl-prop">h:</span> <span class="hl-number">60</span> <span class="hl-punct">}</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@d</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">60</span> <span class="hl-prop">h:</span> <span class="hl-number">60</span> <span class="hl-punct">}</span>
+<span class="hl-punct">}</span>
+
+<span class="hl-comment"># Grid layout</span>
+<span class="hl-keyword">group</span> <span class="hl-id">@grid</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">layout:</span> grid cols=<span class="hl-number">3</span> gap=<span class="hl-number">8</span> pad=<span class="hl-number">12</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@e</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">50</span> <span class="hl-prop">h:</span> <span class="hl-number">50</span> <span class="hl-punct">}</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@f</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">50</span> <span class="hl-prop">h:</span> <span class="hl-number">50</span> <span class="hl-punct">}</span>
+  <span class="hl-keyword">rect</span> <span class="hl-id">@g</span> <span class="hl-punct">{</span> <span class="hl-prop">w:</span> <span class="hl-number">50</span> <span class="hl-prop">h:</span> <span class="hl-number">50</span> <span class="hl-punct">}</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <!-- Annotations -->
+      <h2 id="annotations">Annotations</h2>
+      <p>Structured metadata attached to nodes via <code>spec</code> blocks. Unlike <code># comments</code>, annotations are parsed, stored in the scene graph, and survive round-trips.</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">rect</span> <span class="hl-id">@login_btn</span> <span class="hl-punct">{</span>
+  <span class="hl-keyword">spec</span> <span class="hl-punct">{</span>
+    <span class="hl-string">"Primary CTA — triggers login API call"</span>
+    <span class="hl-prop">accept:</span> <span class="hl-string">"disabled state when fields empty"</span>
+    <span class="hl-prop">accept:</span> <span class="hl-string">"loading spinner during auth"</span>
+    <span class="hl-prop">status:</span> in_progress
+    <span class="hl-prop">priority:</span> high
+    <span class="hl-prop">tag:</span> auth, mvp
+  <span class="hl-punct">}</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">280</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Syntax</th><th>Kind</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td><code>"text"</code></td><td>Description</td><td>What this node is/does</td></tr>
+            <tr><td><code>accept: "text"</code></td><td>Accept</td><td>Acceptance criterion (can repeat)</td></tr>
+            <tr><td><code>status: value</code></td><td>Status</td><td><code>draft</code>, <code>in_progress</code>, <code>done</code></td></tr>
+            <tr><td><code>priority: value</code></td><td>Priority</td><td><code>high</code>, <code>medium</code>, <code>low</code></td></tr>
+            <tr><td><code>tag: value</code></td><td>Tag</td><td>Categorization labels</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>Inline form (single description):</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">rect</span> <span class="hl-id">@btn</span> <span class="hl-punct">{</span>
+  <span class="hl-keyword">spec</span> <span class="hl-string">"Primary action button"</span>
+  <span class="hl-prop">w:</span> <span class="hl-number">200</span> <span class="hl-prop">h:</span> <span class="hl-number">48</span>
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <!-- Colors -->
+      <h2 id="colors">Colors</h2>
+      <p>Hex format with optional alpha:</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-prop">fill:</span> <span class="hl-color">#6C5CE7</span>         <span class="hl-comment"># 6-digit hex</span>
+<span class="hl-prop">fill:</span> <span class="hl-color">#FFF</span>             <span class="hl-comment"># 3-digit shorthand</span>
+<span class="hl-prop">fill:</span> <span class="hl-color">#FF000080</span>        <span class="hl-comment"># 8-digit hex with alpha</span>
+<span class="hl-prop">fill:</span> <span class="hl-color">#0002</span>            <span class="hl-comment"># 4-digit with alpha</span></code></pre>
+      </div>
+
+      <h4>Named colors</h4>
+      <p>17 Tailwind palette colors are accepted by name:</p>
+      <p><code>red</code>, <code>orange</code>, <code>amber</code>, <code>yellow</code>, <code>lime</code>, <code>green</code>, <code>emerald</code>, <code>teal</code>, <code>cyan</code>, <code>sky</code>, <code>blue</code>, <code>indigo</code>, <code>violet</code>, <code>purple</code>, <code>fuchsia</code>, <code>pink</code>, <code>rose</code></p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-prop">fill:</span> purple
+<span class="hl-prop">fill:</span> emerald
+<span class="hl-prop">stroke:</span> rose <span class="hl-number">2</span></code></pre>
+      </div>
+
+      <h4>Background shorthand</h4>
+      <p>Combine fill, corner, and shadow in one line:</p>
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-prop">bg:</span> <span class="hl-color">#FFF</span> corner=<span class="hl-number">12</span> shadow=(<span class="hl-number">0</span>,<span class="hl-number">4</span>,<span class="hl-number">20</span>,<span class="hl-color">#0002</span>)</code></pre>
+      </div>
+
+      <!-- Property Aliases -->
+      <h2 id="property-aliases">Property Aliases</h2>
+      <p>Common CSS/Tailwind names are accepted for convenience. The emitter always outputs the canonical name.</p>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Alias</th><th>Canonical</th></tr></thead>
+          <tbody>
+            <tr><td><code>background:</code>, <code>color:</code></td><td><code>fill:</code></td></tr>
+            <tr><td><code>rounded:</code>, <code>radius:</code></td><td><code>corner:</code></td></tr>
+            <tr><td><code>border:</code></td><td><code>stroke:</code></td></tr>
+            <tr><td><code>apply:</code></td><td><code>use:</code></td></tr>
+            <tr><td><code>pad:</code></td><td><code>padding:</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p>Dimension units are optional — <code>w: 320px</code> is accepted, <code>px</code> is stripped.</p>
+
+      <!-- Imports -->
+      <h2 id="imports">Imports</h2>
+      <p>Reference styles and nodes from other <code>.fd</code> files:</p>
+
+      <div class="code-block">
+        <div class="code-block-header"><span>.fd</span></div>
+        <pre><code><span class="hl-keyword">import</span> <span class="hl-string">"components/buttons.fd"</span> <span class="hl-keyword">as</span> btn
+<span class="hl-keyword">import</span> <span class="hl-string">"shared/tokens.fd"</span> <span class="hl-keyword">as</span> tokens
+
+<span class="hl-keyword">rect</span> <span class="hl-id">@hero</span> <span class="hl-punct">{</span>
+  <span class="hl-prop">use:</span> tokens.accent
+<span class="hl-punct">}</span></code></pre>
+      </div>
+
+      <!-- Prev/Next -->
+      <div class="page-nav">
+        <div></div>
+        <a href="/docs/shortcuts.html" class="page-nav-link next">
+          <span class="page-nav-label">Next →</span>
+          <span class="page-nav-title">Keyboard Shortcuts</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <!-- Footer -->
+  <footer class="docs-footer">
+    <div class="footer-links">
+      <a href="/">Home</a>
+      <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener">VS Code Marketplace</a>
+      <a href="https://github.com/khangnghiem/fast-draft/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+    </div>
+    <p>Made with Rust, WASM, and ❤️ by <a href="https://github.com/khangnghiem" target="_blank" rel="noopener">Khang Nghiêm</a></p>
+  </footer>
+
+  <script>
+    // Mobile sidebar toggle
+    document.querySelector('.mobile-menu-btn')?.addEventListener('click', function() {
+      document.getElementById('docs-sidebar')?.classList.toggle('open');
+    });
+    // Active sidebar link highlight on scroll
+    const headings = document.querySelectorAll('h2[id], h3[id]');
+    const sidebarLinks = document.querySelectorAll('.sidebar-links a[href^="#"]');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          sidebarLinks.forEach(l => l.classList.remove('active'));
+          const link = document.querySelector(`.sidebar-links a[href="#${entry.target.id}"]`);
+          if (link) link.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-80px 0px -70% 0px' });
+    headings.forEach(h => observer.observe(h));
+  </script>
+</body>
+</html>

--- a/site/docs/shortcuts.html
+++ b/site/docs/shortcuts.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Keyboard Shortcuts — Fast Draft Docs</title>
+  <meta name="description" content="Complete keyboard shortcut reference for the Fast Draft canvas editor — tools, edit, transform, z-order, and modifier keys." />
+  <meta property="og:title" content="Keyboard Shortcuts — Fast Draft Docs" />
+  <meta property="og:description" content="Complete keyboard shortcut reference for the Fast Draft canvas editor." />
+  <link rel="canonical" href="https://fast-draft.com/docs/shortcuts.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <!-- ─── Nav ─── -->
+  <nav class="docs-nav">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">
+        <span class="logo-icon">⚡</span>
+        <span class="logo-text">Fast Draft</span>
+      </a>
+      <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/docs/">Docs</a>
+        <a href="/docs/shortcuts.html" class="active">Shortcuts</a>
+        <a href="/docs/changelog.html">Changelog</a>
+        <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install</a>
+      </div>
+      <button class="mobile-menu-btn" aria-label="Toggle menu" onclick="document.querySelector('.nav-links').classList.toggle('open');this.classList.toggle('open')">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+  </nav>
+
+  <div class="docs-layout">
+    <!-- ─── Sidebar ─── -->
+    <aside class="docs-sidebar" id="docs-sidebar">
+      <div class="sidebar-section">
+        <div class="sidebar-title">Pages</div>
+        <ul class="sidebar-links">
+          <li><a href="/docs/" class="sidebar-page-link"><span class="page-icon">📖</span> Language Reference</a></li>
+          <li><a href="/docs/shortcuts.html" class="sidebar-page-link active"><span class="page-icon">⌨️</span> Shortcuts</a></li>
+          <li><a href="/docs/changelog.html" class="sidebar-page-link"><span class="page-icon">📋</span> Changelog</a></li>
+        </ul>
+      </div>
+      <div class="sidebar-section">
+        <div class="sidebar-title">Sections</div>
+        <ul class="sidebar-links">
+          <li><a href="#tools">Tools</a></li>
+          <li><a href="#edit">Edit</a></li>
+          <li><a href="#transform">Transform</a></li>
+          <li><a href="#z-order">Z-Order</a></li>
+          <li><a href="#view">View</a></li>
+          <li><a href="#modifiers">Modifier Keys</a></li>
+          <li><a href="#floating-toolbar">Floating Toolbar</a></li>
+          <li><a href="#zen-mode">Zen Mode</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- ─── Content ─── -->
+    <main class="docs-content">
+      <h1>Keyboard <span class="gradient-text">Shortcuts</span></h1>
+      <p class="subtitle">Complete reference for canvas editor shortcuts. Works in both VS Code extension and the <a href="/">web playground</a>.</p>
+
+      <div class="callout callout-info">
+        <strong>ℹ️ Platform note</strong> — <kbd>⌘</kbd> on macOS = <kbd>Ctrl</kbd> on Windows/Linux. Shortcuts work when the canvas is focused (not the code editor).
+      </div>
+
+      <!-- Tools -->
+      <h2 id="tools">Tools</h2>
+      <p>Press once to activate. Press twice (<kbd>V</kbd><kbd>V</kbd>) to lock the tool (it stays active after drawing).</p>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Key</th><th>Tool</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>V</kbd></td><td>Select</td><td>Click, drag, marquee select, move, resize</td></tr>
+            <tr><td><kbd>R</kbd></td><td>Rectangle</td><td>Draw rects. +Shift = square</td></tr>
+            <tr><td><kbd>O</kbd></td><td>Ellipse</td><td>Draw ovals. +Shift = circle</td></tr>
+            <tr><td><kbd>T</kbd></td><td>Text</td><td>Click to place text, then type</td></tr>
+            <tr><td><kbd>A</kbd></td><td>Arrow</td><td>Draw connectors between nodes</td></tr>
+            <tr><td><kbd>P</kbd></td><td>Pen</td><td>Click/drag for free-form paths</td></tr>
+            <tr><td><kbd>E</kbd></td><td>Eraser</td><td>Click/swipe to erase nodes</td></tr>
+            <tr><td><kbd>F</kbd></td><td>Frame</td><td>Draw a container frame</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Edit -->
+      <h2 id="edit">Edit</h2>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>⌘</kbd><kbd>Z</kbd></td><td>Undo</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>⇧</kbd><kbd>Z</kbd></td><td>Redo</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>C</kbd></td><td>Copy selected node(s) as .fd text</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>V</kbd></td><td>Paste .fd text onto canvas</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>X</kbd></td><td>Cut (copy + delete)</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>D</kbd></td><td>Duplicate selected node(s)</td></tr>
+            <tr><td><kbd>⌫</kbd> / <kbd>Delete</kbd></td><td>Delete selected nodes or edges</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>A</kbd></td><td>Select all</td></tr>
+            <tr><td><kbd>Esc</kbd></td><td>Deselect / cancel drag / exit Zen</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Transform -->
+      <h2 id="transform">Transform</h2>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>↑</kbd><kbd>↓</kbd><kbd>←</kbd><kbd>→</kbd></td><td>Nudge 1px</td></tr>
+            <tr><td><kbd>⇧</kbd> + <kbd>Arrow</kbd></td><td>Nudge 10px</td></tr>
+            <tr><td><kbd>Shift</kbd> + drag</td><td>Constrain to horizontal or vertical axis</td></tr>
+            <tr><td><kbd>Shift</kbd> + draw Rect</td><td>Constrain to square</td></tr>
+            <tr><td><kbd>Shift</kbd> + draw Ellipse</td><td>Constrain to circle</td></tr>
+            <tr><td><kbd>Alt</kbd> + draw</td><td>Draw from center outward</td></tr>
+            <tr><td><kbd>Alt</kbd> + drag node</td><td>Duplicate and drag the clone</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Z-Order -->
+      <h2 id="z-order">Z-Order</h2>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>⌘</kbd><kbd>]</kbd></td><td>Bring Forward</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>[</kbd></td><td>Send Backward</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>⇧</kbd><kbd>]</kbd></td><td>Bring to Front</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>⇧</kbd><kbd>[</kbd></td><td>Send to Back</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>G</kbd></td><td>Group selected nodes</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>⇧</kbd><kbd>G</kbd></td><td>Ungroup</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- View -->
+      <h2 id="view">View</h2>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>⌘</kbd><kbd>+</kbd></td><td>Zoom in</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>-</kbd></td><td>Zoom out</td></tr>
+            <tr><td><kbd>⌘</kbd><kbd>0</kbd></td><td>Fit to content</td></tr>
+            <tr><td><kbd>Ctrl</kbd> + Scroll</td><td>Zoom (scroll wheel)</td></tr>
+            <tr><td><kbd>Space</kbd> + Drag</td><td>Pan canvas (hand tool)</td></tr>
+            <tr><td>Middle mouse + Drag</td><td>Pan canvas</td></tr>
+            <tr><td><kbd>D</kbd></td><td>Toggle light/dark theme</td></tr>
+            <tr><td><kbd>?</kbd></td><td>Show shortcut help overlay</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Modifier Keys -->
+      <h2 id="modifiers">Modifier Keys</h2>
+      <p>Holding a modifier key shows a cursor preview to indicate the available action:</p>
+
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Key</th><th>Cursor</th><th>Indicates</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>⌘</kbd> / <kbd>Ctrl</kbd></td><td>✋ Grab</td><td>Pan the canvas</td></tr>
+            <tr><td><kbd>Alt</kbd> / <kbd>⌥</kbd></td><td>📋 Copy</td><td>Alt+drag will duplicate</td></tr>
+            <tr><td><kbd>Ctrl</kbd> (macOS)</td><td>❌ Eraser</td><td>Ctrl+click will erase</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Style shortcuts -->
+      <h3>Style Shortcuts</h3>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Shortcut</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td><kbd>⌥</kbd><kbd>⌘</kbd><kbd>C</kbd></td><td>Copy style from selected node</td></tr>
+            <tr><td><kbd>⌥</kbd><kbd>⌘</kbd><kbd>V</kbd></td><td>Paste style onto selected node</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Floating Toolbar -->
+      <h2 id="floating-toolbar">Floating Toolbar</h2>
+      <p>The scroll-themed floating toolbar supports drag interactions:</p>
+      <ul>
+        <li><strong>Drag handle</strong> — grab the ornamental handles to reposition the toolbar</li>
+        <li><strong>Drag tool button to canvas</strong> — starts a "drag-to-create" gesture with ghost preview</li>
+        <li><strong>Hold <kbd>⌥</kbd> while dragging</strong> — snap to existing nodes and auto-create edges</li>
+        <li><strong>Double-click handle</strong> — snap toolbar to nearest edge</li>
+      </ul>
+
+      <!-- Zen Mode -->
+      <h2 id="zen-mode">Zen Mode</h2>
+      <p>Zen mode hides all UI chrome for a distraction-free canvas. Toggle with the 🧘 button or <kbd>Esc</kbd> to exit.</p>
+      <ul>
+        <li>In Zen mode, tools still work via keyboard shortcuts</li>
+        <li>The 🧘/✕ button remains visible for quick exit</li>
+        <li>Settings menu also has a Zen Mode toggle</li>
+      </ul>
+
+      <!-- Mobile -->
+      <h2 id="mobile">Mobile / Touch</h2>
+      <div class="docs-table-wrap">
+        <table class="docs-table">
+          <thead><tr><th>Gesture</th><th>Action</th></tr></thead>
+          <tbody>
+            <tr><td>Single finger tap</td><td>Select node</td></tr>
+            <tr><td>Single finger drag</td><td>Move / draw</td></tr>
+            <tr><td>Two-finger drag</td><td>Pan canvas</td></tr>
+            <tr><td>Pinch</td><td>Zoom in/out</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Prev/Next -->
+      <div class="page-nav">
+        <a href="/docs/" class="page-nav-link">
+          <span class="page-nav-label">← Previous</span>
+          <span class="page-nav-title">Language Reference</span>
+        </a>
+        <a href="/docs/changelog.html" class="page-nav-link next">
+          <span class="page-nav-label">Next →</span>
+          <span class="page-nav-title">Changelog</span>
+        </a>
+      </div>
+    </main>
+  </div>
+
+  <!-- Footer -->
+  <footer class="docs-footer">
+    <div class="footer-links">
+      <a href="/">Home</a>
+      <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener">VS Code Marketplace</a>
+      <a href="https://github.com/khangnghiem/fast-draft/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+    </div>
+    <p>Made with Rust, WASM, and ❤️ by <a href="https://github.com/khangnghiem" target="_blank" rel="noopener">Khang Nghiêm</a></p>
+  </footer>
+
+  <script>
+    document.querySelector('.mobile-menu-btn')?.addEventListener('click', function() {
+      document.getElementById('docs-sidebar')?.classList.toggle('open');
+    });
+    const headings = document.querySelectorAll('h2[id], h3[id]');
+    const sidebarLinks = document.querySelectorAll('.sidebar-links a[href^="#"]');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          sidebarLinks.forEach(l => l.classList.remove('active'));
+          const link = document.querySelector(`.sidebar-links a[href="#${entry.target.id}"]`);
+          if (link) link.classList.add('active');
+        }
+      });
+    }, { rootMargin: '-80px 0px -70% 0px' });
+    headings.forEach(h => observer.observe(h));
+  </script>
+</body>
+</html>

--- a/site/docs/style.css
+++ b/site/docs/style.css
@@ -1,0 +1,569 @@
+/* ─── Docs Design Tokens (inherits from main site) ─── */
+:root {
+  --bg-primary: #0D1117;
+  --bg-secondary: #161B22;
+  --bg-card: #1C2128;
+  --bg-card-hover: #21262D;
+  --text-primary: #E6EDF3;
+  --text-secondary: #8B949E;
+  --text-muted: #484F58;
+  --accent: #007AFF;
+  --accent-hover: #0071EB;
+  --accent-glow: rgba(108, 92, 231, 0.2);
+  --border: #30363D;
+  --border-light: #21262D;
+  --success: #34C759;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'SF Pro Display', sans-serif;
+  --mono: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  --transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  --max-width: 1200px;
+  --sidebar-width: 240px;
+  --content-max: 820px;
+}
+
+/* ─── Reset ─── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; scroll-padding-top: 80px; }
+body {
+  font-family: var(--font);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+a { color: var(--accent); text-decoration: none; transition: color var(--transition); }
+a:hover { color: var(--accent-hover); }
+
+/* ─── Nav ─── */
+.docs-nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  background: rgba(13, 17, 23, 0.85);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: 1px solid var(--border);
+}
+.nav-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+.logo-icon { font-size: 1.4rem; }
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+.nav-links a {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  font-weight: 500;
+  transition: color var(--transition);
+}
+.nav-links a:hover { color: var(--text-primary); }
+.nav-links a.active { color: var(--text-primary); font-weight: 600; }
+.btn-nav {
+  background: var(--accent) !important;
+  color: #fff !important;
+  padding: 7px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 600 !important;
+  font-size: 0.85rem;
+  transition: background var(--transition), transform var(--transition) !important;
+}
+.btn-nav:hover {
+  background: var(--accent-hover) !important;
+  transform: translateY(-1px);
+}
+
+/* ─── Mobile menu ─── */
+.mobile-menu-btn {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+.mobile-menu-btn span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--text-primary);
+  border-radius: 2px;
+  transition: transform var(--transition), opacity var(--transition);
+}
+.mobile-menu-btn.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.mobile-menu-btn.open span:nth-child(2) { opacity: 0; }
+.mobile-menu-btn.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+
+/* ─── Layout ─── */
+.docs-layout {
+  display: flex;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding-top: 64px;
+  min-height: 100vh;
+}
+
+/* ─── Sidebar ─── */
+.docs-sidebar {
+  position: fixed;
+  top: 64px;
+  left: max(0px, calc((100vw - var(--max-width)) / 2));
+  width: var(--sidebar-width);
+  height: calc(100vh - 64px);
+  overflow-y: auto;
+  padding: 24px 16px 40px 24px;
+  border-right: 1px solid var(--border-light);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139,148,158,0.2) transparent;
+}
+.docs-sidebar::-webkit-scrollbar { width: 5px; }
+.docs-sidebar::-webkit-scrollbar-track { background: transparent; }
+.docs-sidebar::-webkit-scrollbar-thumb { background: rgba(139,148,158,0.2); border-radius: 3px; }
+.sidebar-section {
+  margin-bottom: 24px;
+}
+.sidebar-title {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  padding-left: 8px;
+}
+.sidebar-links {
+  list-style: none;
+}
+.sidebar-links li a {
+  display: block;
+  padding: 5px 8px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  transition: all 0.15s ease;
+  line-height: 1.5;
+}
+.sidebar-links li a:hover {
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+.sidebar-links li a.active {
+  color: var(--accent);
+  background: rgba(0, 122, 255, 0.08);
+  font-weight: 500;
+}
+.sidebar-links li.nested a {
+  padding-left: 20px;
+  font-size: 0.82rem;
+}
+.sidebar-page-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sidebar-page-link .page-icon {
+  font-size: 0.85rem;
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+/* ─── Content ─── */
+.docs-content {
+  margin-left: var(--sidebar-width);
+  padding: 32px 40px 80px;
+  max-width: var(--content-max);
+  width: 100%;
+}
+.docs-content h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin-bottom: 8px;
+  line-height: 1.2;
+}
+.docs-content .subtitle {
+  font-size: 1.05rem;
+  color: var(--text-secondary);
+  margin-bottom: 32px;
+  line-height: 1.6;
+}
+.gradient-text {
+  background: linear-gradient(135deg, #6C5CE7, #0A84FF);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.docs-content h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 48px;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-light);
+  letter-spacing: -0.01em;
+}
+.docs-content h3 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-top: 32px;
+  margin-bottom: 12px;
+  color: var(--text-primary);
+}
+.docs-content h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-top: 24px;
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+}
+.docs-content p {
+  margin-bottom: 16px;
+  color: var(--text-secondary);
+  line-height: 1.75;
+}
+.docs-content ul, .docs-content ol {
+  margin-bottom: 16px;
+  padding-left: 24px;
+  color: var(--text-secondary);
+}
+.docs-content li {
+  margin-bottom: 6px;
+  line-height: 1.6;
+}
+.docs-content strong { color: var(--text-primary); }
+
+/* ─── Inline code ─── */
+.docs-content code {
+  font-family: var(--mono);
+  background: var(--bg-card);
+  padding: 2px 7px;
+  border-radius: 5px;
+  font-size: 0.85em;
+  color: #E5C07B;
+  border: 1px solid var(--border-light);
+}
+
+/* ─── Code blocks ─── */
+.code-block {
+  position: relative;
+  margin: 16px 0 24px;
+  background: #1E2229;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: rgba(30, 34, 41, 0.9);
+  border-bottom: 1px solid var(--border-light);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.code-copy-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.code-copy-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+.code-block pre {
+  padding: 16px 18px;
+  overflow-x: auto;
+  margin: 0;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139,148,158,0.2) transparent;
+}
+.code-block pre::-webkit-scrollbar { height: 5px; }
+.code-block pre::-webkit-scrollbar-track { background: transparent; }
+.code-block pre::-webkit-scrollbar-thumb { background: rgba(139,148,158,0.2); border-radius: 3px; }
+.code-block code {
+  font-family: var(--mono);
+  font-size: 0.84rem;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: none;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+}
+
+/* Syntax highlighting (Atom One Dark) */
+.hl-keyword { color: #C678DD; }
+.hl-id { color: #E06C75; }
+.hl-prop { color: #D19A66; }
+.hl-string { color: #98C379; }
+.hl-number { color: #D19A66; }
+.hl-comment { color: #5C6370; font-style: italic; }
+.hl-color { color: #56B6C2; }
+.hl-trigger { color: #61AFEF; }
+.hl-punct { color: #ABB2BF; }
+
+/* ─── Tables ─── */
+.docs-table-wrap {
+  margin: 16px 0 24px;
+  overflow-x: auto;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+.docs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.docs-table th {
+  text-align: left;
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--border);
+}
+.docs-table td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border-light);
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+.docs-table tr:last-child td { border-bottom: none; }
+.docs-table tr:hover td { background: rgba(255, 255, 255, 0.02); }
+.docs-table code {
+  font-size: 0.82em;
+  white-space: nowrap;
+}
+
+/* ─── Callout / Tip blocks ─── */
+.callout {
+  margin: 20px 0 24px;
+  padding: 14px 18px;
+  border-radius: var(--radius-sm);
+  border-left: 3px solid;
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+.callout-tip {
+  background: rgba(52, 199, 89, 0.06);
+  border-color: var(--success);
+  color: var(--text-secondary);
+}
+.callout-tip strong { color: var(--success); }
+.callout-info {
+  background: rgba(0, 122, 255, 0.06);
+  border-color: var(--accent);
+  color: var(--text-secondary);
+}
+.callout-info strong { color: var(--accent); }
+.callout-warning {
+  background: rgba(255, 159, 10, 0.06);
+  border-color: #FF9F0A;
+  color: var(--text-secondary);
+}
+.callout-warning strong { color: #FF9F0A; }
+
+/* ─── Keyboard key badges ─── */
+kbd {
+  display: inline-block;
+  padding: 2px 7px;
+  font-family: var(--mono);
+  font-size: 0.78em;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  color: var(--text-primary);
+  line-height: 1.5;
+  vertical-align: middle;
+}
+
+/* ─── Version badges ─── */
+.version-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 4px;
+  background: rgba(0, 122, 255, 0.12);
+  color: var(--accent);
+  vertical-align: middle;
+  margin-left: 6px;
+}
+.version-badge.done {
+  background: rgba(52, 199, 89, 0.12);
+  color: var(--success);
+}
+
+/* ─── Changelog entries ─── */
+.changelog-version {
+  margin-top: 40px;
+  padding-bottom: 4px;
+}
+.changelog-version h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.changelog-version ul {
+  padding-left: 20px;
+}
+.changelog-tag {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 3px;
+  margin-right: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.tag-feature { background: rgba(108, 92, 231, 0.15); color: #6C5CE7; }
+.tag-fix { background: rgba(255, 69, 58, 0.12); color: #FF453A; }
+.tag-ux { background: rgba(52, 199, 89, 0.12); color: var(--success); }
+.tag-perf { background: rgba(255, 159, 10, 0.12); color: #FF9F0A; }
+.tag-docs { background: rgba(0, 122, 255, 0.12); color: var(--accent); }
+.tag-infra { background: rgba(139, 148, 158, 0.15); color: var(--text-secondary); }
+
+/* ─── Footer ─── */
+.docs-footer {
+  border-top: 1px solid var(--border-light);
+  padding: 32px 24px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+.docs-footer a { color: var(--text-secondary); }
+.docs-footer a:hover { color: var(--text-primary); }
+.footer-links {
+  display: flex;
+  gap: 24px;
+  justify-content: center;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+/* ─── Prev/Next navigation ─── */
+.page-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 64px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-light);
+}
+.page-nav-link {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  transition: all 0.2s ease;
+}
+.page-nav-link:hover {
+  border-color: var(--accent);
+  background: rgba(0, 122, 255, 0.04);
+}
+.page-nav-link.next { text-align: right; }
+.page-nav-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.page-nav-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+/* ─── Mobile responsive ─── */
+@media (max-width: 768px) {
+  .docs-sidebar {
+    display: none;
+    position: fixed;
+    top: 56px;
+    left: 0;
+    width: 280px;
+    height: calc(100vh - 56px);
+    background: var(--bg-primary);
+    z-index: 90;
+    border-right: 1px solid var(--border);
+  }
+  .docs-sidebar.open { display: block; }
+  .docs-content {
+    margin-left: 0;
+    padding: 24px 16px 60px;
+  }
+  .mobile-menu-btn { display: flex; }
+  .nav-links { display: none; }
+  .nav-links.open {
+    display: flex;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: rgba(13, 17, 23, 0.95);
+    backdrop-filter: blur(20px);
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border);
+    gap: 12px;
+  }
+  .docs-content h1 { font-size: 1.7rem; }
+  .docs-content h2 { font-size: 1.3rem; }
+  .page-nav { grid-template-columns: 1fr; }
+  .code-block pre { padding: 12px 14px; }
+}
+
+@media (max-width: 1024px) and (min-width: 769px) {
+  .docs-sidebar { width: 200px; }
+  .docs-content { margin-left: 200px; padding: 28px 28px 60px; }
+}
+
+/* ─── Scroll animation ─── */
+.animate-in {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
+}
+.animate-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/site/index.html
+++ b/site/index.html
@@ -36,6 +36,7 @@
         <a href="#features">Features</a>
         <a href="#benchmarks">Benchmarks</a>
         <a href="#architecture">Architecture</a>
+        <a href="/docs/">Docs</a>
 
         <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install Extension</a>
       </div>
@@ -445,6 +446,7 @@
         <span class="logo-text">Fast Draft</span>
       </div>
       <div class="footer-links">
+        <a href="/docs/">Docs</a>
         <a href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener">GitHub</a>
         <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener">VS Code Marketplace</a>
         <a href="https://github.com/khangnghiem/fast-draft/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>


### PR DESCRIPTION
## Summary

Adds a new `/docs/` section to fast-draft.com with three static documentation pages:

### New Pages

1. **Language Reference** (`/docs/`) — Complete `.fd` format guide with 12 sections: node types (rect, ellipse, text, group, frame, path, generic), styles, edges, animations, constraints, layout, annotations, colors, property aliases, and imports. All code examples use syntax-highlighted Atom One Dark palette.

2. **Keyboard Shortcuts** (`/docs/shortcuts.html`) — 8-section reference covering tools, edit, transform, z-order, view, modifier keys, floating toolbar, zen mode, and mobile/touch gestures.

3. **Changelog** (`/docs/changelog.html`) — Curated release notes for recent versions (v0.10.100–v0.10.118) with colored category tags (FEATURE, FIX, UX, PERF, INFRA, DOCS). Links to full CHANGELOG.md on GitHub.

### Infrastructure

- Shared docs stylesheet (`site/docs/style.css`) with dark theme matching main site, fixed sidebar with scroll-spy, responsive layout, code blocks, tables, callouts, `kbd` badges, prev/next page navigation
- "Docs" link added to main site navbar and footer 
- `site/_headers` updated with `no-cache` for `/docs/*.html` and `/docs/*.css`
- CHANGELOG.md updated with v0.10.119 entry

### Design

- Reuses main site's Apple HIG design tokens (dark theme, accent colors, typography)
- Fixed sidebar navigation with IntersectionObserver scroll-spy
- Mobile responsive: collapsible sidebar on screens < 768px
- Prev/Next page navigation at bottom of each page

### Files Changed (7)

- `site/docs/style.css` — NEW
- `site/docs/index.html` — NEW
- `site/docs/shortcuts.html` — NEW
- `site/docs/changelog.html` — NEW
- `site/index.html` — MODIFIED (Docs link in navbar + footer)
- `site/_headers` — MODIFIED (docs cache rules)
- `docs/CHANGELOG.md` — MODIFIED (v0.10.119 entry)