### PR TITLE
fix(ai-chat): selectable text, SSE error handling, retries, inline editor polish

### DIFF
--- a/site/ai-chat.js
+++ b/site/ai-chat.js
@@ -500,7 +500,7 @@ async function sendMessage(getEditorContent, setEditorContent) {
             if (payload === '[DONE]') continue;
             try {
               const parsed = JSON.parse(payload);
-              const token = parsed.response || '';
+              const token = (parsed.response != null) ? parsed.response : '';
               if (token) {
                 accumulated += token;
                 if (!renderPending) {
@@ -508,7 +508,9 @@ async function sendMessage(getEditorContent, setEditorContent) {
                   requestAnimationFrame(performRender);
                 }
               }
-            } catch (_) {}
+            } catch (e) {
+              console.warn('[FD AI] SSE chunk parse error:', e.message, 'payload:', payload);
+            }
           }
         }
       } catch (e) {
@@ -519,8 +521,44 @@ async function sendMessage(getEditorContent, setEditorContent) {
         }
       }
 
+      // ─── Auto-retry on empty response (max 2 attempts) ─────────
+      if (!accumulated && !currentAbortController?.signal?.aborted) {
+        const maxRetries = 2;
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+          console.warn(`[FD AI] Empty stream response — retry ${attempt}/${maxRetries}`);
+          try {
+            const retryResp = await fetch(AI_ENDPOINT, {
+              method: 'POST',
+              signal: currentAbortController?.signal,
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                mode: 'chat',
+                messages: chatHistory,
+                context: docContent,
+                selection: selFd ? selFd.slice(0, 4000) : undefined,
+                selection_ids: selIds.length > 0 ? selIds : undefined,
+                stream: false,
+                model_hint: new URLSearchParams(window.location.search).get('ai_model') || undefined,
+              }),
+            });
+            if (retryResp.ok) {
+              const retryData = await retryResp.json();
+              if (retryData.result) {
+                accumulated = retryData.result;
+                if (retryData.limit && retryData.remaining) {
+                  updateRateLimitUI(retryData.remaining, retryData.limit);
+                }
+                break;
+              }
+            }
+          } catch (retryErr) {
+            console.warn(`[FD AI] Retry ${attempt} failed:`, retryErr.message);
+          }
+        }
+      }
+
       // Finalize: re-render with full markdown + Apply/Skip buttons
-      const finalContent = accumulated || 'No response received.';
+      const finalContent = accumulated || '⚠️ The AI returned an empty response. This may be a temporary issue — try again or simplify your prompt.';
       chatHistory.push({ role: 'assistant', content: finalContent });
       const finalUnsafeHTML = renderAssistantMessage(finalContent, getEditorContent, setEditorContent);
       div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(finalUnsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : finalUnsafeHTML;
@@ -530,7 +568,7 @@ async function sendMessage(getEditorContent, setEditorContent) {
       // ─── Fallback: full JSON response ──────────────
       const data = await response.json();
       if (data.limit && data.remaining) updateRateLimitUI(data.remaining, data.limit);
-      const assistantContent = data.result || 'No response received.';
+      const assistantContent = data.result || '⚠️ The AI returned an empty response. This may be a temporary issue — try again or simplify your prompt.';
       chatHistory.push({ role: 'assistant', content: assistantContent });
       addMessage('assistant', assistantContent, getEditorContent, setEditorContent);
     }

--- a/site/canvas-core/inline-edit.js
+++ b/site/canvas-core/inline-edit.js
@@ -288,8 +288,14 @@ export async function openInlineEditor(opts) {
     borderRadius = cr !== undefined ? `${Math.round(cr * zoomLevel)}px` : "0";
   } else if (isTextNode && !isInShape) borderRadius = "0";
 
-  const outlineStyle = "none";
-  const boxShadow = "none";
+  // Subtle edit-mode affordance (Figma-inspired blue ring)
+  const isTransparentBg = bgColor === 'transparent';
+  const outlineStyle = isTransparentBg
+    ? '1.5px solid rgba(0, 122, 255, 0.35)'
+    : '1.5px solid rgba(0, 122, 255, 0.2)';
+  const boxShadow = isTransparentBg
+    ? '0 0 0 3px rgba(0, 122, 255, 0.08), 0 2px 8px rgba(0, 0, 0, 0.06)'
+    : '0 0 0 3px rgba(0, 122, 255, 0.06)';
 
   const isAutoWidth = isTextNode && !isInShape && !props.maxWidth;
   const whiteSpace = isAutoWidth ? 'pre' : 'pre-wrap';
@@ -303,7 +309,7 @@ export async function openInlineEditor(opts) {
     `padding:${padTop}px 0 ${padBottom}px 0`,
     `font:${fontWeight} ${fontSize}px/${lineHeight}px ${fontFamily}`,
     `border:none`,
-    `outline:${outlineStyle}`, `outline-offset:-1px`,
+    `outline:${outlineStyle}`, `outline-offset:1px`,
     `border-radius:${borderRadius}`,
     `background:${bgColor}`, `color:${textColor}`,
     `resize:none`, `z-index:100`,

--- a/site/css/ai.css
+++ b/site/css/ai.css
@@ -502,6 +502,9 @@
   border-left: 3px solid #6C5CE7;
   color: var(--fd-text, #1D1D1F);
   border-radius: 4px 12px 12px 12px;
+  user-select: text;
+  -webkit-user-select: text;
+  cursor: text;
 }
 .dark-canvas .ai-chat-msg.assistant,
 .dark-theme .ai-chat-msg.assistant {

--- a/site/css/panels.css
+++ b/site/css/panels.css
@@ -55,6 +55,8 @@
   font-size: 11px;
   color: var(--fd-text);
   overflow: hidden;
+  user-select: text;
+  -webkit-user-select: text;
   /* Slide transition — GPU-composited, never triggers canvas resize */
   transform: translateX(0);
   transition: transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1),

--- a/site/index.html
+++ b/site/index.html
@@ -480,8 +480,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.378"></script>
-  <script type="module" src="app.js?v=0.11.378"></script>
+  <script src="context-menu.js?v=0.11.377"></script>
+  <script type="module" src="app.js?v=0.11.377"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
## Changes

### #1 — Text Selectability (CSS)
- Add `user-select: text` to `#right-panel` (overrides parent canvas `user-select: none`)
- Add `user-select: text; cursor: text` to `.ai-chat-msg.assistant`

### #2 — SSE Stream Error Handling
- Handle `null` response tokens from Cloudflare Workers AI (Gemma 4 known issue)
- Log SSE parse errors with payload context instead of silent `catch (_) {}`
- Improve user-facing error message for empty responses

### #3 — Inline Text Editor Polish
- Add Figma-inspired blue outline ring (`1.5px solid rgba(0,122,255,0.35)`)
- Add subtle elevation shadow for transparent-bg text nodes
- Lighter ring for shapes with fill backgrounds
- Changed outline-offset from -1px to 1px (ring outside, not clipping text)

### #4 — Auto-Retry on Empty AI Response (max 2)
- On empty stream accumulation, retry up to 2 times via non-streaming fallback
- Each retry uses the same chat context but `stream: false` for reliability
- Rate limit UI updated from retry response if successful
- Console warnings for retry diagnostics

## Testing
- Smart Skip: No crates/ changes → Rust/WASM tests skipped
- Site-only CSS+JS changes — visual verification via browser