### PR TITLE
fix(editor): await font loading before resolving initial bound metrics

### DIFF
--- a/fd-vscode/package-lock.json
+++ b/fd-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fast-draft",
-  "version": "0.11.376",
+  "version": "0.11.377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fast-draft",
-      "version": "0.11.376",
+      "version": "0.11.377",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.376",
+  "version": "0.11.377",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/site/app.js
+++ b/site/app.js
@@ -3863,6 +3863,7 @@ async function initPlayground() {
       } catch (_) { /* localStorage unavailable */ }
     }
     fdCanvas.set_text(initialFd);
+    if (document.fonts) await document.fonts.ready;
     measureAllTextNodes(fdCanvas, document.getElementById('fd-canvas'));
     console.log(`[FD] ✓ Ready (total ${Math.round(performance.now() - t0)}ms)`);
     // Hand tool is default on load — set grab cursor

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.376" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.376" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.377" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.377" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.376" />
-  <link rel="stylesheet" href="style.css?v=0.11.376" />
+  <link rel="stylesheet" href="shared.css?v=0.11.377" />
+  <link rel="stylesheet" href="style.css?v=0.11.377" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -487,8 +487,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.376"></script>
-  <script type="module" src="app.js?v=0.11.376"></script>
+  <script src="context-menu.js?v=0.11.377"></script>
+  <script type="module" src="app.js?v=0.11.377"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
- Fixes inline text editor height jumping on startup
- Eliminates font race condition between CSSOM and Canvas 2D measureText
- Guarantees true Inter font metrics are cached inside WASM layout solver prior to initial render
