### PR TITLE
fix: migrate Ollama Cloud to OpenAI-compatible /v1/chat/completions

### DIFF
--- a/.agents/workflows/yolo.md
+++ b/.agents/workflows/yolo.md
@@ -22,10 +22,14 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 2. **TDD (Tests)**: Write/update tests in `mod tests` for what changed.
 3. **Lint & Format**: `cargo clippy --workspace --quiet -- -D warnings` and `cargo fmt --all`
 4. **Test**: `cargo test --workspace --quiet`
-5. **UI Bug Verify**: Measure interaction fixes visually or via `execute_browser_javascript` before committing.
+5. **UI Bug Verify**: Measure interaction fixes visually before committing.
+   - Antigravity: use `execute_browser_javascript` to inspect DOM/WASM state
+   - OpenCode: write a Playwright script using `page.evaluate()` (see `tests/check_drag.mjs` for pattern)
 6. **Tauri**: `cd fd-desktop/src-tauri && cargo check --quiet && cargo clippy --quiet -- -D warnings && cargo fmt -- --check`
 7. **TS tests**: `cd fd-vscode && pnpm install && pnpm test`
-8. **Tier 1 E2E Smoke**: Build WASM (`wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm --quiet && cp -a ../../fd-vscode/webview/wasm/. site/wasm/`). Use `browser_subagent` to load the local site and execute the Tier 1 checks from `/e2e`.
+8. **Tier 1 E2E Smoke**: Build WASM (`wasm-pack build crates/fd-wasm --target web --out-dir ../../fd-vscode/webview/wasm --quiet && cp -a ../../fd-vscode/webview/wasm/. site/wasm/`).
+   - Antigravity: use `browser_subagent` to load the local site and execute the Tier 1 checks from `/e2e`
+   - OpenCode: `npx serve site -l 8081 &` → run Playwright test script in `tests/` (e.g. `node tests/check_wasm.mjs`) → `kill %1`
 9. **Report** and STOP for `/yolo local`.
 
 ## `/yolo deploy`
@@ -42,6 +46,7 @@ description: Full pipeline - test, build, commit, PR, and merge in one shot
 19. **Merge**: `gh pr merge $(git branch --show-current) --squash --delete-branch`
 20. **Sync**: `git checkout main && git pull origin main`
 21. **Site Verify**: Wait for `pages.yml` deploy (`gh run watch $(gh run list --workflow=pages.yml -L 1 --json databaseId -q ".[0].databaseId")`).
-    Use `browser_subagent` to navigate to the live site and execute Tier 2 JS Assertions from `/e2e`.
-22. **Publish VS Code**: `cd fd-vscode && pnpm install && pnpm run compile && source ../.env && npx vsce publish --no-dependencies -p $VSCE_PAT && npx ovsx publish --no-dependencies -p $OVSX_PAT`
+   - Antigravity: use `browser_subagent` to navigate to the live site and execute Tier 2 JS Assertions from `/e2e`
+   - OpenCode: `npx serve site -l 8081 &` → run Playwright test script in `tests/` (e.g. `node tests/check_errors.mjs`) → `kill %1`
+22. **Publish VS Code**: `cd fd-vscode && pnpm install && pnpm run compile && source ../.env && npx vsce publish --no-dependencies -p $VSCE_PAT && npx ovsx publish --no-dependencies -p $VSX_PAT`
 23. **Report** completion.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### v0.11.384 — Fix Ollama Cloud API (Tier 2 Fallback)
+- **FIX (AI)**: Migrated Ollama Cloud from deprecated `/api/chat` to OpenAI-compatible `/v1/chat/completions` endpoint. Old endpoint returned `200` with empty body, causing "AI returned an empty response" errors.
+- **FIX (AI)**: Updated request format from Ollama-native (`options.temperature`, `options.num_predict`) to OpenAI-standard (`temperature`, `max_tokens`).
+- **FIX (AI)**: Rewrote `ollamaCloudToCFStream()` to parse OpenAI SSE format (`data: {"choices":[{"delta":{"content":"..."}}]}`) instead of Ollama NDJSON.
+- **FIX (AI)**: All Ollama model mappings now use `-cloud` suffix (e.g. `gemma4:31b-cloud`) required by Ollama Cloud API. Default fallback upgraded from `llama3.1:8b` to `gemma4:31b-cloud`.
+- **FIX (Workflow)**: Fixed `$OVSX_PAT` → `$VSX_PAT` in `yolo.md` to match `.env` variable name.
+
 ### v0.11.383 — Fix Export-All, Select-All & Copy Toast
 - **FIX (Canvas)**: `render_export()` no longer bails when selection is empty — it renders all top-level nodes (entire canvas), matching SVG/HTML/Excalidraw export behavior. Fixes broken "Copy as PNG" when nothing is selected.
 - **FIX (Canvas)**: ⌘A / Ctrl+A now calls `fdCanvas.select_all()` WASM API instead of a broken regex that only matched the first `@id`. All unlocked nodes + edges are now selected.

