### PR TITLE
fix: export-all on empty selection, ⌘A select-all, copy toast

### DIFF
--- a/crates/fd-render/src/hit.rs
+++ b/crates/fd-render/src/hit.rs
@@ -125,7 +125,7 @@ impl SpatialIndex {
             }
         }
         // Sort by z_order descending (topmost first)
-        hits.sort_by(|a, b| b.0.cmp(&a.0));
+        hits.sort_by_key(|b| std::cmp::Reverse(b.0));
         hits.into_iter().map(|(_, id)| id).collect()
     }
 

--- a/crates/fd-wasm/src/export.rs
+++ b/crates/fd-wasm/src/export.rs
@@ -63,18 +63,24 @@ impl FdCanvas {
         self.compute_center_snap()
     }
 
-    /// Render only the selected nodes (and their children) to the given context.
+    /// Render selected nodes (and their children) to the given context.
+    /// When nothing is selected, renders all top-level nodes (entire canvas).
     pub fn render_export(&self, ctx: &CanvasRenderingContext2d, offset_x: f64, offset_y: f64) {
-        if self.select_tool.selected.is_empty() {
-            return;
-        }
-
-        let selected_ids: Vec<String> = self
-            .select_tool
-            .selected
-            .iter()
-            .map(|id| id.as_str().to_string())
-            .collect();
+        let selected_ids: Vec<String> = if self.select_tool.selected.is_empty() {
+            // Nothing selected → export everything (collect all top-level node IDs)
+            self.engine
+                .graph
+                .children(self.engine.graph.root)
+                .into_iter()
+                .map(|idx| self.engine.graph.graph[idx].id.as_str().to_string())
+                .collect()
+        } else {
+            self.select_tool
+                .selected
+                .iter()
+                .map(|id| id.as_str().to_string())
+                .collect()
+        };
 
         render2d::render_export(
             ctx,

--- a/crates/fd-wasm/src/search.rs
+++ b/crates/fd-wasm/src/search.rs
@@ -149,7 +149,7 @@ impl FdCanvas {
         }
 
         // Sort by score descending (exact matches first, then fuzzy by quality)
-        results.sort_by(|a, b| b.score.cmp(&a.score));
+        results.sort_by_key(|r| std::cmp::Reverse(r.score));
 
         serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string())
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### v0.11.383 — Fix Export-All, Select-All & Copy Toast
+- **FIX (Canvas)**: `render_export()` no longer bails when selection is empty — it renders all top-level nodes (entire canvas), matching SVG/HTML/Excalidraw export behavior. Fixes broken "Copy as PNG" when nothing is selected.
+- **FIX (Canvas)**: ⌘A / Ctrl+A now calls `fdCanvas.select_all()` WASM API instead of a broken regex that only matched the first `@id`. All unlocked nodes + edges are now selected.
+- **UX (Canvas)**: `copySelectedAsFd()` (⌘C) now shows a toast notification ("✓ Copied as FD code") on both the multi-node and single-node clipboard paths.
+- **FIX (Cache)**: Bumped WASM import cache-buster from `0.11.309` → `0.11.383`.
+
 ### v0.11.382 — Fix Sticky Marquee & AI Architecture Quality
 - **FIX (Canvas)**: Hardened `pointercancel` handler to call `fdCanvas.cancel_drag()`, clearing WASM marquee/lasso/eraser state when the browser drops pointer capture (e.g., OS gesture intercept, app switch). Extended `pointerleave`/`pointerenter` fallbacks to detect any active WASM interaction (`activePointerId !== -1`), not just pan/zoom state.
 - **FIX (AI)**: Upgraded default AI model from `llama-3.1-8b-instruct` to `gemma-4-26b-a4b-it` (Gemma 4 26B). The 8B model was too small for reliable FD code generation, producing text nodes without `text:` property (blank nodes). The code comment already specified Gemma 4 as the intended default.

--- a/site/app.js
+++ b/site/app.js
@@ -1,5 +1,5 @@
 import { initLayersPanel } from './layers.js?v=0.11.309';
-import init, { FdCanvas } from './wasm/fd_wasm.js?v=0.11.309';
+import init, { FdCanvas } from './wasm/fd_wasm.js?v=0.11.383';
 import { buildUnifiedNodeMenu, buildUnifiedCanvasMenu, buildUnifiedEdgeMenu } from './canvas-core/menu-registry.js?v=0.11.334';
 // ─── FD Playground — WASM-powered interactive editor ───
 
@@ -2086,6 +2086,7 @@ function copySelectedAsFd() {
       if (navigator.clipboard) {
         navigator.clipboard.writeText(fdClipboard).catch(() => {});
       }
+      showToast('✓ Copied as FD code');
       return;
     }
   } catch (_) {}
@@ -2101,6 +2102,7 @@ function copySelectedAsFd() {
   if (navigator.clipboard) {
     navigator.clipboard.writeText(fdClipboard).catch(() => {});
   }
+  showToast('✓ Copied as FD code');
 }
 
 /** Cut the selected node — copy then delete. */
@@ -5806,11 +5808,9 @@ async function initPlayground() {
       // ── Select All (⌘A / Ctrl+A) ──
       if ((e.metaKey || e.ctrlKey) && (e.key.toLowerCase() === 'a') && !e.shiftKey && !editorFocused) {
         e.preventDefault();
-        // Select first visible node as a basic select-all
-        const text = fdCanvas.get_text();
-        const idRe = /@([a-zA-Z_][a-zA-Z0-9_]*)/;
-        const m = idRe.exec(text);
-        if (m) { fdCanvas.select_by_id(m[1]); renderDirty = true; uiDirty = true; }
+        const count = fdCanvas.select_all();
+        renderDirty = true; uiDirty = true;
+        if (count > 0) showToast(`Selected all (${count})`);
         return;
       }
 


### PR DESCRIPTION
- render_export() renders all top-level nodes when nothing is selected,
  matching SVG/Excalidraw export behavior (was returning early)
- ⌘A uses fdCanvas.select_all() WASM API instead of broken regex
  that only matched the first @id in the document
- copySelectedAsFd() shows '✓ Copied as FD code' toast on ⌘C
- Bumped WASM import cache-buster to 0.11.383
