### PR TITLE
fix: sticky marquee outside canvas + upgrade AI model to Gemma 4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,12 @@
 > Tracks requirement completion status across the entire FD project.
 
 ## [Unreleased]
+
+### v0.11.382 — Fix Sticky Marquee & AI Architecture Quality
+- **FIX (Canvas)**: Hardened `pointercancel` handler to call `fdCanvas.cancel_drag()`, clearing WASM marquee/lasso/eraser state when the browser drops pointer capture (e.g., OS gesture intercept, app switch). Extended `pointerleave`/`pointerenter` fallbacks to detect any active WASM interaction (`activePointerId !== -1`), not just pan/zoom state.
+- **FIX (AI)**: Upgraded default AI model from `llama-3.1-8b-instruct` to `gemma-4-26b-a4b-it` (Gemma 4 26B). The 8B model was too small for reliable FD code generation, producing text nodes without `text:` property (blank nodes). The code comment already specified Gemma 4 as the intended default.
+- **FIX (AI)**: Strengthened CRITICAL RULE #1 in AI system prompt to explicitly forbid text nodes without `text:` property, preventing blank node generation.
+- **UX (AI)**: Replaced 'Align Objects' quick-action chip with '🏗️ Architecture' chip that pre-populates a detailed architecture diagram prompt with specific instructions for colored frames, text labels, and connecting edges.
 - **FEAT (AI)**: Overhauled AI Agent system prompts for dramatically higher-quality FD code generation. Prompts now include comprehensive syntax reference with explicit text node syntax, layout-first design rules, design quality standards, and 3 golden examples (Login Form, Dashboard, Architecture Diagram).
 - **FEAT (AI)**: Dual-action Apply mechanism — AI-generated complete designs now show "⟳ Replace Canvas" (blue, replaces all content) and "+ Merge" (green, appends to existing). Detection via `isCompleteDesign()` heuristic counting node + style blocks.
 - **FIX (AI)**: 3-tier fallback now gracefully skips Workers AI when binding is unavailable, going directly to Ollama Cloud or OpenRouter. Previously, missing AI binding caused hard 503 errors blocking all local dev.

--- a/fd-vscode/package-lock.json
+++ b/fd-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fast-draft",
-  "version": "0.11.380",
+  "version": "0.11.382",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fast-draft",
-      "version": "0.11.380",
+      "version": "0.11.382",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/fd-vscode/package.json
+++ b/fd-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "fast-draft",
   "displayName": "Fast Draft",
   "description": "Design as Code — The world's first AI-native semantic layout engine.",
-  "version": "0.11.381",
+  "version": "0.11.382",
   "publisher": "khangnghiem",
   "license": "MIT",
   "icon": "icon.png",

--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -40,8 +40,8 @@ const KV_TTL_SECONDS = 86400;
 
 // ─── Default Models (override via env vars) ──────────────────────────────
 
-const DEFAULT_MODEL_FAST = '@cf/meta/llama-3.1-8b-instruct';
-const DEFAULT_MODEL_QUALITY = '@cf/meta/llama-3.1-8b-instruct';
+const DEFAULT_MODEL_FAST = '@cf/google/gemma-4-26b-a4b-it';
+const DEFAULT_MODEL_QUALITY = '@cf/google/gemma-4-26b-a4b-it';
 
 // ─── Model Aliases (for admin URL param override) ────────────────────────
 
