### PR TITLE
feat(site): theme polish batch 2 — animated hero skeleton, navbar theme toggle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.120 — Website Theme Polish Batch 2 (R6.5)
+
+- **UX (R6.5)**: Animated hero skeleton during WASM load — three CSS shapes (card, title bar, button) assemble from scattered positions with spring-curve easing; purple→blue gradient progress bar fills during load; status text transitions through "Loading engine…" → "Initializing runtime…" → "Parsing scene…" → "✓ Ready"; smooth 400ms fade-out when canvas is ready; `prefers-reduced-motion` fallback disables assembly animation
+- **UX (R6.5)**: Navbar canvas theme toggle — pill-style sun/moon toggle in the navigation bar; clicking switches the canvas between dark (default) and light themes via `fdCanvas.set_theme()`; toggles `.dark-canvas` class on wrapper for canvas chrome; slider animates with gradient knob between sun ☀️ and moon 🌙 positions; purple glow on hover
+- **SITE**: Changes in `site/style.css`, `site/index.html`, `site/playground.js`
+
 ### v0.10.119 — Documentation Pages (R6.15)
 
 - **SITE (R6.15)**: New `/docs/` section on fast-draft.com — three static pages served from `site/docs/`:

--- a/site/index.html
+++ b/site/index.html
@@ -38,6 +38,11 @@
         <a href="#architecture">Architecture</a>
         <a href="/docs/">Docs</a>
 
+        <button id="canvas-theme-toggle" class="theme-pill" title="Toggle canvas theme" aria-label="Toggle canvas theme">
+          <span class="theme-pill-icon theme-pill-sun">☀️</span>
+          <span class="theme-pill-icon theme-pill-moon">🌙</span>
+          <span class="theme-pill-slider"></span>
+        </button>
         <a href="https://marketplace.visualstudio.com/items?itemName=khangnghiem.fast-draft" target="_blank" rel="noopener" class="btn-nav">Install Extension</a>
       </div>
       <button id="mobile-menu-btn" class="mobile-menu-btn" aria-label="Toggle menu">
@@ -228,13 +233,13 @@
             </div>
             <div id="dimension-tooltip"></div>
             <div id="canvas-loading" class="canvas-loading">
-              <div class="skeleton-preview">
-                <div class="skeleton-shape skeleton-rect"></div>
-                <div class="skeleton-shape skeleton-circle"></div>
-                <div class="skeleton-shape skeleton-line"></div>
-                <div class="skeleton-shape skeleton-line skeleton-line-short"></div>
+              <div class="skeleton-scene">
+                <div class="skeleton-shape skeleton-card"></div>
+                <div class="skeleton-shape skeleton-title"></div>
+                <div class="skeleton-shape skeleton-btn-shape"></div>
               </div>
-              <p class="loading-text">Initializing WASM engine…</p>
+              <div class="loading-progress"><div class="loading-progress-bar"></div></div>
+              <p class="loading-text" id="loading-status">Loading engine…</p>
             </div>
             <div class="panel-resize-handle props-handle" id="props-resize"></div>
             <div class="panel-restore-strip layers-restore" id="layers-restore" title="Show layers panel"></div>

