### PR TITLE
docs: add bounded exploration contract

### DIFF
--- a/.agents/shared/canonical.md
+++ b/.agents/shared/canonical.md
@@ -32,6 +32,20 @@ Before changing any file:
 - When shell-based content search is necessary, use `rg` instead of `grep`.
 - Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
 
+### Codebase exploration contract
+
+When delegating or performing broad codebase exploration, optimize for an evidence map rather than exhaustive discovery.
+
+- Start with a bounded prompt: scope, known target symbols or terms, search budget, file-read budget, and expected output format.
+- Default to at most 12 searches, 8 file reads, 4 search rounds, and 3 files opened per round; for explicitly large scopes use at most 18 searches, 12 file reads, 5 rounds, and 4 files per round.
+- Never exceed 24 searches, 16 file reads, or 6 rounds unless the user explicitly asks for deeper exploration.
+- A search round is one hypothesis → targeted search → rank files → read top files → evidence update cycle.
+- Search ladder: use file-pattern search once when the path family is unknown, use `rg` or the host-native content search for targeted text matches, use AST-aware search when available for structural matches, read only the highest-value files, then stop and summarize.
+- Stop early and return a partial report when two rounds add no useful evidence, queries become near-duplicates, candidate files do not narrow, results stay broad after discovery, or 75% of the search budget is gone with confidence below 0.5.
+- Treat useful negative searches as evidence; track queries already issued and do not keep reformulating the same query.
+- Do not spawn nested exploration agents unless the caller explicitly allows it; if allowed, use at most two child agents with disjoint scopes and smaller budgets.
+- Always return a structured report with status, confidence, scope assessment, budget used, primary findings with path evidence, files examined, searches performed, symbols found, unanswered questions, suggested next queries, stuck signals, and handoff notes.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,20 @@ Before changing any file:
 - When shell-based content search is necessary, use `rg` instead of `grep`.
 - Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
 
+### Codebase exploration contract
+
+When delegating or performing broad codebase exploration, optimize for an evidence map rather than exhaustive discovery.
+
+- Start with a bounded prompt: scope, known target symbols or terms, search budget, file-read budget, and expected output format.
+- Default to at most 12 searches, 8 file reads, 4 search rounds, and 3 files opened per round; for explicitly large scopes use at most 18 searches, 12 file reads, 5 rounds, and 4 files per round.
+- Never exceed 24 searches, 16 file reads, or 6 rounds unless the user explicitly asks for deeper exploration.
+- A search round is one hypothesis → targeted search → rank files → read top files → evidence update cycle.
+- Search ladder: use file-pattern search once when the path family is unknown, use `rg` or the host-native content search for targeted text matches, use AST-aware search when available for structural matches, read only the highest-value files, then stop and summarize.
+- Stop early and return a partial report when two rounds add no useful evidence, queries become near-duplicates, candidate files do not narrow, results stay broad after discovery, or 75% of the search budget is gone with confidence below 0.5.
+- Treat useful negative searches as evidence; track queries already issued and do not keep reformulating the same query.
+- Do not spawn nested exploration agents unless the caller explicitly allows it; if allowed, use at most two child agents with disjoint scopes and smaller budgets.
+- Always return a structured report with status, confidence, scope assessment, budget used, primary findings with path evidence, files examined, searches performed, symbols found, unanswered questions, suggested next queries, stuck signals, and handoff notes.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,20 @@ Before changing any file:
 - When shell-based content search is necessary, use `rg` instead of `grep`.
 - Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
 
+### Codebase exploration contract
+
+When delegating or performing broad codebase exploration, optimize for an evidence map rather than exhaustive discovery.
+
+- Start with a bounded prompt: scope, known target symbols or terms, search budget, file-read budget, and expected output format.
+- Default to at most 12 searches, 8 file reads, 4 search rounds, and 3 files opened per round; for explicitly large scopes use at most 18 searches, 12 file reads, 5 rounds, and 4 files per round.
+- Never exceed 24 searches, 16 file reads, or 6 rounds unless the user explicitly asks for deeper exploration.
+- A search round is one hypothesis → targeted search → rank files → read top files → evidence update cycle.
+- Search ladder: use file-pattern search once when the path family is unknown, use `rg` or the host-native content search for targeted text matches, use AST-aware search when available for structural matches, read only the highest-value files, then stop and summarize.
+- Stop early and return a partial report when two rounds add no useful evidence, queries become near-duplicates, candidate files do not narrow, results stay broad after discovery, or 75% of the search budget is gone with confidence below 0.5.
+- Treat useful negative searches as evidence; track queries already issued and do not keep reformulating the same query.
+- Do not spawn nested exploration agents unless the caller explicitly allows it; if allowed, use at most two child agents with disjoint scopes and smaller budgets.
+- Always return a structured report with status, confidence, scope assessment, budget used, primary findings with path evidence, files examined, searches performed, symbols found, unanswered questions, suggested next queries, stuck signals, and handoff notes.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -56,6 +56,20 @@ Before changing any file:
 - When shell-based content search is necessary, use `rg` instead of `grep`.
 - Use shell `grep` only when `rg` is unavailable or a specific environment constraint requires it, and state the reason briefly.
 
