### PR TITLE
feat(site): unified playground header bar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Completed Requirements
 
+### v0.10.123 — Unified Playground Header Bar (R6.6)
+
+- **UX (R6.6)**: Code and Design headers are now visually connected as one continuous frosted glass bar — both panels share unified `--header-bg` and `--header-border` CSS tokens; `::before` pseudo-element on the resize handle bridges the 6px gutter gap; removes the `.dark-theme #canvas-toolbar` override (now unnecessary); headers have matching `backdrop-filter: blur(20px) saturate(180%)` and 0.5px hairline border-bottom
+- **SITE**: Changes in `site/style.css`
+
 ### v0.10.122 — Playground 30-70 Code/Design Split (R6.6)
 
 - **UX (R6.6)**: Default playground split changed from 40/60 to **30/70** — design canvas gets 70% of horizontal space, code editor 30%; gives the visual canvas more room by default while keeping code readable; grid-template-columns changed from `2fr auto 3fr` to `3fr auto 7fr`

--- a/site/style.css
+++ b/site/style.css
@@ -551,6 +551,9 @@ code {
   background: var(--border);
   box-shadow: var(--shadow), var(--shadow-glow);
   min-height: 75vh;
+  /* Unified header: no gap color bleeding into the header row */
+  --header-bg: rgba(28, 28, 30, 0.88);
+  --header-border: rgba(255, 255, 255, 0.06);
 }
 
 /* ── Split Resize Handle ── */
@@ -565,6 +568,19 @@ code {
 .split-resize-handle:hover,
 .split-resize-handle.active {
   background: var(--accent);
+}
+/* Bridge the header gap — pseudo-element covers the handle's header zone */
+.split-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 42px; /* matches header height */
+  background: var(--header-bg, rgba(28, 28, 30, 0.88));
+  border-bottom: 0.5px solid var(--header-border, rgba(255, 255, 255, 0.06));
+  pointer-events: none;
+  z-index: 3;
 }
 .playground-editor {
   background: #282C34; /* Atom One Dark — always dark code mode */
@@ -587,7 +603,11 @@ code {
   padding: 10px 16px;
   height: 42px;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border);
+  /* Unified header — match Design toolbar's frosted glass */
+  background: var(--header-bg, rgba(28, 28, 30, 0.88));
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-bottom: 0.5px solid var(--header-border, rgba(255, 255, 255, 0.06));
   font-size: 0.8rem;
   font-weight: 600;
   color: var(--text-secondary);
@@ -632,17 +652,14 @@ code {
   padding: 10px 16px;
   height: 42px;
   box-sizing: border-box;
-  background: var(--fd-toolbar-bg, rgba(246,246,248,0.72));
+  /* Unified header — same frosted glass as Code header */
+  background: var(--header-bg, rgba(28, 28, 30, 0.88));
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
-  border-bottom: 0.5px solid var(--fd-toolbar-border, rgba(0,0,0,0.06));
+  border-bottom: 0.5px solid var(--header-border, rgba(255, 255, 255, 0.06));
   flex-shrink: 0;
   align-items: center;
   z-index: 10;
-}
-.dark-theme #canvas-toolbar {
-  --fd-toolbar-bg: rgba(28,28,30,0.72);
-  --fd-toolbar-border: rgba(255,255,255,0.06);
 }
 .tb-zone { display: flex; align-items: center; gap: 3px; }
 .tb-left { flex: 0 0 auto; }


### PR DESCRIPTION
## Summary

Unifies the Code and Design headers into one visually continuous frosted glass bar.

## Changes

- `site/style.css`: Both headers share `--header-bg` and `--header-border` CSS tokens; `::before` pseudo-element on resize handle bridges the 6px gutter gap; removed `.dark-theme #canvas-toolbar` override
- `docs/CHANGELOG.md`: v0.10.123 entry

## Testing

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --workspace` ✅
- CSS-only change — no JS/WASM impact