### PR TITLE
fix(ux): bind inline editor to WASM dimensions (v0.11.375)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@
 -->
 ## Completed Requirements
 
+### v0.11.375 — Fix: True WASM Dimension Sync for Inline Editor
+- **Bug Fix**: Completely removed HTML `scrollHeight` dependencies from the inline editor, moving to standard full-sync with the WASM engine. Previously, `scrollHeight` combined with sub-pixel rendering differences caused phantom height jumps and extra lines on Auto-Height nodes (`pre-wrap`). The inline editor now fetches and applies its dimensions directly via `get_node_bounds()` on every keystroke, guaranteeing absolute parity with Canvas layout.
+
 ### v0.11.374 — Fix: Inline Editor Sub-Pixel Wrapping
 - **Bug Fix**: Fixed an issue where the inline `textarea` editor occasionally rendered one more line of text than the WASM canvas engine on "Auto-Width" text nodes. This was caused by CSS `white-space: pre-wrap` triggering a premature line break due to sub-pixel font measurement discrepancies between the HTML DOM and Canvas2D context. Auto-Width text now uses `white-space: pre` and dynamically syncs its horizontal bounds directly from the WASM layout engine on every keystroke.
 

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.374",
+  "version": "0.11.375",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/site/canvas-core/inline-edit.js
+++ b/site/canvas-core/inline-edit.js
@@ -206,7 +206,7 @@ export async function openInlineEditor(opts) {
   const canvasOffsetY = canvasRect.top - containerRect.top;
   const scaledW = bw * zoomLevel;
   const scaledH = bh * zoomLevel;
-  const sw = Math.max(scaledW, 80);
+  const sw = Math.max(scaledW, 80) + 2;
   const sh = Math.max(scaledH, lineHeight + 4);
 
   // Determine node context BEFORE coordinate math
@@ -326,10 +326,6 @@ export async function openInlineEditor(opts) {
     textarea.select();
   }
 
-  // Auto-expand height to fit wrapped content on initial open
-  textarea.style.height = 'auto';
-  textarea.style.height = `${textarea.scrollHeight}px`;
-
   let lastSyncedValue = currentValue;
   textarea.addEventListener("input", () => {
     const val = textarea.value;
@@ -358,23 +354,21 @@ export async function openInlineEditor(opts) {
     if (nodeId) {
       fdCanvas.select_by_id(nodeId);
       fdCanvas.set_node_prop(propKey, val);
+      measureAndUpdateTextBounds(fdCanvas, canvasEl, nodeId);
       renderFn();
       syncFn();
 
-      if (isAutoWidth) {
-        const boundsJson = fdCanvas.get_node_bounds(nodeId);
-        if (boundsJson) {
-          const newB = JSON.parse(boundsJson);
-          const newScaledW = newB.w * zoomLevel;
-          const newSw = Math.max(newScaledW, 80);
-          textarea.style.width = `${newSw}px`;
-        }
+      const boundsJson = fdCanvas.get_node_bounds(nodeId);
+      if (boundsJson) {
+        const newB = JSON.parse(boundsJson);
+        const newScaledW = newB.w * zoomLevel;
+        const newScaledH = newB.h * zoomLevel;
+        const newSw = Math.max(newScaledW, 80) + 2;
+        const newSh = Math.max(newScaledH, lineHeight + 4);
+        textarea.style.width = `${newSw}px`;
+        textarea.style.height = `${newSh}px`;
       }
     }
-
-    // Auto-expand height to fit wrapped content
-    textarea.style.height = 'auto';
-    textarea.style.height = `${textarea.scrollHeight}px`;
   });
 
   const commit = () => {

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.374" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.374" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.375" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.375" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.374" />
-  <link rel="stylesheet" href="style.css?v=0.11.374" />
+  <link rel="stylesheet" href="shared.css?v=0.11.375" />
+  <link rel="stylesheet" href="style.css?v=0.11.375" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -487,8 +487,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.374"></script>
-  <script type="module" src="app.js?v=0.11.374"></script>
+  <script src="context-menu.js?v=0.11.375"></script>
+  <script type="module" src="app.js?v=0.11.375"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
- Removed DOM scrollHeight dependency which caused sub-pixel wrapper clashes and phantom height jumps on Auto-Height nodes.
- Input event listener now universally fetches get_node_bounds from the WASM engine on every keystroke.
- Added 2px horizontal padding to HTML textarea to prevent CSS pre-wrap from wrapping text before Canvas2D.
