### PR TITLE
⚡ Bolt: [O(N^2) Layout Optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-24 - [Avoid O(N^2) in Vector Membership Checks]
 **Learning:** Using `Vec::contains()` in a loop creates an O(N^2) complexity bottleneck, especially when preserving insertion order in layout algorithms.
 **Action:** When maintaining ordered collections (like `Vec<String>` for struct fields), use a local `HashSet<String>` alongside it for O(1) membership checks during population to avoid lifetime complexities and performance hits.
+## 2024-05-24 - [Avoid O(N^2) Vector Membership Checks in Layout]
+**Learning:** Using `!flow_children.contains(&child_idx)` within a loop over all children in `Column`, `Row`, and `Grid` layout algorithms (`crates/fd-core/src/layout.rs`) introduces an O(N^2) complexity.
+**Action:** Replace `Vec::contains()` in loops by doing a single pass over the collection to partition it into separate vectors (e.g., `flow_children` and `abs_children`) using `.push()`, eliminating the bottleneck while preserving order.

--- a/crates/fd-core/src/layout.rs
+++ b/crates/fd-core/src/layout.rs
@@ -199,18 +199,22 @@ fn resolve_children(
     match layout {
         LayoutMode::Column { gap, pad, align } => {
             let content_width = parent_bounds.width - 2.0 * pad;
-            // Filter: children with Position constraints are absolutely positioned
+            // Partition: children with Position constraints are absolutely positioned
             // within the frame — they don't participate in the column flow.
-            let flow_children: Vec<NodeIndex> = children
-                .iter()
-                .copied()
-                .filter(|&ci| {
-                    !graph.graph[ci]
-                        .constraints
-                        .iter()
-                        .any(|c| matches!(c, Constraint::Position { .. }))
-                })
-                .collect();
+            let mut flow_children = Vec::new();
+            let mut abs_children = Vec::new();
+            for &ci in &children {
+                if graph.graph[ci]
+                    .constraints
+                    .iter()
+                    .any(|c| matches!(c, Constraint::Position { .. }))
+                {
+                    abs_children.push(ci);
+                } else {
+                    flow_children.push(ci);
+                }
+            }
+
             // Pass 1: initialize flow children at parent origin + pad
             for &child_idx in &flow_children {
                 let child_node = &graph.graph[child_idx];
@@ -235,17 +239,15 @@ fn resolve_children(
                 resolve_children(graph, child_idx, bounds, viewport);
             }
             // Absolutely-positioned children: initialize from intrinsic_size
-            for &child_idx in &children {
-                if !flow_children.contains(&child_idx) {
-                    let child_size = intrinsic_size(&graph.graph[child_idx]);
-                    bounds.entry(child_idx).or_insert(ResolvedBounds {
-                        x: parent_bounds.x,
-                        y: parent_bounds.y,
-                        width: child_size.0,
-                        height: child_size.1,
-                    });
-                    resolve_children(graph, child_idx, bounds, viewport);
-                }
+            for &child_idx in &abs_children {
+                let child_size = intrinsic_size(&graph.graph[child_idx]);
+                bounds.entry(child_idx).or_insert(ResolvedBounds {
+                    x: parent_bounds.x,
+                    y: parent_bounds.y,
+                    width: child_size.0,
+                    height: child_size.1,
+                });
+                resolve_children(graph, child_idx, bounds, viewport);
             }
             // Pass 2: reposition flow children using resolved sizes
             let mut y = parent_bounds.y + pad;
@@ -272,17 +274,21 @@ fn resolve_children(
         }
         LayoutMode::Row { gap, pad, align } => {
             let content_height = parent_bounds.height - 2.0 * pad;
-            // Filter: absolutely-positioned children skip the row flow
-            let flow_children: Vec<NodeIndex> = children
-                .iter()
-                .copied()
-                .filter(|&ci| {
-                    !graph.graph[ci]
-                        .constraints
-                        .iter()
-                        .any(|c| matches!(c, Constraint::Position { .. }))
-                })
-                .collect();
+            // Partition: absolutely-positioned children skip the row flow
+            let mut flow_children = Vec::new();
+            let mut abs_children = Vec::new();
+            for &ci in &children {
+                if graph.graph[ci]
+                    .constraints
+                    .iter()
+                    .any(|c| matches!(c, Constraint::Position { .. }))
+                {
+                    abs_children.push(ci);
+                } else {
+                    flow_children.push(ci);
+                }
+            }
+
             // Pass 1: initialize flow children
             for &child_idx in &flow_children {
                 let child_node = &graph.graph[child_idx];
@@ -307,17 +313,15 @@ fn resolve_children(
                 resolve_children(graph, child_idx, bounds, viewport);
             }
             // Absolutely-positioned children
-            for &child_idx in &children {
-                if !flow_children.contains(&child_idx) {
-                    let child_size = intrinsic_size(&graph.graph[child_idx]);
-                    bounds.entry(child_idx).or_insert(ResolvedBounds {
-                        x: parent_bounds.x,
-                        y: parent_bounds.y,
-                        width: child_size.0,
-                        height: child_size.1,
-                    });
-                    resolve_children(graph, child_idx, bounds, viewport);
-                }
+            for &child_idx in &abs_children {
+                let child_size = intrinsic_size(&graph.graph[child_idx]);
+                bounds.entry(child_idx).or_insert(ResolvedBounds {
+                    x: parent_bounds.x,
+                    y: parent_bounds.y,
+                    width: child_size.0,
+                    height: child_size.1,
+                });
+                resolve_children(graph, child_idx, bounds, viewport);
             }
             // Pass 2: reposition flow children
             let mut x = parent_bounds.x + pad;
@@ -348,17 +352,20 @@ fn resolve_children(
             pad,
             align,
         } => {
-            // Filter: absolutely-positioned children skip the grid flow
-            let flow_children: Vec<NodeIndex> = children
-                .iter()
-                .copied()
-                .filter(|&ci| {
-                    !graph.graph[ci]
-                        .constraints
-                        .iter()
-                        .any(|c| matches!(c, Constraint::Position { .. }))
-                })
-                .collect();
+            // Partition: absolutely-positioned children skip the grid flow
+            let mut flow_children = Vec::new();
+            let mut abs_children = Vec::new();
+            for &ci in &children {
+                if graph.graph[ci]
+                    .constraints
+                    .iter()
+                    .any(|c| matches!(c, Constraint::Position { .. }))
+                {
+                    abs_children.push(ci);
+                } else {
+                    flow_children.push(ci);
+                }
+            }
 
             // Grid cell width is based on parent width divided by cols, minus gaps
             let total_gap_w = gap * (cols.saturating_sub(1) as f32);
@@ -389,17 +396,15 @@ fn resolve_children(
                 resolve_children(graph, child_idx, bounds, viewport);
             }
             // Absolutely-positioned children
-            for &child_idx in &children {
-                if !flow_children.contains(&child_idx) {
-                    let child_size = intrinsic_size(&graph.graph[child_idx]);
-                    bounds.entry(child_idx).or_insert(ResolvedBounds {
-                        x: parent_bounds.x,
-                        y: parent_bounds.y,
-                        width: child_size.0,
-                        height: child_size.1,
-                    });
-                    resolve_children(graph, child_idx, bounds, viewport);
-                }
+            for &child_idx in &abs_children {
+                let child_size = intrinsic_size(&graph.graph[child_idx]);
+                bounds.entry(child_idx).or_insert(ResolvedBounds {
+                    x: parent_bounds.x,
+                    y: parent_bounds.y,
+                    width: child_size.0,
+                    height: child_size.1,
+                });
+                resolve_children(graph, child_idx, bounds, viewport);
             }
             // Pass 2: reposition flow children
             let mut x = parent_bounds.x + pad;


### PR DESCRIPTION
💡 What: Refactored `layout.rs` to eliminate `!flow_children.contains(&child_idx)` inside loops for layout modes `Column`, `Row`, and `Grid`. Instead, children are partitioned in a single $O(N)$ pass upfront.
🎯 Why: Calling `.contains()` on a Vector within an iteration loop creates an $O(N^2)$ algorithmic bottleneck, causing unnecessary layout slowdowns when a node has numerous children.
📊 Impact: Expected to reduce layout resolution time for densely-nested component trees from quadratic $O(N^2)$ complexity to linear $O(N)$ time per level.
🔬 Measurement: Verify by executing large canvas scenes and comparing layout computation times, or observe linear scaling in flamegraphs during `Column/Row/Grid` layouts.

---
*PR created automatically by Jules for task [17379924515743619625](https://jules.google.com/task/17379924515743619625) started by @khangnghiem*