### PR TITLE
fix(site): cache-bust WASM modulepreload/import paths

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           SHA=$(git rev-parse --short=7 HEAD)
           sed -i "s/?v=[0-9.]*/?v=$SHA/g" site/index.html
+          sed -i "s/?v=[0-9.]*/?v=$SHA/g" site/playground.js
           echo "Cache-bust: ?v=$SHA"
 
       - name: Deploy to Cloudflare Pages

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,13 @@
 
 ## Completed Requirements
 
+### v0.10.121 — Fix WASM Import Error on Chrome/Edge (R6.9)
+
+- **FIX (R6.9)**: Canvas no longer fails on Chrome with `WebAssembly.instantiate(): Import #0 "./fd_wasm_bg.js" "__wbg_instanceof_Window_ed49b2db8df90359": function import requires a callable` — root cause: stale `fd_wasm.js` glue file cached by browser while `fd_wasm_bg.wasm` was updated; the `modulepreload` link and dynamic `import()` call had no cache-busting `?v=` query strings, causing Chrome/Edge to serve mismatched JS+WASM pairs
+- **INFRA**: Added `?v=0.11.5` to all four WASM paths: `modulepreload` and `preload` in `index.html`, `import()` and `wasm.default()` in `playground.js`; these are auto-replaced with git SHA by `pages.yml` on every deploy
+- **INFRA**: Extended `pages.yml` auto-bust step to also `sed` `playground.js` (was only `index.html`); ensures WASM import paths get unique URLs on every deploy
+- **DOCS**: New LESSONS.md entry — "WASM Modulepreload Cache Mismatch Breaks Chrome/Edge"
+
 ### v0.10.120 — Website Theme Polish Batch 2 (R6.5)
 
 - **UX (R6.5)**: Animated hero skeleton during WASM load — three CSS shapes (card, title bar, button) assemble from scattered positions with spring-curve easing; purple→blue gradient progress bar fills during load; status text transitions through "Loading engine…" → "Initializing runtime…" → "Parsing scene…" → "✓ Ready"; smooth 400ms fade-out when canvas is ready; `prefers-reduced-motion` fallback disables assembly animation

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -34,6 +34,7 @@ Engineering lessons discovered through building FD.
   hover, click, press, pointer-down    → L405-417 (Pointer Down Must Not Set Hover State)
   resize-observer, raf, canvas-blank, click → L419-431 (ResizeObserver Must Repaint Synchronously)
   deploy, cache-bust, stale, cdn, browser → L433-445 (Deploy Without Cache-Bust = Invisible Fix)
+  wasm, modulepreload, import, cache, chrome → L447-459 (WASM Modulepreload Cache Mismatch)
 -->
 
 
@@ -423,3 +424,16 @@ Browser subagents inherit the full parent conversation context. When context exc
 **Fix**: (1) Bumped `?v=0.11.5` immediately. (2) Added `pages.yml` auto-bust step that replaces `?v=X.Y.Z` with `?v=<git-sha>` before every deploy. (3) Added `Cache-Control: no-cache` for `/*.js` and `/*.css` in `_headers` as belt-and-suspenders.
 
 **Rule**: **Every site deploy must produce unique asset URLs.** Content-hash or git-SHA query strings are the only reliable way to invalidate browser caches. CDN purge alone is insufficient — browsers own their cache independently. Automate this in CI; never rely on manual version bumps.
+
+---
+
+## WASM Modulepreload Cache Mismatch Breaks Chrome/Edge
+
+**Date**: 2026-03-12
+**Context**: Canvas broken on Chrome with `WebAssembly.instantiate(): Import #0 "./fd_wasm_bg.js" "__wbg_instanceof_Window_ed49b2db8df90359": function import requires a callable`. Very slow on Edge.
+
+**Root cause**: `index.html` had `<link rel="modulepreload" href="./wasm/fd_wasm.js" />` and `playground.js` had `import('./wasm/fd_wasm.js')` — neither with cache-busting `?v=` query strings. The `_headers` file specified `no-cache` for `/wasm/*`, but `modulepreload` and dynamic `import()` bypass that in some browsers, serving a stale JS glue file that's missing functions the newer WASM binary expects.
+
+**Fix**: Added `?v=0.11.5` to all four WASM paths (modulepreload, preload, import, init). Extended `pages.yml` auto-bust to also `sed` `playground.js`.
+
+**Rule**: **Cache-bust every resource loaded by `modulepreload`, `import()`, and `fetch()` — not just `<script src>`.** The `_headers` `no-cache` directive only affects `fetch()`-style loads; `modulepreload` has its own caching behavior in Chrome/Edge. All importable resources must have version-stamped URLs.

--- a/site/index.html
+++ b/site/index.html
@@ -19,8 +19,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-sans/style.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <!-- Preload WASM for instant playground -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm" as="fetch" crossorigin />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.5" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.5" as="fetch" crossorigin />
   <link rel="stylesheet" href="style.css?v=0.11.5" />
 
 </head>

--- a/site/playground.js
+++ b/site/playground.js
@@ -2236,9 +2236,9 @@ async function initPlayground() {
     // Load WASM module
     const statusEl = document.getElementById('loading-status');
     if (statusEl) statusEl.textContent = 'Loading engine…';
-    const wasm = await import('./wasm/fd_wasm.js');
+    const wasm = await import('./wasm/fd_wasm.js?v=0.11.5');
     if (statusEl) statusEl.textContent = 'Initializing runtime…';
-    await wasm.default('./wasm/fd_wasm_bg.wasm');
+    await wasm.default('./wasm/fd_wasm_bg.wasm?v=0.11.5');
 
     // Size the canvas
     const resizeCanvas = () => {


### PR DESCRIPTION
## Summary

Fixes Canvas broken on Chrome with `WebAssembly.instantiate(): Import #0 "./fd_wasm_bg.js" "__wbg_instanceof_Window_ed49b2db8df90359": function import requires a callable` error. Very slow on Edge.

## Root Cause

Cache mismatch: Chrome/Edge cached a stale `fd_wasm.js` while `fd_wasm_bg.wasm` was updated. The `modulepreload` and `import()` calls had no cache-busting `?v=` query strings.

## Changes

- `site/index.html`: `?v=0.11.5` on modulepreload/preload links
- `site/playground.js`: `?v=0.11.5` on import()/wasm.default()
- `pages.yml`: extended auto-bust sed to also cover playground.js
- `docs/LESSONS.md`: new lesson
- `docs/CHANGELOG.md`: v0.10.121 entry

## Testing

cargo check/clippy/test/fmt all pass. Local browser test OK. No Rust crate changes.