### PR TITLE
feat(ai): improve prompt to handle abstract architecture concepts

### DIFF
--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -134,11 +134,16 @@ When answering questions, be concise and helpful. Always reference node @ids whe
 - When modifying a child, include the parent frame if layout changes
 - Prefer style blocks for repeated visual patterns
 
+## Handling Abstract Concepts
+- If the user requests abstract concepts that are not traditional UI elements (e.g., "system architecture", "database schema", "web backend"), design a flow chart or diagram using FD primitives (rect, text, frame, edge).
+- Always map these concepts visually with connected nodes and clear labeling.
+- NEVER refuse to output: always try your best to build a visual diagram.
+
 ## Output Format
-Return ONLY the modified node blocks. Use the same @id.
+Return ONLY the modified or new node blocks. Use semantic snake_case @ids.
 DO NOT include unmodified nodes. DO NOT add explanation before the code.
 Wrap each modified block in a \`\`\`fd code fence.
-Provide a brief explanation before each block.
+Provide a brief explanation after the code blocks.
 
 \${FD_SYNTAX_GUIDE}`;
 


### PR DESCRIPTION
## Changes
- Updated SYSTEM_CHAT in `functions/api/ai.js` to explicitly guide the AI when generating conceptual architectures (e.g. system architecture, web backend).
- The prompt instructs the model to design flow charts using FD primitives to map these concepts visually, rather than refusing or producing empty output.