+### Codebase exploration contract
+
+When delegating or performing broad codebase exploration, optimize for an evidence map rather than exhaustive discovery.
+
+- Start with a bounded prompt: scope, known target symbols or terms, search budget, file-read budget, and expected output format.
+- Default to at most 12 searches, 8 file reads, 4 search rounds, and 3 files opened per round; for explicitly large scopes use at most 18 searches, 12 file reads, 5 rounds, and 4 files per round.
+- Never exceed 24 searches, 16 file reads, or 6 rounds unless the user explicitly asks for deeper exploration.
+- A search round is one hypothesis → targeted search → rank files → read top files → evidence update cycle.
+- Search ladder: use file-pattern search once when the path family is unknown, use `rg` or the host-native content search for targeted text matches, use AST-aware search when available for structural matches, read only the highest-value files, then stop and summarize.
+- Stop early and return a partial report when two rounds add no useful evidence, queries become near-duplicates, candidate files do not narrow, results stay broad after discovery, or 75% of the search budget is gone with confidence below 0.5.
+- Treat useful negative searches as evidence; track queries already issued and do not keep reformulating the same query.
+- Do not spawn nested exploration agents unless the caller explicitly allows it; if allowed, use at most two child agents with disjoint scopes and smaller budgets.
+- Always return a structured report with status, confidence, scope assessment, budget used, primary findings with path evidence, files examined, searches performed, symbols found, unanswered questions, suggested next queries, stuck signals, and handoff notes.
+
 ### Branch, review, and secret safety
 
 - Never work directly on `main`.

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -596,3 +596,17 @@ Never use `localStorage.getItem(...)` as the source of truth for current visual 
 **Root cause**: Agent tools execute commands as non-interactive, non-login shells (`zsh -c "..."`). Zsh only sources `~/.zshenv` for these shells — `~/.zprofile` (login-only) and `~/.zshrc` (interactive-only) are skipped. Homebrew's PATH additions (`/opt/homebrew/bin`, `/usr/local/bin`) were in `~/.zshrc` (line 83, 86), so they were invisible to agent shells.
 **Fix**: Moved `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:$PATH"` to `~/.zshenv`. Removed all `export PATH=...` workarounds from workflow templates (`yolo.md`, `e2e.md`).
 **Rule**: **PATH modifications for tools needed by non-interactive processes (CI agents, cron, IDE terminals) MUST go in `~/.zshenv`.** The zsh sourcing order is: `zshenv` (all) → `zprofile` (login) → `zshrc` (interactive) → `zlogin` (login). Only `zshenv` is universal. Never work around missing PATH with inline exports in workflow scripts — fix the shell configuration at the source.
+
+---
+
+## Explorer Agents Need Search Budgets, Not More Search
+
+**Date**: 2026-04-26
+
+**Context**: Codebase exploration agents were getting stuck in repeated `grep`/`glob` loops while trying to discover broad systems.
+
+**Root cause**: The issue was not just tool choice. Open-ended prompts, missing search budgets, no convergence report, and no stuck-detection rules let agents keep reformulating similar queries instead of returning partial evidence.
+
+**Fix**: Add a bounded exploration contract: scoped prompt, `rg` or host-native content search for broad text, AST-aware search for code structure, small read budgets, mandatory stop conditions, and a structured report with confidence, evidence, gaps, and next queries. See the canonical `Codebase exploration contract` section in `.agents/shared/canonical.md`.
+
+**Rule**: **Exploration should produce an evidence map, not exhaustive certainty.** When an agent stops narrowing the candidate set, it should return a partial report instead of doing one more search.


### PR DESCRIPTION
## Summary
- Add a shared codebase exploration contract with bounded search/read budgets and stop conditions.
- Render AGENTS, CLAUDE, and GEMINI surfaces from the canonical policy.
- Document the explorer search-loop lesson and link it back to the canonical rule.

## Test Plan
- npm run verify:agent-surfaces
- cd fd-vscode && pnpm test -- src/agent-surfaces.test.ts