--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -347,28 +347,29 @@ function computeScore(categories) {
 // ─── Fallback Models Mapping ─────────────────────────────────────────────
 
 function getFallbackModels(model) {
-  // Returns [OllamaModel, OpenRouterModel]
+  // Returns [OllamaCloudModel, OpenRouterModel]
+  // Ollama Cloud API requires '-cloud' suffix models
   let ollamaModel = model;
   let orModel = model;
 
   if (model.includes('llama-3.1-8b')) {
-    ollamaModel = 'llama3.1:8b'; orModel = 'meta-llama/llama-3.1-8b-instruct';
+    ollamaModel = 'llama3.1:8b-cloud'; orModel = 'meta-llama/llama-3.1-8b-instruct';
   } else if (model.includes('llama-3.2-1b')) {
-    ollamaModel = 'llama3.2:1b'; orModel = 'meta-llama/llama-3.2-1b-instruct';
+    ollamaModel = 'llama3.2:1b-cloud'; orModel = 'meta-llama/llama-3.2-1b-instruct';
   } else if (model.includes('llama-3.2-3b')) {
-    ollamaModel = 'llama3.2:3b'; orModel = 'meta-llama/llama-3.2-3b-instruct';
+    ollamaModel = 'llama3.2:3b-cloud'; orModel = 'meta-llama/llama-3.2-3b-instruct';
   } else if (model.includes('llama-3.3-70b')) {
-    ollamaModel = 'llama3.3:70b'; orModel = 'meta-llama/llama-3.3-70b-instruct';
+    ollamaModel = 'llama3.3:70b-cloud'; orModel = 'meta-llama/llama-3.3-70b-instruct';
   } else if (model.includes('gemma-4')) {
-    ollamaModel = 'gemma4:26b'; orModel = 'google/gemma-4-26b-a4b-it';
+    ollamaModel = 'gemma4:31b-cloud'; orModel = 'google/gemma-4-26b-a4b-it';
   } else if (model.includes('gemma-3')) {
-    ollamaModel = 'gemma2:9b'; orModel = 'google/gemma-3-12b-it';
+    ollamaModel = 'gemma3:12b-cloud'; orModel = 'google/gemma-3-12b-it';
   } else if (model.includes('qwen2.5-coder')) {
-    ollamaModel = 'qwen2.5-coder:32b'; orModel = 'qwen/qwen-2.5-coder-32b-instruct';
+    ollamaModel = 'qwen2.5-coder:32b-cloud'; orModel = 'qwen/qwen-2.5-coder-32b-instruct';
   } else if (model.includes('deepseek-r1')) {
-    ollamaModel = 'deepseek-r1:32b'; orModel = 'deepseek/deepseek-r1-distill-qwen-32b';
+    ollamaModel = 'deepseek-r1:32b-cloud'; orModel = 'deepseek/deepseek-r1-distill-qwen-32b';
   } else {
-    ollamaModel = 'llama3.1:8b';
+    ollamaModel = 'gemma4:31b-cloud';
     orModel = !model.startsWith('@cf/') ? model : 'google/gemma-4-26b-a4b-it';
   }
 
@@ -376,6 +377,7 @@ function getFallbackModels(model) {
 }
 
 // ─── Ollama Cloud Integration (Tier 2) ───────────────────────────────────
+// Uses the OpenAI-compatible /v1/chat/completions endpoint.
 
 async function runWithOllamaCloud(env, model, messages, maxTokens, temp, stream) {
   const [ollamaModel] = getFallbackModels(model);
@@ -385,7 +387,7 @@ async function runWithOllamaCloud(env, model, messages, maxTokens, temp, stream)
 
   let response;
   try {
-    response = await fetch('https://ollama.com/api/chat', {
+    response = await fetch('https://ollama.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${env.OLLAMA_API_KEY}`,
@@ -395,7 +397,8 @@ async function runWithOllamaCloud(env, model, messages, maxTokens, temp, stream)
         model: ollamaModel,
         messages,
         stream: !!stream,
-        options: { temperature: temp, num_predict: maxTokens },
+        temperature: temp,
+        max_tokens: maxTokens,
       }),
       signal: controller.signal
     });
@@ -414,31 +417,38 @@ async function runWithOllamaCloud(env, model, messages, maxTokens, temp, stream)
   }
 
   if (stream) {
+    // OpenAI-compatible SSE → CF Workers AI SSE
     return response.body.pipeThrough(ollamaCloudToCFStream());
   }
   const data = await response.json();
-  return { response: data.message?.content || '' };
+  const content = data.choices?.[0]?.message?.content || '';
+  return { response: content };
 }
 
 function ollamaCloudToCFStream() {
+  // Transforms OpenAI-compatible SSE (data: {"choices":[{"delta":{"content":"..."}}]})
+  // into CF Workers AI SSE format (data: {"response":"..."})
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   let buffer = '';
 
   const processLines = (lines, controller) => {
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const data = JSON.parse(line);
-        const content = data.message?.content;
-        if (content) {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ response: content })}\n\n`));
-        }
-        if (data.done) {
+    for (let line of lines) {
+      if (line.startsWith('data: ')) {
+        const payload = line.slice(6).trim();
+        if (payload === '[DONE]') {
           controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          continue;
         }
-      } catch (e) {
-        console.warn('Ollama stream parse error:', e.message);
+        try {
+          const data = JSON.parse(payload);
+          const content = data.choices?.[0]?.delta?.content;
+          if (content) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ response: content })}\n\n`));
+          }
+        } catch (e) {
+          console.warn('Ollama stream parse error:', e.message);
+        }
       }
     }
   };


### PR DESCRIPTION
Old /api/chat endpoint returned 200 + empty body, breaking Tier 2 fallback.
New endpoint uses OpenAI format (temperature, max_tokens, SSE streaming).
All model mappings now use -cloud suffix required by Ollama Cloud API.
Also fixed $OVSX_PAT → $VSX_PAT in yolo.md workflow.
