### PR TITLE
docs: add search tool hygiene policy

### DIFF
--- a/.agents/shared/canonical.md
+++ b/.agents/shared/canonical.md
@@ -26,6 +26,12 @@ Before changing any file:
 - Before adding or rewriting a requirement, search `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md`, and `docs/specs/` first.
 - If an existing requirement already covers the behavior, extend it instead of duplicating it.
 
+### Search tool hygiene
+
+- Prefer the host-native content-search tool when searching file contents.
+- When shell-based content search is necessary, use `rg` instead of `grep`.
+- Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,12 @@ Before changing any file:
 - Before adding or rewriting a requirement, search `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md`, and `docs/specs/` first.
 - If an existing requirement already covers the behavior, extend it instead of duplicating it.
 
+### Search tool hygiene
+
+- Prefer the host-native content-search tool when searching file contents.
+- When shell-based content search is necessary, use `rg` instead of `grep`.
+- Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ Before changing any file:
 - Before adding or rewriting a requirement, search `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md`, and `docs/specs/` first.
 - If an existing requirement already covers the behavior, extend it instead of duplicating it.
 
+### Search tool hygiene
+
+- Prefer the host-native content-search tool when searching file contents.
+- When shell-based content search is necessary, use `rg` instead of `grep`.
+- Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -50,6 +50,12 @@ Before changing any file:
 - Before adding or rewriting a requirement, search `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md`, and `docs/specs/` first.
 - If an existing requirement already covers the behavior, extend it instead of duplicating it.
 
+### Search tool hygiene
+
+- Prefer the host-native content-search tool when searching file contents.
+- When shell-based content search is necessary, use `rg` instead of `grep`.
+- Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.


### PR DESCRIPTION
## Summary
- Add a shared `Search tool hygiene` rule to the canonical agent-surface policy.
- Regenerate `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` so every rendered surface inherits the same guidance.
- Clarify that agents should prefer host-native content search tools first, use `rg` for shell searches, and only fall back to shell `grep` when required with a brief reason.

## Test Plan
- [x] `npm run verify:agent-surfaces`