### PR TITLE
feat(playground): fullscreen mode + deep links with URL compression

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 ## Completed Requirements
 
+### v0.10.127 — Fullscreen Mode + Deep Links (R6.6)
+
+- **FEATURE (R6.6)**: Full Screen mode — ⛶ button in canvas toolbar expands playground to fill entire viewport; `Shift+F` shortcut; `Escape` to exit; separate from Zen mode (Zen hides code editor, Fullscreen hides page chrome); CSS `fullscreen-mode` class with fixed positioning and smooth enter animation
+- **FEATURE (R6.6)**: Deep linking with URL compression — 🔗 Share button compresses current editor text via LZ-String (`compressToEncodedURIComponent`) and copies `?code=...` URL to clipboard; loading a `?code=` URL decompresses and populates the editor; `?fullscreen` parameter auto-enters fullscreen on load
+- **PARITY (R6.6)**: VS Code extension — fullscreen toggle button, CSS, Shift+F shortcut, and Escape exit added to `webview-html.ts`, `navigation.js`, `shortcuts.js`, `main.js`; state persisted via `vscode.setState()`
+- **SITE**: Changes in `site/style.css`, `site/index.html`, `site/playground.js`
+- **EXTENSION**: Changes in `fd-vscode/src/webview-html.ts`, `fd-vscode/webview/src/navigation.js`, `fd-vscode/webview/src/shortcuts.js`, `fd-vscode/webview/src/main.js`, `fd-vscode/webview/main.js` (built)
+
 ### v0.10.126 — FAB Persistent During Drag (R6.6)
 
 - **UX (R6.6)**: Floating Action Bar (FAB) now stays visible and tracks the node during move drag — previously disappeared on pointerdown and only reappeared on pointerup; `updateFab(canvas)` added to the ~10fps render loop alongside `updatePropertiesPanel()`; CSS transitions (`left 0.08s ease, top 0.08s ease`) provide smooth tracking animation for free

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -137,6 +137,20 @@ Zen mode keeps: 6 core tools (Select, Rect, Ellipse, Pen, Arrow, Text), Sketchy 
 
 ---
 
+## Full Screen Mode
+
+| Action                        | Effect                                |
+| ----------------------------- | ------------------------------------- |
+| Click ⛶/✕ toggle (toolbar)    | Toggle Full Screen mode               |
+| `⇧F` (Shift+F)               | Toggle Full Screen mode               |
+| `Escape`                      | Exit Full Screen mode                 |
+
+Full Screen mode hides: Navigation, hero, footer, page chrome. Expands playground to fill viewport.
+Full Screen mode keeps: Code editor, canvas, toolbar, all tools.
+Full Screen is independent of Zen mode — both can be active simultaneously.
+
+---
+
 ## Apple Pencil Pro
 
 | Gesture              | Action                |

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.10.112",
+  "version": "0.10.113",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/fd-vscode/src/webview-html.ts
+++ b/fd-vscode/src/webview-html.ts
@@ -2429,6 +2429,25 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
       display: block !important;
     }
 
+    /* ── Full Screen Mode (separate from Zen) ── */
+    .fullscreen-mode #toolbar {
+      padding: 4px 8px;
+      gap: 2px;
+    }
+    .fullscreen-mode .zen-full-only { display: none !important; }
+    .fullscreen-mode #layers-panel { display: none !important; }
+    .fullscreen-mode #props-panel { display: none !important; }
+    .fullscreen-mode #minimap-container { display: none !important; }
+    .fullscreen-mode #spec-overlay { display: none !important; }
+    .fullscreen-mode #floating-toolbar { display: none !important; }
+    #fullscreen-toggle-btn {
+      font-size: 15px;
+    }
+    #fullscreen-toggle-btn.fs-active {
+      color: var(--fd-accent);
+      background: var(--fd-accent-dim);
+    }
+
     /* ── Renamify Panel (diff-preview overlay) ── */
     #renamify-panel {
       display: none;
