### PR TITLE
fix(ux): auto-expand inline editor height on text wrap (v0.11.373)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@
 -->
 ## Completed Requirements
 
+### v0.11.373 — Fix: Inline Editor Auto-Expanding Height
+- **Bug Fix**: The inline text editor (`textarea`) now auto-expands its height to fit wrapped text content. Previously, the textarea was fixed to its initial height (typically 24px) regardless of how much text was typed or wrapped, causing overflow text to be completely hidden. The fix uses the standard `scrollHeight` sync pattern on both initial open and every `input` event.
+
 ### v0.11.372 — Fix: Inline Editor Font Readiness
 - **Bug Fix**: Gated the inline editor initialization behind `document.fonts.ready` to ensure the correct web font (Inter) is fully loaded before calculating text node bounding boxes on cold start. This eliminates a subtle visual drift caused by initial measurements using fallback fonts.
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.372",
+  "version": "0.11.373",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/site/canvas-core/inline-edit.js
+++ b/site/canvas-core/inline-edit.js
@@ -323,6 +323,10 @@ export async function openInlineEditor(opts) {
     textarea.select();
   }
 
+  // Auto-expand height to fit wrapped content on initial open
+  textarea.style.height = 'auto';
+  textarea.style.height = `${textarea.scrollHeight}px`;
+
   let lastSyncedValue = currentValue;
   textarea.addEventListener("input", () => {
     const val = textarea.value;
@@ -354,6 +358,10 @@ export async function openInlineEditor(opts) {
       renderFn();
       syncFn();
     }
+
+    // Auto-expand height to fit wrapped content
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
   });
 
   const commit = () => {

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.372" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.372" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.373" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.373" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.372" />
-  <link rel="stylesheet" href="style.css?v=0.11.372" />
+  <link rel="stylesheet" href="shared.css?v=0.11.373" />
+  <link rel="stylesheet" href="style.css?v=0.11.373" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -487,8 +487,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.372"></script>
-  <script type="module" src="app.js?v=0.11.372"></script>
+  <script src="context-menu.js?v=0.11.373"></script>
+  <script type="module" src="app.js?v=0.11.373"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
- Textarea now syncs height with scrollHeight on open and every input event
- Fixes wrapped text being hidden behind overflow:hidden constraint
