### PR TITLE
fix(desktop): Remove CDN imports for offline .app bundle

### DIFF
--- a/fd-desktop/package.json
+++ b/fd-desktop/package.json
@@ -11,7 +11,6 @@
     "@tauri-apps/cli": "^2"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-updater": "^2"
+    "@tauri-apps/api": "^2"
   }
 }

--- a/site/css/desktop.css
+++ b/site/css/desktop.css
@@ -1,10 +1,6 @@
 /* ─── Desktop (Tauri) Overrides ─── */
 /* Applied only when running inside Tauri webview */
 
-/* Title bar overlay: add drag region + traffic light padding */
-.tauri-desktop #canvas-content {
-  /* macOS traffic lights sit ~52px from top-left */
-}
 
 /* Make the top area draggable (window chrome) */
 .tauri-desktop .canvas-chrome-left,

--- a/site/tauri.js
+++ b/site/tauri.js
@@ -1,6 +1,9 @@
 // ── Tauri Desktop Integration ──────────────────────────────────────────────
 // Detect Tauri runtime and wire native file I/O shortcuts.
 // On web (non-Tauri), this entire module is a no-op.
+//
+// IMPORTANT: All plugin APIs use invoke() directly instead of importing
+// @tauri-apps/plugin-* JS wrappers, because site/ has no node_modules.
 
 /**
  * Initialize Tauri desktop integration (file open/save, auto-update).
@@ -17,6 +20,12 @@ export function initTauri(api) {
   // Add desktop class for CSS targeting (drag regions, traffic light padding)
   document.body.classList.add('tauri-desktop');
 
+  /** Helper: invoke Tauri IPC command */
+  function invoke(cmd, args) {
+    const internals = window.__TAURI_INTERNALS__ || window.__TAURI__;
+    return internals.invoke(cmd, args);
+  }
+
   let currentFilePath = null;
 
   /** Update window title to show the current file name. */
