### PR TITLE
fix(ai): Fix undefined property in rate limiting

### DIFF
--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -217,7 +217,7 @@ const SYSTEM_DEFAULT = `You are an expert UI designer. Return ONLY valid FD text
 async function checkRateLimit(context) {
   if (context.env.DISABLE_RATE_LIMIT) return { allowed: true, remaining: 5000, limit: 5000 };
 
-  const ip = context.req.headers.get('CF-Connecting-IP') || 'unknown';
+  const ip = context.request.headers.get('CF-Connecting-IP') || 'unknown';
   const { success, limit, remaining } = await context.env.AI_RATE_LIMITER.limit({ key: ip });
   return { allowed: success, remaining, limit };
 }


### PR DESCRIPTION
Uses context.request instead of context.req in checkRateLimit which is correct for Pages Functions.