--- a/site/playground.js
+++ b/site/playground.js
@@ -2234,7 +2234,10 @@ async function initPlayground() {
 
   try {
     // Load WASM module
+    const statusEl = document.getElementById('loading-status');
+    if (statusEl) statusEl.textContent = 'Loading engine…';
     const wasm = await import('./wasm/fd_wasm.js');
+    if (statusEl) statusEl.textContent = 'Initializing runtime…';
     await wasm.default('./wasm/fd_wasm_bg.wasm');
 
     // Size the canvas
@@ -2280,7 +2283,9 @@ async function initPlayground() {
     // Dark theme to match marketing page
     fdCanvas.set_theme(true);
     wrapper.classList.add('dark-canvas');
+    if (statusEl) statusEl.textContent = 'Parsing scene…';
     fdCanvas.set_text(DEFAULT_FD);
+    if (statusEl) statusEl.textContent = '✓ Ready';
 
     // ── Create CodeMirror Editor ──────────────────────────────────────
     const fdLinter = linter((view) => {
@@ -2457,7 +2462,22 @@ async function initPlayground() {
     }, 100);
 
     // Hide loading overlay
-    loading.classList.add('hidden');
+    // Hide loading overlay with fade-out
+    loading.classList.add('fade-out');
+    setTimeout(() => loading.classList.add('hidden'), 400);
+
+    // ── Theme Toggle ─────────────────────────────────────────────────
+    const themeToggle = document.getElementById('canvas-theme-toggle');
+    if (themeToggle) {
+      themeToggle.addEventListener('click', () => {
+        isDark = !isDark;
+        if (fdCanvas) fdCanvas.set_theme(isDark);
+        wrapper.classList.toggle('dark-canvas', isDark);
+        themeToggle.classList.toggle('is-light', !isDark);
+        renderDirty = true;
+        renderCanvas();
+      });
+    }
 
     // ── Panel Resize Setup ───────────────────────────────────────────
     setupPanelResize(wrapper, resizeCanvas);

--- a/site/style.css
+++ b/site/style.css
@@ -190,6 +190,60 @@ code {
   transform: scale(0.95);
 }
 
+/* ─── Theme Pill Toggle ─── */
+.theme-pill {
+  position: relative;
+  width: 52px;
+  height: 28px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 14px;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  flex-shrink: 0;
+}
+.theme-pill:hover {
+  border-color: #6C5CE7;
+  box-shadow: 0 0 12px rgba(108, 92, 231, 0.25);
+}
+.theme-pill-icon {
+  position: absolute;
+  font-size: 12px;
+  line-height: 1;
+  z-index: 1;
+  transition: opacity 0.3s ease;
+}
+.theme-pill-sun {
+  left: 6px;
+  opacity: 0.4;
+}
+.theme-pill-moon {
+  right: 6px;
+  opacity: 1;
+}
+.theme-pill-slider {
+  position: absolute;
+  right: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6C5CE7, #0A84FF);
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+}
+.theme-pill.is-light .theme-pill-slider {
+  transform: translateX(-24px);
+}
+.theme-pill.is-light .theme-pill-sun {
+  opacity: 1;
+}
+.theme-pill.is-light .theme-pill-moon {
+  opacity: 0.4;
+}
+
 .btn-nav {
   background: var(--accent) !important;
   color: #fff !important;
@@ -1549,57 +1603,118 @@ code {
   justify-content: center;
   gap: 20px;
   background: var(--bg-card);
+  transition: opacity 0.4s ease;
+  z-index: 10;
+}
+.canvas-loading.fade-out {
+  opacity: 0;
+  pointer-events: none;
 }
 .canvas-loading.hidden { display: none; }
 
-.skeleton-preview {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-  width: 160px;
+.skeleton-scene {
+  position: relative;
+  width: 200px;
+  height: 120px;
 }
 .skeleton-shape {
+  position: absolute;
+  border-radius: var(--radius-sm);
   background: linear-gradient(90deg,
     var(--border) 25%,
     var(--bg-card-hover) 50%,
     var(--border) 75%
   );
   background-size: 200% 100%;
-  animation: skeleton-shimmer 1.5s ease-in-out infinite;
-  border-radius: var(--radius-sm);
+  animation: skeleton-shimmer 1.5s ease-in-out infinite,
+             skeleton-assemble 1s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
-.skeleton-rect {
-  width: 120px;
-  height: 60px;
+.skeleton-card {
+  width: 160px;
+  height: 100px;
+  left: 20px;
+  top: 10px;
   border-radius: var(--radius);
+  border: 1px solid var(--border);
+  transform: translateY(30px) scale(0.8);
+  opacity: 0;
+  animation-delay: 0s, 0.1s;
 }
-.skeleton-circle {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  animation-delay: 0.2s;
+.skeleton-title {
+  width: 100px;
+  height: 12px;
+  left: 40px;
+  top: 30px;
+  border-radius: 6px;
+  transform: translateX(-40px);
+  opacity: 0;
+  animation-delay: 0.2s, 0.3s;
 }
-.skeleton-line {
+.skeleton-btn-shape {
+  width: 80px;
+  height: 24px;
+  left: 60px;
+  top: 60px;
+  border-radius: 8px;
+  background: linear-gradient(90deg,
+    rgba(108, 92, 231, 0.3) 25%,
+    rgba(10, 132, 255, 0.3) 50%,
+    rgba(108, 92, 231, 0.3) 75%
+  );
+  background-size: 200% 100%;
+  transform: translateY(20px) scale(0.9);
+  opacity: 0;
+  animation-delay: 0.4s, 0.5s;
+}
+
+/* Progress bar */
+.loading-progress {
+  width: 120px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--border);
+  overflow: hidden;
+}
+.loading-progress-bar {
   width: 100%;
-  height: 10px;
-  border-radius: 5px;
-  animation-delay: 0.4s;
+  height: 100%;
+  background: linear-gradient(90deg, #6C5CE7, #0A84FF);
+  border-radius: 2px;
+  animation: progress-fill 2.5s ease-in-out;
 }
-.skeleton-line-short {
-  width: 70%;
-  animation-delay: 0.6s;
-}
+
 .loading-text {
   color: var(--text-muted);
   font-size: 0.8rem;
   font-weight: 500;
   letter-spacing: 0.02em;
+  transition: opacity 0.3s ease;
 }
 
 @keyframes skeleton-shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
+}
+@keyframes skeleton-assemble {
+  0% { /* initial values from inline transform */ }
+  100% { transform: translateY(0) translateX(0) scale(1); opacity: 1; }
+}
+@keyframes progress-fill {
+  0% { transform: translateX(-100%); }
+  80% { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shape {
+    animation: skeleton-shimmer 1.5s ease-in-out infinite;
+    opacity: 1;
+    transform: none;
+  }
+  .loading-progress-bar {
+    animation: none;
+    transform: none;
+  }
 }
 
 /* ─── Features ─── */


### PR DESCRIPTION
## Theme Polish Batch 2

Two medium-effort enhancements adding interactivity and polish:

### Changes
1. **Animated Hero Skeleton** — Shapes assemble from scattered positions during WASM load with spring-curve easing, purple→blue gradient progress bar, status text transitions ("Loading engine…" → "✓ Ready"), smooth 400ms fade-out, `prefers-reduced-motion` fallback
2. **Navbar Canvas Theme Toggle** — Pill-style sun/moon toggle switches canvas between dark (default) and light themes via `set_theme()`, gradient slider knob with purple hover glow

### Files Changed
- `site/style.css` — Theme pill styles, skeleton assembly animation, progress bar, reduced-motion
- `site/index.html` — Theme toggle button in navbar, enhanced skeleton scene
- `site/playground.js` — Status text updates, fade-out transition, theme toggle handler
- `docs/CHANGELOG.md` — v0.10.120 entry

### Testing
- ✅ `cargo check --workspace`
- ✅ `cargo clippy --workspace -- -D warnings`
- ✅ `cargo test --workspace`
- ✅ `cargo fmt --all -- --check`
- No Rust code changes — pure CSS/HTML/JS