### PR TITLE
fix(ux): gate inline editor behind font readiness (v0.11.372) (#1069)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@
 -->
 ## Completed Requirements
 
+### v0.11.372 — Fix: Inline Editor Font Readiness
+- **Bug Fix**: Gated the inline editor initialization behind `document.fonts.ready` to ensure the correct web font (Inter) is fully loaded before calculating text node bounding boxes on cold start. This eliminates a subtle visual drift caused by initial measurements using fallback fonts.
+
 ### v0.11.371 — Fix: Inline Text Editor Position & Font Consistency
 - **Bug Fix**: Fixed a visual regression where the inline text editor appeared at an incorrect offset from the actual text node position when creating new text nodes via the Text tool. The root cause was an unconditional centering adjustment (`- (sw - scaledW) / 2`) that shifted the overlay when min-width exceeded actual text width. Standalone text nodes now anchor at top-left (matching Canvas2D `draw_text` baseline); text-in-shape retains centered positioning.
 - **Bug Fix**: The `get_node_props` WASM API now always emits font fallback values (`fontFamily`, `fontSize`, `fontWeight`) even when `style.font` is `None`, ensuring the inline editor uses identical defaults as the canvas renderer (`Inter, sans-serif`, 14px, 400).

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.371",
+  "version": "0.11.372",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/site/canvas-core/inline-edit.js
+++ b/site/canvas-core/inline-edit.js
@@ -128,8 +128,9 @@ export function measureAllTextNodes(fdCanvas, canvasEl, renderFn) {
  * @param {number} opts.zoomLevel    — current zoom
  * @param {string} [opts.parentShapeId] — parent shape ID for text-in-shape editing
  */
-export function openInlineEditor(opts) {
+export async function openInlineEditor(opts) {
   if (inlineEditorActive) return;
+  inlineEditorActive = true;
 
   let { nodeId } = opts;
   const {
@@ -142,6 +143,7 @@ export function openInlineEditor(opts) {
   } = opts;
 
   if (nodeId) {
+    if (document.fonts) await document.fonts.ready;
     // Force-measure text bounds BEFORE reading them
     measureAndUpdateTextBounds(fdCanvas, canvasEl, nodeId);
   }
@@ -163,8 +165,6 @@ export function openInlineEditor(opts) {
   }
   const bw = b.w || 80;
   const bh = b.h || 24;
-
-  inlineEditorActive = true;
 
   // Suppress text rendering AND set selection BEFORE any render — prevents
   // the blue selection box from flashing for a single frame.

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.371" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.371" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.372" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.372" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.371" />
-  <link rel="stylesheet" href="style.css?v=0.11.371" />
+  <link rel="stylesheet" href="shared.css?v=0.11.372" />
+  <link rel="stylesheet" href="style.css?v=0.11.372" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -487,8 +487,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.371"></script>
-  <script type="module" src="app.js?v=0.11.371"></script>
+  <script src="context-menu.js?v=0.11.372"></script>
+  <script type="module" src="app.js?v=0.11.372"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
- Make openInlineEditor async and wait for document.fonts.ready
- Ensures canvas measureText uses actual font metrics on cold start
