### PR TITLE
🧹 Gardener: Split main() function in fdraft

### DIFF
--- a/crates/fdraft/src/main.rs
+++ b/crates/fdraft/src/main.rs
@@ -110,103 +110,113 @@ fn read_input(file: &str) -> String {
     text
 }
 
+fn handle_fmt(file: String, write: bool) {
+    let text = read_input(&file);
+    let config = FormatConfig::default();
+    match format_document(&text, &config) {
+        Ok(formatted) => {
+            if write && file != "-" {
+                fs::write(&file, formatted).unwrap_or_else(|e| {
+                    eprintln!("Error writing to file '{}': {}", file, e);
+                    process::exit(1);
+                });
+            } else {
+                print!("{}", formatted);
+            }
+        }
+        Err(e) => {
+            eprintln!("Formatting error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn handle_view(mode: CliReadMode, file: String) {
+    let text = read_input(&file);
+    match parse_document(&text) {
+        Ok(graph) => {
+            let rmode: ReadMode = mode.into();
+            print!("{}", emit_filtered(&graph, rmode));
+        }
+        Err(e) => {
+            eprintln!("Parse error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn handle_check(file: String) {
+    let text = read_input(&file);
+    match parse_document(&text) {
+        Ok(_) => {
+            println!("✅ OK: No syntax errors.");
+        }
+        Err(e) => {
+            eprintln!("❌ Check failed: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn handle_score(file: String) {
+    let text = read_input(&file);
+    match parse_document(&text) {
+        Ok(graph) => {
+            let report = compute_score(&graph);
+            println!("Comprehensibility Score: {}/100", report.total);
+            println!("------------------------------------------------");
+            for metric in report.metrics {
+                println!("- {}: {}/20", metric.label, metric.score);
+                if !metric.suggestion.is_empty() {
+                    println!("    Suggestion: {}", metric.suggestion);
+                }
+            }
+            if report.total < 80 {
+                process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("Parse error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn handle_export(target: ExportTarget, file: String) {
+    let text = read_input(&file);
+    match parse_document(&text) {
+        Ok(graph) => {
+            let viewport = fd_core::layout::Viewport {
+                width: 1920.0,
+                height: 1080.0,
+            };
+            let bounds = fd_core::layout::resolve_layout(&graph, viewport);
+            match target {
+                ExportTarget::Html => {
+                    let out = fd_core::html_export::export_html(&graph, &bounds, &[]);
+                    print!("{}", out);
+                }
+                ExportTarget::Excalidraw => {
+                    let out = fd_core::excalidraw::export_excalidraw(&graph, &bounds, &[]);
+                    println!("{}", out);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Parse error: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Fmt { file, write } => {
-            let text = read_input(&file);
-            let config = FormatConfig::default();
-            match format_document(&text, &config) {
-                Ok(formatted) => {
-                    if write && file != "-" {
-                        fs::write(&file, formatted).unwrap_or_else(|e| {
-                            eprintln!("Error writing to file '{}': {}", file, e);
-                            process::exit(1);
-                        });
-                    } else {
-                        print!("{}", formatted);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Formatting error: {}", e);
-                    process::exit(1);
-                }
-            }
-        }
-        Commands::View { mode, file } => {
-            let text = read_input(&file);
-            match parse_document(&text) {
-                Ok(graph) => {
-                    let rmode: ReadMode = mode.into();
-                    print!("{}", emit_filtered(&graph, rmode));
-                }
-                Err(e) => {
-                    eprintln!("Parse error: {}", e);
-                    process::exit(1);
-                }
-            }
-        }
-        Commands::Check { file } => {
-            let text = read_input(&file);
-            match parse_document(&text) {
-                Ok(_) => {
-                    println!("✅ OK: No syntax errors.");
-                }
-                Err(e) => {
-                    eprintln!("❌ Check failed: {}", e);
-                    process::exit(1);
-                }
-            }
-        }
-        Commands::Score { file } => {
-            let text = read_input(&file);
-            match parse_document(&text) {
-                Ok(graph) => {
-                    let report = compute_score(&graph);
-                    println!("Comprehensibility Score: {}/100", report.total);
-                    println!("------------------------------------------------");
-                    for metric in report.metrics {
-                        println!("- {}: {}/20", metric.label, metric.score);
-                        if !metric.suggestion.is_empty() {
-                            println!("    Suggestion: {}", metric.suggestion);
-                        }
-                    }
-                    if report.total < 80 {
-                        process::exit(1);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Parse error: {}", e);
-                    process::exit(1);
-                }
-            }
-        }
-        Commands::Export { target, file } => {
-            let text = read_input(&file);
-            match parse_document(&text) {
-                Ok(graph) => {
-                    let viewport = fd_core::layout::Viewport {
-                        width: 1920.0,
-                        height: 1080.0,
-                    };
-                    let bounds = fd_core::layout::resolve_layout(&graph, viewport);
-                    match target {
-                        ExportTarget::Html => {
-                            let out = fd_core::html_export::export_html(&graph, &bounds, &[]);
-                            print!("{}", out);
-                        }
-                        ExportTarget::Excalidraw => {
-                            let out = fd_core::excalidraw::export_excalidraw(&graph, &bounds, &[]);
-                            println!("{}", out);
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Parse error: {}", e);
-                    process::exit(1);
-                }
-            }
-        }
+        Commands::Fmt { file, write } => handle_fmt(file, write),
+        Commands::View { mode, file } => handle_view(mode, file),
+        Commands::Check { file } => handle_check(file),
+        Commands::Score { file } => handle_score(file),
+        Commands::Export { target, file } => handle_export(target, file),
     }
 }


### PR DESCRIPTION
## What
Refactored `crates/fdraft/src/main.rs` to break up the `main()` function, which was over 100 lines long, into multiple smaller handler functions (`handle_fmt`, `handle_view`, `handle_check`, `handle_score`, and `handle_export`), each under 30 lines.

## Why
This addresses a violation of the ≤30 lines rule for clean code as specified in GEMINI.md, making the code much easier to read and maintain.

## Result
`main()` is now just a succinct `match` statement. All functionality, standard I/O, and error handling are preserved. The workspace has been checked to ensure that behavior remains unchanged, types still check, and no formatting issues or warnings were introduced.

---
*PR created automatically by Jules for task [16080467893172804210](https://jules.google.com/task/16080467893172804210) started by @khangnghiem*