@@ -32,10 +41,8 @@ export function initTauri(api) {
   /** Open a .fd file via native file dialog. */
   async function tauriOpen() {
     try {
-      const { invoke } = window.__TAURI_INTERNALS__ || window.__TAURI__;
-      // Open file dialog via IPC
-      const { open } = await import('https://unpkg.com/@tauri-apps/plugin-dialog@2/dist-js/index.mjs');
-      const result = await open({
+      // Use plugin:dialog IPC directly instead of CDN import
+      const result = await invoke('plugin:dialog|open', {
         multiple: false,
         filters: [{ name: 'Fast Draft', extensions: ['fd'] }],
       });
@@ -63,7 +70,6 @@ export function initTauri(api) {
   async function tauriSave() {
     if (!currentFilePath) return tauriSaveAs();
     try {
-      const { invoke } = window.__TAURI_INTERNALS__ || window.__TAURI__;
       const editorView = api.getEditorView();
       const content = editorView ? editorView.state.doc.toString() : '';
       await invoke('save_file', { path: currentFilePath, content });
@@ -77,9 +83,8 @@ export function initTauri(api) {
   /** Save As — prompt for new file path. */
   async function tauriSaveAs() {
     try {
-      const { invoke } = window.__TAURI_INTERNALS__ || window.__TAURI__;
-      const { save } = await import('https://unpkg.com/@tauri-apps/plugin-dialog@2/dist-js/index.mjs');
-      const path = await save({
+      // Use plugin:dialog IPC directly instead of CDN import
+      const path = await invoke('plugin:dialog|save', {
         filters: [{ name: 'Fast Draft', extensions: ['fd'] }],
       });
       if (!path) return; // user cancelled
@@ -116,7 +121,6 @@ export function initTauri(api) {
   // Check if launched with a file argument
   (async () => {
     try {
-      const { invoke } = window.__TAURI_INTERNALS__ || window.__TAURI__;
       const path = await invoke('get_current_file');
       if (path) {
         currentFilePath = path;
@@ -130,53 +134,47 @@ export function initTauri(api) {
   // Shows a toast if a new version is available.
   setTimeout(async () => {
     try {
-      const { check } = await import('https://unpkg.com/@tauri-apps/plugin-updater@2/dist-js/index.mjs');
-      const update = await check();
-      if (update) {
-        console.log(`[FD] Update available: v${update.version}`);
-        // Show persistent toast with update action
-        const toast = document.createElement('div');
-        toast.className = 'fd-update-toast';
-        toast.innerHTML = `
-          <span>Fast Draft v${update.version} available</span>
-          <button id="fd-update-btn">Update Now</button>
-          <button id="fd-update-dismiss" style="background:none;border:none;color:inherit;cursor:pointer;font-size:16px;padding:4px;">✕</button>
-        `;
-        document.body.appendChild(toast);
-        // Trigger animation
-        requestAnimationFrame(() => toast.classList.add('visible'));
-
-        document.getElementById('fd-update-dismiss')?.addEventListener('click', () => {
-          toast.classList.remove('visible');
-          setTimeout(() => toast.remove(), 300);
-        });
-
-        document.getElementById('fd-update-btn')?.addEventListener('click', async () => {
-          const btn = document.getElementById('fd-update-btn');
-          btn.textContent = 'Downloading…';
-          btn.disabled = true;
-          try {
-            await update.downloadAndInstall((progress) => {
-              if (progress?.event === 'Started' && progress.data?.contentLength) {
-                btn.textContent = 'Downloading… 0%';
-              } else if (progress?.event === 'Progress') {
-                // Progress updates
-              } else if (progress?.event === 'Finished') {
-                btn.textContent = 'Restarting…';
-              }
-            });
-            // Restart the app after update
-            const { relaunch } = await import('https://unpkg.com/@tauri-apps/plugin-process@2/dist-js/index.mjs');
-            await relaunch();
-          } catch (err) {
-            console.error('[FD] Update failed:', err);
-            btn.textContent = 'Update Failed';
-            api.showToast('Update failed — try again later');
-          }
-        });
-      } else {
+      // Use plugin:updater IPC channel directly
+      const updateRaw = await invoke('plugin:updater|check', {});
+      if (!updateRaw || !updateRaw.available) {
         console.log('[FD] App is up to date');
+        return;
       }
+
+      const version = updateRaw.version || 'new';
+      console.log(`[FD] Update available: v${version}`);
+
+      // Show persistent toast with update action
+      const toast = document.createElement('div');
+      toast.className = 'fd-update-toast';
+      toast.innerHTML = `
+        <span>Fast Draft v${version} available</span>
+        <button id="fd-update-btn">Update Now</button>
+        <button id="fd-update-dismiss" style="background:none;border:none;color:inherit;cursor:pointer;font-size:16px;padding:4px;">✕</button>
+      `;
+      document.body.appendChild(toast);
+      requestAnimationFrame(() => toast.classList.add('visible'));
+
+      document.getElementById('fd-update-dismiss')?.addEventListener('click', () => {
+        toast.classList.remove('visible');
+        setTimeout(() => toast.remove(), 300);
+      });
+
+      document.getElementById('fd-update-btn')?.addEventListener('click', async () => {
+        const btn = document.getElementById('fd-update-btn');
+        btn.textContent = 'Downloading…';
+        btn.disabled = true;
+        try {
+          await invoke('plugin:updater|download_and_install', {});
+          btn.textContent = 'Restarting…';
+          // Restart the app after update
+          await invoke('plugin:process|restart', {});
+        } catch (err) {
+          console.error('[FD] Update failed:', err);
+          btn.textContent = 'Update Failed';
+          api.showToast('Update failed — try again later');
+        }
+      });
     } catch (err) {
       // Silently ignore update check failures (network error, no release, etc.)
       console.debug('[FD] Update check skipped:', err.message || err);


### PR DESCRIPTION
## Critical Fix

`tauri.js` imported Tauri plugin APIs from **unpkg.com CDN**:
- `@tauri-apps/plugin-dialog` (open/save dialogs)
- `@tauri-apps/plugin-updater` (update check)
- `@tauri-apps/plugin-process` (relaunch)

In a production `.app` bundle, these CDN imports fail without internet access, breaking all file I/O and auto-update functionality.

### Fix
Replace all 4 CDN `import()` calls with direct `invoke()` IPC calls:
- `plugin:dialog|open` / `plugin:dialog|save`
- `plugin:updater|check`
- `plugin:process|restart`

Also removed the now-unused `@tauri-apps/plugin-updater` npm dependency and cleaned up an empty CSS placeholder rule.