### PR TITLE
fix(fab): keep floating action bar visible during move drag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ## Completed Requirements
 
+### v0.10.126 — FAB Persistent During Drag (R6.6)
+
+- **UX (R6.6)**: Floating Action Bar (FAB) now stays visible and tracks the node during move drag — previously disappeared on pointerdown and only reappeared on pointerup; `updateFab(canvas)` added to the ~10fps render loop alongside `updatePropertiesPanel()`; CSS transitions (`left 0.08s ease, top 0.08s ease`) provide smooth tracking animation for free
+- **FIX (R6.6)**: Dead FAB-hide code on pointerdown — `document.getElementById('fab')` targeted nonexistent element (actual ID is `floating-action-bar`); fixed to correct ID and gated behind draw-gesture check (FAB only hides during draw/resize tools, not during select-tool move)
+- **PARITY (R6.6)**: VS Code extension `updateFloatingBar()` updated with same draw-gesture gate — `pointerIsDown` no longer unconditionally hides the FAB; `scheduleSideEffects()` now calls `updateFloatingBar()` + `updatePropertiesPanel()` at ~10fps for consistent tracking
+- **SITE**: Changes in `site/playground.js`
+- **EXTENSION**: Changes in `fd-vscode/webview/main.js`
+
 ### v0.10.125 — Fix Multi-Node Drag Double-Move (R3.16)
 
 - **FIX (R3.16)**: Selected parent+child nodes now move at the same speed when dragged together — root cause: `MoveNode` in `sync.rs` propagated dx/dy to **all** descendants' cached bounds; when both parent and child were selected and dragged, the child received the delta twice (once from its own `MoveNode` + once from the parent's descendant propagation); fix: new `apply_mutation_with_co_selected()` method accepts a slice of co-selected `NodeId`s and skips descendant propagation for nodes in that set; `CommandStack::execute_with_co_selected()` and `FdCanvas::apply_mutations()` wire the co-selected context through the pipeline

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1939,7 +1939,12 @@ function updateFloatingBar() {
   if (!fab || !fdCanvas) return;
 
   const selectedId = fdCanvas.get_selected_id();
-  if (!selectedId || pointerIsDown || inlineEditorActive) {
+  if (!selectedId || inlineEditorActive) {
+    fab.classList.remove("visible");
+    return;
+  }
+  // Hide FAB during draw gestures (not during select-tool move — FAB tracks via side-effects loop)
+  if (pointerIsDown && fdCanvas.get_tool_name() !== 'select') {
     fab.classList.remove("visible");
     return;
   }
@@ -7304,6 +7309,8 @@ function scheduleSideEffects() {
     if (viewMode === "spec") refreshSpecView();
     refreshLayersPanel();
     renderMinimap();
+    updateFloatingBar();
+    updatePropertiesPanel();
   }, 100);
 }
 

--- a/site/playground.js
+++ b/site/playground.js
@@ -2465,6 +2465,7 @@ async function initPlayground() {
         renderMinimap(canvas);
         refreshLayersPanel();
         updatePropertiesPanel();
+        updateFab(canvas);
         minimapLastRender = time;
         uiDirty = false;
       }
@@ -2545,8 +2546,10 @@ async function initPlayground() {
         return;
       }
 
-      // Hide FAB during interaction
-      document.getElementById('fab')?.classList.remove('visible');
+      // Hide FAB during draw gestures (not during move — FAB tracks via render loop)
+      if (fdCanvas.get_tool_name() !== 'select') {
+        document.getElementById('floating-action-bar')?.classList.remove('visible');
+      }
 
       const changed = fdCanvas.handle_pointer_down(
         x, y, e.pressure || 1.0,


### PR DESCRIPTION
## Summary

The Floating Action Bar (FAB) now stays visible and tracks the selected node during move drag operations. Previously, it disappeared on pointerdown and only reappeared on pointerup.

### Site (playground.js)
- Added updateFab(canvas) to ~10fps render loop
- Fixed dead #fab selector → #floating-action-bar
- FAB only hides during draw gestures, not move/resize

### VS Code Extension (main.js)
- updateFloatingBar() allows FAB during select-tool drag
- scheduleSideEffects() calls updateFloatingBar() + updatePropertiesPanel()

### Testing
- ✅ cargo clippy/fmt/test — all pass
- No Rust changes — JS-only fix