### PR TITLE
fix(ux): prevent phantom subpixel wrapping in inline editor (v0.11.374)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@
 -->
 ## Completed Requirements
 
+### v0.11.374 — Fix: Inline Editor Sub-Pixel Wrapping
+- **Bug Fix**: Fixed an issue where the inline `textarea` editor occasionally rendered one more line of text than the WASM canvas engine on "Auto-Width" text nodes. This was caused by CSS `white-space: pre-wrap` triggering a premature line break due to sub-pixel font measurement discrepancies between the HTML DOM and Canvas2D context. Auto-Width text now uses `white-space: pre` and dynamically syncs its horizontal bounds directly from the WASM layout engine on every keystroke.
+
 ### v0.11.373 — Fix: Inline Editor Auto-Expanding Height
 - **Bug Fix**: The inline text editor (`textarea`) now auto-expands its height to fit wrapped text content. Previously, the textarea was fixed to its initial height (typically 24px) regardless of how much text was typed or wrapped, causing overflow text to be completely hidden. The fix uses the standard `scrollHeight` sync pattern on both initial open and every `input` event.
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.373",
+  "version": "0.11.374",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/site/canvas-core/inline-edit.js
+++ b/site/canvas-core/inline-edit.js
@@ -291,6 +291,9 @@ export async function openInlineEditor(opts) {
   const outlineStyle = "none";
   const boxShadow = "none";
 
+  const isAutoWidth = isTextNode && !isInShape && !props.maxWidth;
+  const whiteSpace = isAutoWidth ? 'pre' : 'pre-wrap';
+
   const textarea = document.createElement("textarea");
   textarea.value = currentValue;
   textarea.style.cssText = [
@@ -308,7 +311,7 @@ export async function openInlineEditor(opts) {
     `overflow:hidden`, `text-align:${hAlign}`,
     `box-sizing:border-box`,
     `-webkit-text-size-adjust:100%`,
-    `word-wrap:break-word`, `white-space:pre-wrap`,
+    `word-wrap:break-word`, `white-space:${whiteSpace}`,
     `overflow-wrap:break-word`,
     `letter-spacing:0px`,
   ].join(";");
@@ -357,6 +360,16 @@ export async function openInlineEditor(opts) {
       fdCanvas.set_node_prop(propKey, val);
       renderFn();
       syncFn();
+
+      if (isAutoWidth) {
+        const boundsJson = fdCanvas.get_node_bounds(nodeId);
+        if (boundsJson) {
+          const newB = JSON.parse(boundsJson);
+          const newScaledW = newB.w * zoomLevel;
+          const newSw = Math.max(newScaledW, 80);
+          textarea.style.width = `${newSw}px`;
+        }
+      }
     }
 
     // Auto-expand height to fit wrapped content

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.373" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.373" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.374" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.374" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.373" />
-  <link rel="stylesheet" href="style.css?v=0.11.373" />
+  <link rel="stylesheet" href="shared.css?v=0.11.374" />
+  <link rel="stylesheet" href="style.css?v=0.11.374" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -487,8 +487,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.373"></script>
-  <script type="module" src="app.js?v=0.11.373"></script>
+  <script src="context-menu.js?v=0.11.374"></script>
+  <script type="module" src="app.js?v=0.11.374"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
- Auto-Width text now uses white-space: pre to guarantee no premature wraps.
- Textarea width now dynamically syncs with WASM bounding box via get_node_bounds on every stroke, implementing proper horizontal text auto-expansion.