@@ -2580,6 +2599,7 @@ export const HTML_TEMPLATE = `<!DOCTYPE html>
     </div>
     <div class="tb-zone tb-right">
       <span class="zen-full-only" id="status">Loading WASM…</span>
+      <button class="tool-btn" id="fullscreen-toggle-btn" title="Full Screen (⇧F)">⛶</button>
       <button class="tool-btn" id="zen-toggle-btn" title="Switch to Zen mode">🧘</button>
       <!-- Settings Hamburger ☰ -->
       <div class="settings-dropdown-container zen-full-only" id="settings-dropdown-container">

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -1323,6 +1323,20 @@ document.addEventListener("keydown", (e) => {
     closeAnnotationCard();
     closeContextMenu();
     closeShortcutHelp();
+    // Exit fullscreen mode on Escape (before Zen mode)
+    if (document.body.classList.contains("fullscreen-mode")) {
+      applyFullscreenMode(false);
+      vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: false });
+    }
+  }
+
+  // ── Shift+F: toggle fullscreen ──
+  if (e.key === "F" && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    const isFull = document.body.classList.contains("fullscreen-mode");
+    applyFullscreenMode(!isFull);
+    vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: !isFull });
+    return;
   }
 
   // ── Grid toggle shortcut ──
@@ -1939,12 +1953,7 @@ function updateFloatingBar() {
   if (!fab || !fdCanvas) return;
 
   const selectedId = fdCanvas.get_selected_id();
-  if (!selectedId || inlineEditorActive) {
-    fab.classList.remove("visible");
-    return;
-  }
-  // Hide FAB during draw gestures (not during select-tool move — FAB tracks via side-effects loop)
-  if (pointerIsDown && fdCanvas.get_tool_name() !== 'select') {
+  if (!selectedId || pointerIsDown || inlineEditorActive) {
     fab.classList.remove("visible");
     return;
   }
@@ -6093,6 +6102,37 @@ function applyZenMode(isZen) {
   }
 }
 
+
+// ─── Full Screen Mode Toggle ──────────────────────────────────────────────────
+
+function setupFullscreenToggle() {
+  const btn = document.getElementById("fullscreen-toggle-btn");
+  if (!btn) return;
+
+  // Restore persisted state
+  const savedState = vscode.getState();
+  if (savedState && savedState.fullscreenMode) {
+    applyFullscreenMode(true);
+  }
+
+  btn.addEventListener("click", () => {
+    const isFull = document.body.classList.contains("fullscreen-mode");
+    applyFullscreenMode(!isFull);
+    vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: !isFull });
+  });
+}
+
+function applyFullscreenMode(isFull) {
+  const btn = document.getElementById("fullscreen-toggle-btn");
+  if (isFull) {
+    document.body.classList.add("fullscreen-mode");
+    if (btn) { btn.textContent = '✕'; btn.title = 'Exit Full Screen (Esc)'; btn.classList.add('fs-active'); }
+  } else {
+    document.body.classList.remove("fullscreen-mode");
+    if (btn) { btn.textContent = '⛶'; btn.title = 'Full Screen (⇧F)'; btn.classList.remove('fs-active'); }
+  }
+}
+
 // ─── Copy / Paste / Cut / Select All (Figma/Sketch standard) ─────────────────
 
 /** Clipboard buffer for FD node text */
@@ -7064,6 +7104,7 @@ async function main() {
     setupThemeToggle();
     setupSketchyToggle();
     setupZenModeToggle();
+    setupFullscreenToggle();
     setupZoomIndicator();
     setupGridToggle();
     setupSpecBadgeToggle();
@@ -7309,8 +7350,6 @@ function scheduleSideEffects() {
     if (viewMode === "spec") refreshSpecView();
     refreshLayersPanel();
     renderMinimap();
-    updateFloatingBar();
-    updatePropertiesPanel();
   }, 100);
 }
 

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -77,6 +77,7 @@ async function main() {
     setupThemeToggle();
     setupSketchyToggle();
     setupZenModeToggle();
+    setupFullscreenToggle();
     setupZoomIndicator();
     setupGridToggle();
     setupSpecBadgeToggle();

--- a/fd-vscode/webview/src/navigation.js
+++ b/fd-vscode/webview/src/navigation.js
@@ -1561,3 +1561,34 @@ function applyZenMode(isZen) {
   }
 }
 
+
+// ─── Full Screen Mode Toggle ──────────────────────────────────────────────────
+
+function setupFullscreenToggle() {
+  const btn = document.getElementById("fullscreen-toggle-btn");
+  if (!btn) return;
+
+  // Restore persisted state
+  const savedState = vscode.getState();
+  if (savedState && savedState.fullscreenMode) {
+    applyFullscreenMode(true);
+  }
+
+  btn.addEventListener("click", () => {
+    const isFull = document.body.classList.contains("fullscreen-mode");
+    applyFullscreenMode(!isFull);
+    vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: !isFull });
+  });
+}
+
+function applyFullscreenMode(isFull) {
+  const btn = document.getElementById("fullscreen-toggle-btn");
+  if (isFull) {
+    document.body.classList.add("fullscreen-mode");
+    if (btn) { btn.textContent = '✕'; btn.title = 'Exit Full Screen (Esc)'; btn.classList.add('fs-active'); }
+  } else {
+    document.body.classList.remove("fullscreen-mode");
+    if (btn) { btn.textContent = '⛶'; btn.title = 'Full Screen (⇧F)'; btn.classList.remove('fs-active'); }
+  }
+}
+

--- a/fd-vscode/webview/src/shortcuts.js
+++ b/fd-vscode/webview/src/shortcuts.js
@@ -69,6 +69,20 @@ document.addEventListener("keydown", (e) => {
     closeAnnotationCard();
     closeContextMenu();
     closeShortcutHelp();
+    // Exit fullscreen mode on Escape (before Zen mode)
+    if (document.body.classList.contains("fullscreen-mode")) {
+      applyFullscreenMode(false);
+      vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: false });
+    }
+  }
+
+  // ── Shift+F: toggle fullscreen ──
+  if (e.key === "F" && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    const isFull = document.body.classList.contains("fullscreen-mode");
+    applyFullscreenMode(!isFull);
+    vscode.setState({ ...(vscode.getState() || {}), fullscreenMode: !isFull });
+    return;
   }
 
   // ── Grid toggle shortcut ──

--- a/site/index.html
+++ b/site/index.html
@@ -101,6 +101,8 @@
               </div>
               <div class="tb-zone tb-right">
                 <span class="zen-full-only" id="canvas-status">Ready</span>
+                <button class="tool-btn" id="share-btn" title="Share playground link">🔗</button>
+                <button class="tool-btn" id="fullscreen-toggle-btn" title="Full Screen (⇧F)">⛶</button>
                 <button class="tool-btn" id="zen-toggle-btn" title="Zen Mode (Esc)">🧘</button>
                 <div class="settings-dropdown-container zen-full-only" id="settings-dropdown-container">
                   <button class="tool-btn" id="settings-menu-btn" title="Settings &amp; tools">☰</button>

--- a/site/playground.js
+++ b/site/playground.js
@@ -12,6 +12,7 @@ import { autocompletion, closeBrackets, closeBracketsKeymap } from 'https://esm.
 import { linter, lintGutter } from 'https://esm.sh/@codemirror/lint@6';
 import { defaultKeymap, history, historyKeymap } from 'https://esm.sh/@codemirror/commands@6';
 import { highlightSelectionMatches } from 'https://esm.sh/@codemirror/search@6';
+import LZString from 'https://esm.sh/lz-string@1.5.0';
 
 // ─── FD Language Definition (StreamLanguage) ─────────────────────────────
 const fdLanguage = StreamLanguage.define({
@@ -218,6 +219,7 @@ let zoomLevel = 1.0;
 let gridEnabled = false;
 const GRID_SPACING = 20;
 let zenMode = false;
+let fullscreenMode = false;
 const ZOOM_MIN = 0.1, ZOOM_MAX = 5;
 let isPanning = false;
 let inlineEditorActive = false;
@@ -344,6 +346,19 @@ function fitToContent(canvas) {
     updateZoomIndicator();
     renderDirty = true; uiDirty = true;
   } catch (_) { }
+}
+
+/** Toggle full-screen mode (expands playground to fill entire viewport) */
+function toggleFullscreen() {
+  fullscreenMode = !fullscreenMode;
+  document.body.classList.toggle('fullscreen-mode', fullscreenMode);
+  const btn = document.getElementById('fullscreen-toggle-btn');
+  if (btn) {
+    btn.textContent = fullscreenMode ? '✕' : '⛶';
+    btn.title = fullscreenMode ? 'Exit Full Screen (Esc)' : 'Full Screen (⇧F)';
+    btn.classList.toggle('fs-active', fullscreenMode);
+  }
+  setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
 }
 
 /** Show a brief toast notification */
@@ -1075,13 +1090,23 @@ function setupContextMenu() {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
       closeContextMenu();
-      // Exit Zen mode on Escape
-      if (zenMode) {
+      // Exit fullscreen mode on Escape
+      if (fullscreenMode) {
+        toggleFullscreen();
+      } else if (zenMode) {
+        // Exit Zen mode on Escape
         zenMode = false;
         document.querySelector('.hero-playground')?.classList.remove('zen-mode');
         const zb = document.getElementById('zen-toggle-btn');
         if (zb) { zb.textContent = '🧘'; zb.title = 'Zen Mode (Esc)'; }
         setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
+      }
+    }
+    // Shift+F → toggle fullscreen
+    if (e.key === 'F' && e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+      if (document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') {
+        e.preventDefault();
+        toggleFullscreen();
       }
     }
   });
@@ -2305,7 +2330,17 @@ async function initPlayground() {
     fdCanvas.set_theme(true);
     wrapper.classList.add('dark-canvas');
     if (statusEl) statusEl.textContent = 'Parsing scene…';
-    fdCanvas.set_text(DEFAULT_FD);
+    // Deep link: load ?code= param if present, else use default
+    const urlParams = new URLSearchParams(window.location.search);
+    const codeParam = urlParams.get('code');
+    let initialFd = DEFAULT_FD;
+    if (codeParam) {
+      try {
+        const decoded = LZString.decompressFromEncodedURIComponent(codeParam);
+        if (decoded && decoded.trim().length > 0) initialFd = decoded;
+      } catch (_) { /* invalid code param, use default */ }
+    }
+    fdCanvas.set_text(initialFd);
     if (statusEl) statusEl.textContent = '✓ Ready';
 
     // ── Create CodeMirror Editor ──────────────────────────────────────
@@ -2382,7 +2417,7 @@ async function initPlayground() {
 
     editorView = new EditorView({
       state: EditorState.create({
-        doc: DEFAULT_FD,
+        doc: initialFd,
         extensions: [
           lineNumbers(),
           highlightActiveLine(),
@@ -2443,6 +2478,32 @@ async function initPlayground() {
       zenBtn.title = zenMode ? 'Exit Zen Mode (Esc)' : 'Zen Mode (Esc)';
       setTimeout(() => { resizeCanvas(); renderCanvas(); }, 50);
     });
+
+    // Full Screen toggle
+    document.getElementById('fullscreen-toggle-btn')?.addEventListener('click', toggleFullscreen);
+
+    // Share button — copy ?code= deep link to clipboard
+    document.getElementById('share-btn')?.addEventListener('click', () => {
+      if (!editorView) return;
+      const text = editorView.state.doc.toString();
+      const compressed = LZString.compressToEncodedURIComponent(text);
+      const url = new URL(window.location.href);
+      url.searchParams.set('code', compressed);
+      // Also preserve fullscreen state if active
+      if (fullscreenMode) url.searchParams.set('fullscreen', '');
+      else url.searchParams.delete('fullscreen');
+      navigator.clipboard.writeText(url.toString()).then(() => {
+        showToast('Link copied to clipboard!');
+      }).catch(() => {
+        // Fallback: show URL in prompt
+        prompt('Copy this link:', url.toString());
+      });
+    });
+
+    // Auto-fullscreen from URL param
+    if (urlParams.has('fullscreen')) {
+      setTimeout(toggleFullscreen, 100);
+    }
 
     // ── Toolbar buttons ──────────────────────────────────────────────
     document.getElementById('ai-touch-btn')?.addEventListener('click', aiTouch);

--- a/site/style.css
+++ b/site/style.css
@@ -2063,6 +2063,45 @@ code {
 .zen-mode #floating-toolbar { display: none !important; }
 .zen-mode #minimap-container { display: none !important; }
 
+/* ─── Full Screen Mode ─── */
+/* Separate from Zen: expands playground to fill entire viewport */
+.fullscreen-mode #navbar,
+.fullscreen-mode #hero .hero-content,
+.fullscreen-mode #hero .hero-bg,
+.fullscreen-mode .section,
+.fullscreen-mode #cta,
+.fullscreen-mode #footer { display: none !important; }
+
+.fullscreen-mode #hero {
+  padding: 0;
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  overflow: hidden;
+}
+.fullscreen-mode .hero-playground {
+  max-width: 100%;
+  width: 100%;
+  height: 100vh;
+  margin: 0;
+  animation: fullscreen-enter 0.25s ease-out;
+}
+.fullscreen-mode .playground-split {
+  min-height: 100vh;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+}
+@keyframes fullscreen-enter {
+  from { transform: scale(0.97); opacity: 0.8; }
+  to { transform: scale(1); opacity: 1; }
+}
+/* Fullscreen toolbar button highlight */
+#fullscreen-toggle-btn.fs-active {
+  color: var(--fd-accent, #007AFF);
+  background: var(--fd-accent-dim, rgba(0,122,255,0.1));
+}
+
 /* ─── Responsive ─── */
 @media (max-width: 768px) {
   .nav-links {


### PR DESCRIPTION
## Changes

### Full Screen Mode (separate from Zen)
- ⛶ button in canvas toolbar toggles fullscreen
- Shift+F shortcut / Escape to exit
- Hides page chrome (nav, hero, footer) while keeping editor + canvas

### Deep Links with URL Compression
- 🔗 Share button compresses editor text via LZ-String → ?code= URL
- ?fullscreen auto-enters fullscreen on load

### VS Code Extension Parity
- Fullscreen toggle button, CSS, Shift+F, Escape, state persistence

## All checks pass
- cargo clippy ✅ / cargo fmt ✅ / cargo test ✅ / webview build ✅