### PR TITLE
fix: detect Workers AI empty response + force_ollama on retry

### DIFF
--- a/functions/api/ai.js
+++ b/functions/api/ai.js
@@ -564,12 +564,26 @@ async function runAI(env, { config, aiMessages, stream, shouldUseOpenRouter, ove
   const hasWorkersAI = env.AI && typeof env.AI.run === 'function';
   if (hasWorkersAI) {
     try {
-      return await env.AI.run(config.model, {
+      const result = await env.AI.run(config.model, {
         messages: aiMessages,
         max_tokens: config.maxTokens,
         temperature: config.temp,
         stream,
       });
+
+      // For non-streaming: check if Workers AI returned empty content
+      // (happens under load or when model is warming up)
+      if (!stream) {
+        const content = result?.response || '';
+        if (!content.trim()) {
+          console.log(JSON.stringify({ event: 'ai_fallback', from: 'workers_ai', reason: 'empty_response', model: config.model }));
+          // Fall through to Ollama/OpenRouter
+        } else {
+          return result;
+        }
+      } else {
+        return result;
+      }
     } catch (e) {
       const isQuotaError = e.message && (/\b429\b/i.test(e.message) || /\b(rate limit|quota)\b/i.test(e.message));
       const isTransientError = e.message && (e.message.includes('502') || e.message.includes('503'));

--- a/site/ai-chat.js
+++ b/site/ai-chat.js
@@ -653,6 +653,7 @@ async function sendMessage(getEditorContent, setEditorContent) {
                 selection: selFd ? selFd.slice(0, 4000) : undefined,
                 selection_ids: selIds.length > 0 ? selIds : undefined,
                 stream: false,
+                force_ollama: true, // Bypass Workers AI which returned empty
                 model_hint: new URLSearchParams(window.location.search).get('ai_model') || undefined,
               }),
             });


### PR DESCRIPTION
Workers AI sometimes returns 200 OK with empty content for Gemma 4.
- Non-streaming: detect empty result.response and fall through to Ollama
- Frontend retry: send force_ollama=true to bypass Workers AI on retry
- Ensures at least one provider actually generates content
