### PR TITLE
chore: bump extension to v0.11.329, remove stray patch3.py

### DIFF
--- a/fd-vscode/package-lock.json
+++ b/fd-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fast-draft",
-  "version": "0.11.328",
+  "version": "0.11.329",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fast-draft",
-      "version": "0.11.328",
+      "version": "0.11.329",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design Specs as Code",
-  "version": "0.11.328",
+  "version": "0.11.329",
   "publisher": "KhangNghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/patch3.py
+++ b/patch3.py
@@ -1,7 +1,0 @@
-with open('docs/REQUIREMENTS.md', 'r') as f:
-    text = f.read()
-
-text = text.replace('| R3.16       | `hit_test_resize_handle` (WASM), E2E UX cursor tests                                                                                                                                                                                                               | ⚠️ WASM-side only              |', '| R3.16       | `hit_test_resize_handle` (WASM), E2E UX cursor tests                                                                                                                                                                                                               | ✅ 3 tests                     |')
-
-with open('docs/REQUIREMENTS.md', 'w') as f:
-    f.write(text)


### PR DESCRIPTION
Cleanup after batch merge of 14 PRs: version bump to v0.11.329 (already published), delete stray patch3.py left by Jules agent.