### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in WASM error toast

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The Cloudflare Pages Function at `functions/api/ai.js` had an overly permissive CORS configuration (`Access-Control-Allow-Origin: *`), potentially allowing external sites to make cross-origin requests.
 **Learning:** Hardcoded wildcard `*` CORS configurations expose APIs to misuse from unauthorized domains. Because the API needs to be accessible from both the web playground (`https://fast-draft.com`) and the VS Code extension webviews (`vscode-webview://`), a dynamic CORS handler is required.
 **Prevention:** Avoid `*` in CORS origins. Implement dynamic CORS validation that checks the incoming `Origin` header against an explicitly defined whitelist (or prefix list, like `vscode-webview://`). Always include `Vary: Origin` in the response when returning dynamically set `Access-Control-Allow-Origin` headers.
+## 2024-05-18 - [WASM Error Toast XSS]
+**Vulnerability:** Unescaped WASM error messages were directly inserted into the DOM via innerHTML in showWasmErrorToast.
+**Learning:** Even internal error paths can be vectors for XSS if user-controlled input (like invalid FD syntax triggering a WASM error) is reflected back without sanitization. In a system where multiple JS files are concatenated (e.g. fd-vscode/webview), global sanitization functions like escapeHtml must be defined early in the dependency chain (like state.js) so they are available to later modules.
+**Prevention:** Always sanitize any dynamic content before injecting it into innerHTML, even in error handlers, and ensure the sanitization function is defined in scope.

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -10127,7 +10127,7 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -31,7 +31,7 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `showWasmErrorToast` function in `fd-vscode/webview/src/main.js` was directly inserting the `msg` parameter into the DOM using `toast.innerHTML` without sanitizing it.
🎯 Impact: If a user provided malicious Fast Draft syntax that triggered a WASM error containing their input, that input would be executed as raw HTML/JavaScript within the context of the VS Code webview, leading to a Cross-Site Scripting (XSS) vulnerability.
🔧 Fix: Wrapped the `msg` parameter in the globally available `escapeHtml` function (defined in `state.js`) before injecting it into the template literal for `toast.innerHTML`. Rebuilt the webview to propagate this change to `main.js`.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. The webview was rebuilt and the `main.js` file now correctly shows the escaped message.

---
*PR created automatically by Jules for task [16007610120722870393](https://jules.google.com/task/16007610120722870393) started by @khangnghiem*