### PR TITLE
fix(layout): constrain text-in-shape width to parent bounds

### DIFF
--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -488,20 +488,22 @@ fn resolve_children(
 
                 // Priority 2: auto-center text children in shape parents
                 // (no explicit place: and no Position constraint)
-                // Uses padded bounds for centering area
+                // Uses padded bounds for centering area.
+                // Width constrained to content_w so text wraps within parent.
                 if parent_is_shape
                     && matches!(child_node.kind, NodeKind::Text { .. })
                     && !has_position
                     && let Some(child_b) = bounds.get(&child_idx).copied()
                 {
-                    let cx = content_x + (content_w - child_b.width) / 2.0;
+                    let constrained_w = content_w.min(child_b.width);
+                    let cx = content_x + (content_w - constrained_w) / 2.0;
                     let cy = content_y + (content_h - child_b.height) / 2.0;
                     bounds.insert(
                         child_idx,
                         ResolvedBounds {
                             x: cx,
                             y: cy,
-                            width: child_b.width,
+                            width: constrained_w,
                             height: child_b.height,
                         },
                     );

--- a/crates/fd-core/src/layout_tests.rs
+++ b/crates/fd-core/src/layout_tests.rs
@@ -1107,3 +1107,54 @@ rect @btn {
         btn.width
     );
 }
+
+#[test]
+fn layout_text_in_rect_constrained_to_parent_width() {
+    let input = r#"
+rect @box {
+  w: 160 h: 120
+  text @long "This is a very long text string that would normally exceed the parent width as a single line because it has many words" {
+    font: "Inter" 400 14
+  }
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let viewport = Viewport {
+        width: 800.0,
+        height: 600.0,
+    };
+    let bounds = resolve_layout(&graph, viewport);
+
+    let box_b = bounds[&graph.index_of(NodeId::intern("box")).unwrap()];
+    let long_b = bounds[&graph.index_of(NodeId::intern("long")).unwrap()];
+
+    assert!(
+        long_b.width <= box_b.width + 1.0,
+        "text width ({}) should be <= parent width ({}) — text must not overflow rect",
+        long_b.width,
+        box_b.width
+    );
+}
+
+#[test]
+fn layout_text_standalone_stays_unconstrained() {
+    let input = r#"
+text @free "This is a long standalone text that should not wrap because it has no parent shape" {
+  font: "Inter" 400 14
+}
+"#;
+    let graph = parse_document(input).unwrap();
+    let viewport = Viewport {
+        width: 800.0,
+        height: 600.0,
+    };
+    let bounds = resolve_layout(&graph, viewport);
+
+    let free_b = bounds[&graph.index_of(NodeId::intern("free")).unwrap()];
+
+    assert!(
+        free_b.width > 160.0,
+        "standalone text width ({}) should be > 160 — must not be artificially constrained",
+        free_b.width
+    );
+}

--- a/crates/fd-wasm/src/render2d.rs
+++ b/crates/fd-wasm/src/render2d.rs
@@ -556,7 +556,10 @@ fn draw_text(
     ctx.set_text_baseline(text_baseline_str);
 
     let line_height = (size * 1.2) as f64;
-    let wrap_width = max_width.map(|w| w as f64);
+    let mut wrap_width = max_width.map(|w| w as f64);
+    if in_shape && wrap_width.is_none() {
+        wrap_width = Some(b.width as f64);
+    }
 
     // Build lines: split by existing newlines, then word-wrap within wrap_width
     let lines: Vec<String> = if let Some(ww) = wrap_width {


### PR DESCRIPTION
## Summary
- Text children inside Free-layout shape parents (Rect/Ellipse/Frame) now inherit parent `content_w` as a width cap, preventing single-line overflow beyond the shape boundary
- Canvas2D renderer falls back to resolved bounds width for `in_shape` text with no explicit `max_width`, ensuring word-wrap parity with the inline DOM textarea
- Standalone text nodes remain unconstrained (only explicit `limit`/`max_width` applies)

## Changes
| File | What |
|------|------|
| `crates/fd-core/src/layout.rs` | `LayoutMode::Free` Priority 2: use `content_w.min(child_b.width)` instead of unconstrained `child_b.width` |
| `crates/fd-wasm/src/render2d.rs` | `draw_text()`: when `in_shape && wrap_width.is_none()`, fall back to `b.width` |
| `crates/fd-core/src/layout_tests.rs` | +2 tests: `layout_text_in_rect_constrained_to_parent_width`, `layout_text_standalone_stays_unconstrained` |

## Testing
- ✅ 309 Rust unit tests (+2 new layout tests)
- ✅ 208 VS Code TS tests
- ✅ Playwright E2E: dblclick rect → type long text → verify wrap within bounds
- ✅ Standalone text remains unconstrained (>160px width)
- ✅ Bidi-Sync roundtrip intact
- ✅ Clippy, fmt, Tauri check all pass