### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in WASM error toast

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Vulnerability:** The Cloudflare Pages Function at `functions/api/ai.js` had an overly permissive CORS configuration (`Access-Control-Allow-Origin: *`), potentially allowing external sites to make cross-origin requests.
 **Learning:** Hardcoded wildcard `*` CORS configurations expose APIs to misuse from unauthorized domains. Because the API needs to be accessible from both the web playground (`https://fast-draft.com`) and the VS Code extension webviews (`vscode-webview://`), a dynamic CORS handler is required.
 **Prevention:** Avoid `*` in CORS origins. Implement dynamic CORS validation that checks the incoming `Origin` header against an explicitly defined whitelist (or prefix list, like `vscode-webview://`). Always include `Vary: Origin` in the response when returning dynamically set `Access-Control-Allow-Origin` headers.
+
+## 2026-04-20 - Cross-Site Scripting (XSS) in WASM Error Toast
+**Vulnerability:** Found an XSS vulnerability in `fd-vscode/webview/src/main.js` where the untrusted `msg` parameter of `showWasmErrorToast` was directly interpolated into `toast.innerHTML`.
+**Learning:** Error messages thrown from WASM or external bridges can sometimes contain user-controlled input (e.g. from parsing user documents). Even though it is an error log, rendering it to the DOM using `innerHTML` without sanitization creates an XSS vector in the webview.
+**Prevention:** Always escape dynamically generated strings before injecting them into HTML context via `innerHTML`, even for simple error toasts, or use safer APIs like `textContent`.

--- a/fd-vscode/scripts/build-webview.mjs
+++ b/fd-vscode/scripts/build-webview.mjs
@@ -81,6 +81,7 @@ function stripModuleSyntax(content) {
     .replace(/^export (let|const|function|class|async function) /gm, '$1 ')
     .replace(/^export \{[^}]*\};\s*$/gm, '')
     .replace(/^import \{[^}]*\} from '[^']*';\s*$/gm, '')
+    .replace(/^import \*\s+as\s+[A-Za-z0-9_]+\s+from\s+'[^']+';\s*$/gm, '')
     .replace(/^export default /gm, '');
 }
 

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -192,7 +192,6 @@ function showToast(message, durationMs = 1200, container = null) {
 // - Grid drawing utility
 // - Fit-to-content viewport calculation
 
-import * as S from './state.js';
 
 // ─── Tween Engine ────────────────────────────────────────────────────────
 
@@ -10138,7 +10137,7 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -31,7 +31,7 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `showWasmErrorToast` function directly interpolated the external WASM error message into the DOM using `toast.innerHTML` without sanitization. WASM errors often incorporate user inputs (e.g. malformed identifiers from parsing).
🎯 Impact: Potentially allows Cross-Site Scripting (XSS) within the VS Code Webview if an attacker can manipulate the input to trigger an error containing a malicious payload.
🔧 Fix: Wrapped the `msg` interpolation with the project's shared `escapeHtml` utility function.
✅ Verification: Ran `pnpm build:webview` to confirm module concatenation was correct, followed by `pnpm lint` and `pnpm test` in `fd-vscode`, which passed without regressions.

---
*PR created automatically by Jules for task [10484863891855857881](https://jules.google.com/task/10484863891855857881) started by @khangnghiem*