@@ -122,7 +122,7 @@ const SYSTEM_CHAT = `You are an expert visual designer working with the FD (Fast
 
 ## CRITICAL RULES (must follow)
 
-1. **Text Content**: Use \`text @id { text: "content" }\` — NEVER \`text @id "content" { }\`
+1. **Text Content**: EVERY text node MUST have a \`text: "..."\` property with non-empty content. Use \`text @id { text: "content" }\` — NEVER \`text @id "content" { }\` and NEVER \`text @id { font: ... }\` without text:.
 2. **Layout First**: ALWAYS wrap related elements in a \`frame\` with \`layout: column\` or \`layout: row\`. NO loose top-level nodes with absolute x/y.
 3. **Unique IDs**: ALL @ids MUST be globally unique. Prefix with context: @login_title, @login_email, @login_btn.
 4. **Nesting**: Children MUST be inside parent braces. Never declare children as separate top-level blocks.

--- a/site/ai-chat.js
+++ b/site/ai-chat.js
@@ -130,9 +130,9 @@ export function updateContextBadge() {
 // ─── Quick-Action Chips ─────────────────────────────────
 
 const CHIPS_NONE = [
+  { label: '🏗️ Architecture', msg: 'Create a web application architecture diagram with Frontend, Backend, API Gateway, and Database layers. Use colored frames for each layer with text labels, and connecting edges between layers.' },
   { label: 'Suggest Variants', msg: 'Suggest layout or color variants for this design' },
   { label: 'Edit Style', msg: 'Improve the color palette to be more harmonious and modern' },
-  { label: 'Align Objects', msg: 'Align and arrange the layout cleanly' },
 ];
 
 const CHIPS_SINGLE = [

--- a/site/app.js
+++ b/site/app.js
@@ -5417,14 +5417,21 @@ async function initPlayground() {
       if (e.pointerId === activePointerId) {
         activePointerId = -1;
         panDragging = false;
+        // Cancel any WASM drag/marquee state that would otherwise stick
+        if (fdCanvas && fdCanvas.cancel_drag) {
+          fdCanvas.cancel_drag();
+        }
+        lassoActive = false;
+        eraserActive = false;
         canvas.style.cursor = '';
+        renderDirty = true;
       }
     });
 
     canvas.addEventListener('pointerleave', (e) => {
       // Fallback: if pointer capture was lost (e.g. browser bug, OS gesture intercept)
-      // and pointer exits with no buttons held, clean up.
-      if (e.buttons === 0 && (panDragging || rightClickPending || zoomScrubActive)) {
+      // and pointer exits with no buttons held, clean up any active interaction.
+      if (e.buttons === 0 && (panDragging || rightClickPending || zoomScrubActive || activePointerId !== -1)) {
         clearInteractionState();
       }
     });
@@ -5432,7 +5439,7 @@ async function initPlayground() {
     canvas.addEventListener('pointerenter', (e) => {
       // Fallback: if pointer re-enters with no buttons held, the release was missed
       // outside the window while capture was inactive.
-      if (e.buttons === 0 && (panDragging || rightClickPending || zoomScrubActive)) {
+      if (e.buttons === 0 && (panDragging || rightClickPending || zoomScrubActive || activePointerId !== -1)) {
         clearInteractionState();
       }
     });

--- a/site/index.html
+++ b/site/index.html
@@ -20,15 +20,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" />
   <!-- Preload WASM for instant startup -->
-  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.381" />
-  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.381" as="fetch" crossorigin fetchpriority="high" />
+  <link rel="modulepreload" href="./wasm/fd_wasm.js?v=0.11.382" />
+  <link rel="preload" href="./wasm/fd_wasm_bg.wasm?v=0.11.382" as="fetch" crossorigin fetchpriority="high" />
   <!-- Security: DOMPurify for streaming AI Markdown -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
   <!-- Preload local vendor bundle (CodeMirror + lz-string, no CDN) -->
   <link rel="modulepreload" href="./vendor/cm.min.js" />
   <script src="icons.js"></script>
-  <link rel="stylesheet" href="shared.css?v=0.11.381" />
-  <link rel="stylesheet" href="style.css?v=0.11.381" />
+  <link rel="stylesheet" href="shared.css?v=0.11.382" />
+  <link rel="stylesheet" href="style.css?v=0.11.382" />
 
   <!-- ── Layout State Machine ──
        Sets data-attrs + CSS vars on <html> SYNCHRONOUSLY before <body> parse.
@@ -480,8 +480,8 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-  <script src="context-menu.js?v=0.11.381"></script>
-  <script type="module" src="app.js?v=0.11.381"></script>
+  <script src="context-menu.js?v=0.11.382"></script>
+  <script type="module" src="app.js?v=0.11.382"></script>
   <script>
     // Mobile menu toggle
     document.getElementById('mobile-menu-btn')?.addEventListener('click', function() {


### PR DESCRIPTION
## Changes

### Fix 1: Sticky Marquee Selection (Canvas Interaction)
- Hardened `pointercancel` handler to call `fdCanvas.cancel_drag()` when the browser drops pointer capture
- Extended `pointerleave`/`pointerenter` fallbacks to detect active WASM interactions (`activePointerId !== -1`)
- Fixes: marquee selection persisting when mouse exits canvas bounds

### Fix 2: AI Blank Nodes (Architecture Generation)  
- Upgraded default AI model from `llama-3.1-8b-instruct` to `gemma-4-26b-a4b-it` (Gemma 4 26B)
- Strengthened CRITICAL RULE #1 in system prompt to explicitly forbid text nodes without `text:` property
- Added '🏗️ Architecture' quick-action chip with pre-structured diagram prompt

### Files Changed
- `site/app.js` — pointer event hardening
- `functions/api/ai.js` — model upgrade + prompt fix
- `site/ai-chat.js` — architecture chip
- `docs/CHANGELOG.md` — v0.11.382 entry