### PR TITLE
🛡️ Sentinel: [HIGH] Fix DOM XSS in showWasmErrorToast

### DIFF
--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -10138,7 +10138,8 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span class="error-msg" style="opacity:0.9"></span></div>`;
+  toast.querySelector('.error-msg').textContent = msg;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -31,7 +31,8 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${msg}</span></div>`;
+  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span class="error-msg" style="opacity:0.9"></span></div>`;
+  toast.querySelector('.error-msg').textContent = msg;
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `showWasmErrorToast` function in `fd-vscode/webview/src/main.js` was interpolating an unescaped `msg` string directly into a template literal assigned to `toast.innerHTML`. Since this error string could originate from unhandled promise rejections or arbitrary `window.error` events, it created a DOM-based Cross-Site Scripting (XSS) vulnerability if an attacker could control those error messages (e.g., via malformed data causing specific parsing errors that echo input).
🎯 **Impact:** An attacker could potentially execute arbitrary JavaScript within the context of the VS Code webview, potentially accessing internal extension states, files, or triggering unwanted actions depending on the VS Code extension permissions.
🔧 **Fix:** Refactored the DOM manipulation to establish the toast structure using `innerHTML` with a safe, empty span `<span class="error-msg"></span>`, and then safely set the untrusted error message via `toast.querySelector('.error-msg').textContent = msg`. This ensures any HTML entities in the message are properly escaped and treated strictly as text.
✅ **Verification:** Verified that `pnpm build:webview` succeeds, the resulting compiled `main.js` integrates the change correctly, `pnpm lint` passes with no errors, and the vitest suite (`pnpm test`) continues to pass (218 tests).

---
*PR created automatically by Jules for task [8960881310327450756](https://jules.google.com/task/8960881310327450756) started by @khangnghiem*