### PR TITLE
feat(site): playground 30-70 code/design split

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,12 @@
 
 ## Completed Requirements
 
+### v0.10.122 — Playground 30-70 Code/Design Split (R6.6)
+
+- **UX (R6.6)**: Default playground split changed from 40/60 to **30/70** — design canvas gets 70% of horizontal space, code editor 30%; gives the visual canvas more room by default while keeping code readable; grid-template-columns changed from `2fr auto 3fr` to `3fr auto 7fr`
+- **UX (R6.6)**: Minimum split fraction lowered from 25% to 15% — users can now drag the code panel narrower for even more canvas space; double-click handle resets to 30/70 (was 50/50)
+- **SITE**: Changes in `site/style.css`, `site/playground.js`
+
 ### v0.10.121 — Fix WASM Import Error on Chrome/Edge (R6.9)
 
 - **FIX (R6.9)**: Canvas no longer fails on Chrome with `WebAssembly.instantiate(): Import #0 "./fd_wasm_bg.js" "__wbg_instanceof_Window_ed49b2db8df90359": function import requires a callable` — root cause: stale `fd_wasm.js` glue file cached by browser while `fd_wasm_bg.wasm` was updated; the `modulepreload` link and dynamic `import()` call had no cache-busting `?v=` query strings, causing Chrome/Edge to serve mismatched JS+WASM pairs

--- a/site/playground.js
+++ b/site/playground.js
@@ -1328,7 +1328,7 @@ function setupSplitResize(container, resizeCanvas) {
   const handle = document.getElementById('split-resize');
   if (!handle || !container) return;
 
-  const MIN_FRAC = 0.25;
+  const MIN_FRAC = 0.15;
   const MAX_FRAC = 0.75;
 
   let dragging = false;
@@ -1360,7 +1360,7 @@ function setupSplitResize(container, resizeCanvas) {
   handle.addEventListener('pointerup', endDrag);
   handle.addEventListener('pointercancel', endDrag);
 
-  // Double-click to reset to 50/50
+  // Double-click to reset to default 30/70 split
   handle.addEventListener('dblclick', (e) => {
     e.preventDefault();
     container.style.removeProperty('--editor-width');

--- a/site/style.css
+++ b/site/style.css
@@ -544,7 +544,7 @@ code {
 
 .playground-split {
   display: grid;
-  grid-template-columns: var(--editor-width, 2fr) auto 3fr;
+  grid-template-columns: var(--editor-width, 3fr) auto 7fr;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   overflow: hidden;


### PR DESCRIPTION
## Summary

Changes the default playground split from 40/60 to **30/70** (code/design), giving the design canvas more screen real estate.

## Changes

- `site/style.css`: `grid-template-columns` from `2fr auto 3fr` → `3fr auto 7fr`
- `site/playground.js`: `MIN_FRAC` from 0.25 → 0.15, double-click reset comment updated to 30/70
- `docs/CHANGELOG.md`: v0.10.122 entry

## Testing

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅
- Site-only CSS/JS change — no WASM/Rust impact