### PR TITLE
feat(memory-harness): agent memory harness design + init guide

### DIFF
--- a/MEMORY_INIT.md
+++ b/MEMORY_INIT.md
@@ -1,0 +1,276 @@
+# Memory Harness — Init Guide
+
+> **Purpose:** project-agnostic checklist to bring a new repo onto the agent
+> memory harness defined in
+> `openspec/changes/agent-memory-harness/design.md`.
+>
+> Use this when adding the harness to any future project. Replace
+> `<owner>`, `<repo>`, and `<owner>__<repo>` with your values.
+
+---
+
+## Prereqs (one-time per machine)
+
+You only do this once per workstation. Skip if already done.
+
+1. **Global `agent-memory` repo** cloned to `~/.config/agent-memory/`.
+   ```bash
+   gh repo clone <owner>/agent-memory ~/.config/agent-memory
+   ```
+2. **Shell alias** in `~/.zshrc`:
+   ```bash
+   alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'
+   ```
+3. **Secrets file** `~/.zshrc.secrets` exists and is sourced from `~/.zshrc`.
+4. **`gh`, `git`, `npx`** available on PATH.
+
+If any of these are missing, follow Phases 0–4 of
+`openspec/changes/agent-memory-harness/tasks.md` in any project that already
+has the harness — those phases set up the global pieces, not the project.
+
+---
+
+## Per-project init (run inside the new project repo)
+
+### Step 1 — Topic branch
+
+```bash
+git checkout -b feat/memory-harness-init
+```
+
+Never wire the harness directly on `main`.
+
+### Step 2 — Add `.memory/config.yml`
+
+Create `.memory/config.yml` at repo root with schema v1:
+
+```yaml
+schema: 1
+
+# Project identity. Used to namespace project content under
+# agent-memory/projects/<project_id>/.
+project_id: <owner>__<repo>
+
+# Local scratch directory (gitignored, not synced).
+scratch_dir: .scratch
+
+# Project-canonical doc paths the agent should read first.
+# Customize this list to match your project's actual canonical docs.
+canonical_doc_paths:
+  - docs/REQUIREMENTS.md
+  - docs/LESSONS.md
+  - docs/CHANGELOG.md
+  - docs/specs/
+  - openspec/
+
+# Optional vector/cache paths. All gitignored.
+lancedb_path: .memory/cache/lancedb
+gitnexus_path: .gitnexus
+
+# OpenSpec config root.
+openspec_dir: openspec
+
+# Web capture default routing: project | global | both.
+web_capture_target: project
+
+# Path to the global agent-memory clone on this machine.
+agent_memory_path: ~/.config/agent-memory
+```
+
+### Step 3 — `.gitignore` entries
+
+Append to `.gitignore`:
+
+```
+# Agent memory harness — local-only
+.scratch/
+.memory/cache/
+.gitnexus/
+.lancedb/
+```
+
+Keep `.memory/config.yml` tracked.
+
+Verify:
+
+```bash
+git check-ignore .scratch/foo .memory/cache/foo
+# both should print
+git check-ignore .memory/config.yml
+# should print nothing (file is tracked)
+```
+
+### Step 4 — Create the project subtree in global memory
+
+```bash
+mkdir -p ~/.config/agent-memory/projects/<owner>__<repo>/{lessons,sessions,drafts,transcripts,web,attachments}
+```
+
+Add a `README.md` for the project subtree:
+
+```bash
+cat > ~/.config/agent-memory/projects/<owner>__<repo>/README.md <<'EOF'
+# <owner>/<repo> — project memory
+
+## License flags
+- (note any non-permissive deps used here, e.g., GitNexus PolyForm Noncommercial)
+
+## Deploy quirks
+- (record one-off prod gotchas here)
+
+## Cross-machine session log convention
+- `sessions/YYYY-MM-DD.md`
+EOF
+```
+
+Commit and push in `agent-memory`:
+
+```bash
+cd ~/.config/agent-memory
+git add projects/<owner>__<repo>/
+git commit -m "chore: add <owner>__<repo> project subtree"
+git push
+cd -
+```
+
+### Step 5 — Initialize OpenSpec (if not already)
+
+```bash
+npx -y openspec init
+```
+
+Verify `openspec/config.yaml` exists. If you already have feature specs under
+`docs/specs/`, leave them in place — OpenSpec is for in-flight changes only.
+
+### Step 6 — Agent surfaces
+
+If the project uses the same surface renderer as Fast Draft
+(`.agents/shared/canonical.md` + `.agents/overrides/repo.md` →
+`AGENTS.md` / `CLAUDE.md` / `GEMINI.md`):
+
+1. Confirm `.agents/shared/canonical.md` already contains the generic
+   "Memory Harness" section (it should, since it's shared).
+2. Add a project-specific section to `.agents/overrides/repo.md`:
+   ```markdown
+   ## Memory Harness — project specifics
+
+   - Global memory repo: `~/.config/agent-memory/`
+   - Project subtree: `agent-memory/projects/<owner>__<repo>/`
+   - Project config: `.memory/config.yml`
+   - MCP launch: `npx tsx ~/.config/agent-memory/mcp-server/index.ts`
+   - `project_id`: `<owner>__<repo>`
+   ```
+3. Regenerate:
+   ```bash
+   npm run render:agent-surfaces
+   npm run verify:agent-surfaces
+   ```
+
+If the project does **not** use a renderer, hand-edit `AGENTS.md` to add an
+equivalent "Memory Harness" section. Less ideal but acceptable for small repos.
+
+### Step 7 — Register MCP for your agent host
+
+Create `.opencode/mcp.json` (or the equivalent for Claude Code, Cursor, etc.):
+
+```json
+{
+  "mcpServers": {
+    "agentmem": {
+      "command": "npx",
+      "args": ["tsx", "/Users/<you>/.config/agent-memory/mcp-server/index.ts"]
+    }
+  }
+}
+```
+
+Restart the agent host to pick up the new MCP.
+
+### Step 8 — CI guard for `.scratch/`
+
+Add a CI job that rejects PRs touching `.scratch/`. Minimal GitHub Actions
+snippet:
+
+```yaml
+- name: Block .scratch/ commits
+  run: |
+    if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^\.scratch/'; then
+      echo "::error::.scratch/ files are local-only; do not commit."
+      exit 1
+    fi
+```
+
+### Step 9 — Smoke test
+
+Open an agent session in the project repo and verify:
+
+```
+agent calls repo.read_config        → returns parsed config
+agent calls repo.search             → returns project hits
+agent calls repo.write_scratch      → file appears in .scratch/, not staged
+agent calls promote.scratch_to_project_global
+                                    → file copied to agent-memory/projects/<id>/
+                                    → commit present in agent-memory
+agent calls sync.push --scope global → push succeeds
+```
+
+If any step fails, see troubleshooting below.
+
+### Step 10 — Document and land
+
+1. Add a "Memory Harness" entry to `docs/REQUIREMENTS.md`.
+2. Add a changelog entry to `docs/CHANGELOG.md`.
+3. Open PR `feat: memory harness init`.
+4. Merge.
+
+---
+
+## Daily workflow once initialized
+
+| When | What | How |
+|------|------|-----|
+| Session start | Pull latest memory | `agentmem sync pull --scope both` |
+| During work | Capture session notes | `agentmem repo write-scratch ...` |
+| During work | Look up past lessons | `agentmem global list-lessons` or via MCP |
+| Worth keeping | Promote to project memory | `agentmem promote scratch-to-project-global ...` |
+| Worth sharing | Promote to global lessons | `agentmem promote lesson-to-global ...` |
+| Session end | Push memory updates | `agentmem sync push --scope global` |
+
+`.scratch/` is local-only by design. If you change machines, anything you want
+to carry with you must already be promoted to `agent-memory/projects/<id>/`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `repo.read_config` fails | `.memory/config.yml` missing or schema invalid | Recreate from Step 2 template |
+| `sync.pull` fails with non-fast-forward | Concurrent edits on another machine | Manual `git pull --rebase` in `~/.config/agent-memory/`, resolve, retry |
+| MCP tools not visible | Agent host not restarted | Restart agent host after editing `.opencode/mcp.json` |
+| `.scratch/` files showing in `git status` | Missing `.gitignore` entry | Re-do Step 3 |
+| Pre-commit secret scanner false positive | Pattern matched legit content | Whitelist via env var name reference instead of literal value |
+| `agent-memory` push rejected | Branch protection or unconfigured remote | `cd ~/.config/agent-memory && git remote -v && git push -u origin main` |
+
+---
+
+## What you do **NOT** do per project
+
+- Do **not** create a separate `<project>.notes` repo. Project content lives
+  under `agent-memory/projects/<owner>__<repo>/`.
+- Do **not** commit anything under `.scratch/`. It is local-only.
+- Do **not** hand-edit generated `AGENTS.md` if a renderer exists.
+- Do **not** put secrets in any memory layer. Reference env var names only.
+- Do **not** publish `agentmem` to npm. Distribution is via `git pull` in
+  `~/.config/agent-memory/`.
+
+---
+
+## References
+
+- Canonical design: `openspec/changes/agent-memory-harness/design.md`
+  (lives in the Fast Draft repo; mirror or copy into your new project's
+  OpenSpec changes if you want a local copy).
+- First-time bootstrap tasks (global pieces — only needed if no project on this
+  machine has set up the harness yet):
+  `openspec/changes/agent-memory-harness/tasks.md` (Phases 0–4).

--- a/docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md
+++ b/docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md
@@ -1,0 +1,115 @@
+# Agent Memory Harness — Brainstorming Snapshot
+
+> **Status:** FROZEN brainstorming snapshot. Captured 2026-04-26.
+>
+> **Living canonical version:**
+> [`openspec/changes/agent-memory-harness/design.md`](../../../openspec/changes/agent-memory-harness/design.md)
+>
+> This file captures the design at the moment brainstorming concluded and the
+> OpenSpec change was opened. Do not edit. All subsequent revisions land in the
+> OpenSpec design.md above.
+
+## Context
+
+Brainstorming session producing a layered, multi-machine, multi-project agent
+memory + code-intelligence harness for Fast Draft and future projects.
+
+Three council rounds (memory landscape audit, final-revision audit, defaults
+audit) drove the locked architecture below.
+
+## Locked Architecture (at brainstorming time)
+
+### Two-repo model
+
+- **Project repo** (this repo, public): hosts canonical docs, OpenSpec changes,
+  `.memory/config.yml`, and a gitignored `.scratch/` directory for local
+  ephemeral notes.
+- **`agent-memory` repo** (private, cloned to `~/.config/agent-memory/`): hosts
+  global content at root and per-project content under `projects/<owner>__<repo>/`.
+- **No third `<project>.notes` repo.** Rejected because Fast Draft is public so
+  privacy via gitignore beats privacy via separate repo, and project-scoped
+  cross-machine content fits cleanly under `agent-memory/projects/<id>/`.
+
+### Layer cake
+
+| Layer | Storage |
+|-------|---------|
+| L0 ephemeral session | Agent chat |
+| L1 project local scratch | `.scratch/` (gitignored, local-only) |
+| L2 project canonical | Project repo `docs/`, `openspec/`, `.memory/` |
+| L3 code intelligence | `.gitnexus/`, `.lancedb/`, `.memory/cache/` (gitignored) |
+| L4 global memory | `agent-memory` repo (global root + `projects/<id>/`) |
+| L5 web cache | `agent-memory/web/` or `agent-memory/projects/<id>/web/` |
+
+### Storage and search
+
+- Markdown canonical. Ripgrep canonical search.
+- ast-grep for structural code search.
+- GitNexus for code graph (PolyForm Noncommercial 1.0.0; license review required
+  before monetization).
+- LanceDB optional vector backend (Apache 2.0). Qdrant rejected.
+- All indexes gitignored and rebuildable.
+
+### Tooling
+
+- `agentmem` CLI vendored in `agent-memory/cli/` (TypeScript, run via
+  `npx tsx`). Source of truth.
+- MCP wrapper in `agent-memory/mcp-server/` imports CLI library functions
+  directly.
+- Distribution: shell alias `agentmem` in `~/.zshrc`. No npm publish.
+- Tool namespaces: `global.*`, `repo.*`, `sync.*`, `promote.*`, `web.*`,
+  `lance.*`. No `spec.*` (OpenSpec ops fold under `repo.*`).
+
+### Configuration
+
+- `.memory/config.yml` at project repo root (committed, schema v1, namespaced
+  dir, tool-agnostic name).
+- Caches as gitignored siblings inside `.memory/`.
+- Discoverability: AGENTS.md instructs the agent to read it; MCP exposes
+  `repo.read_config`.
+
+### OpenSpec ↔ Superpowers
+
+- **OpenSpec is canonical artifact system.** Superpowers is process layer.
+- Both tools use their own default folders. No cross-writing.
+  - OpenSpec: `openspec/changes/<change>/`.
+  - Superpowers brainstorming: `docs/superpowers/specs/<date>-<topic>-design.md`
+    (this file).
+- Superpowers snapshots are frozen at brainstorming time and point to the living
+  OpenSpec design. OpenSpec design.md back-references the snapshot.
+- `docs/specs/` (9 stable feature specs) remains the durable archive.
+  No migration.
+
+### Sync
+
+- `git pull --ff-only` at session start; `git push` at session end. No daemons.
+- `.scratch/` never synced (local-only by design).
+
+### Secret hygiene
+
+- Secrets in `~/.zshrc.secrets` (gitignored, sourced from `~/.zshrc`).
+- Agents reference env var names only.
+- Pre-commit secret scanner in `agent-memory/scripts/check-secrets.sh`.
+
+## Priority order
+
+Experimentation > Autonomy > Parity > Reliability.
+
+## Rejected options
+
+- Cloud memory services (Mem0 cloud, Zep cloud, Supermemory, Pinecone).
+- Codanna, Serena, sqlite-vec, Qdrant.
+- `codebase-memory` npm, `@csuwl/opencode-memory-plugin` as core,
+  `opencode-working-memory` as core, `opencode-supermemory`.
+- Tracked `scratch/` in project repo (disqualified for public repo).
+- Branch-based scratch (branches in public repos are public).
+- Background auto-capture / auto-summarization.
+- Knowledge graph / temporal memory (Graphiti/Zep) — defer.
+- Three-repo model with `<project>.notes` (collapsed to two-repo + `.scratch/`).
+
+## Pointer to living design
+
+For all current details, schema, tool surface, sync protocol, migration path,
+risk register, and acceptance criteria, see:
+
+[`openspec/changes/agent-memory-harness/design.md`](../../../openspec/changes/agent-memory-harness/design.md)

--- a/openspec/changes/agent-memory-harness/design.md
+++ b/openspec/changes/agent-memory-harness/design.md
@@ -1,0 +1,581 @@
+# Agent Memory Harness — Design
+
+> **Status:** Canonical design. Authoritative copy.
+>
+> A brainstorming snapshot exists at
+> `docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md`.
+> That snapshot freezes the design at brainstorming time and points here for
+> the living version.
+
+## 1. Goals and Non-Goals
+
+### Goals
+
+- **Persistent memory** across sessions and machines for AI coding agents.
+- **Tool-agnostic**: works under OpenCode today, survives migration to Claude Code,
+  Cursor, Aider, Copilot CLI, or whatever ships next.
+- **Multi-machine**: single dev now using multiple macOS machines, future small team.
+- **Layered separation** of ephemeral / project-scratch / project-canonical /
+  code-intel / global / web layers, each with explicit ownership and lifecycle.
+- **Markdown canonical**: ripgrep is the canonical search. Vector and graph stores
+  are disposable caches, never canonical.
+- **Explicit promotion**: nothing becomes durable knowledge without human PR review.
+- **Secret hygiene**: agents never write secret-shaped strings into memory; only
+  reference environment variable names.
+
+### Non-Goals
+
+- **Cloud memory services.** No Mem0 cloud, Zep cloud, Supermemory, Pinecone.
+- **Real-time sync daemons.** All sync is `git pull` at session start, `git push` at
+  session end.
+- **Agent host parity beyond MCP and CLI.** We do not target proprietary memory
+  APIs of individual agents (e.g., Cursor `.cursorrules` auto-load, Claude Code
+  project files). AGENTS.md instructions and the `agentmem` CLI are the portable
+  contract.
+- **Knowledge graph / temporal memory.** Defer Graphiti / Zep until markdown +
+  ripgrep + LanceDB demonstrably fall short.
+- **Auto-capture / auto-summarization.** All writes to durable layers are explicit
+  agent or human actions, not background ingestion.
+
+## 2. Priority Order
+
+When trade-offs collide:
+
+1. **Experimentation** — make it cheap to try new patterns and discard them.
+2. **Autonomy** — agents can operate end-to-end without humans in the loop except at
+   the promotion gate.
+3. **Parity** — host-independent behavior; the same agent action works on any
+   machine.
+4. **Reliability** — durability and consistency are important but yield to the above
+   when in conflict.
+
+## 3. Layer Cake
+
+| Layer | Name | Storage | Owner | Promotion target |
+|------|------|---------|-------|------------------|
+| L0 | Ephemeral session memory | Agent chat, in-memory todos | Agent | L1 (selective) |
+| L1 | Project local scratch | `.scratch/` in project repo (gitignored, local-only) | Local machine | L2 or L4 (selective, via PR or `global.write_project_*`) |
+| L2 | Project canonical | Project repo (`docs/`, `openspec/`, `.memory/config.yml`) | Project | L4 (cross-project lessons only) |
+| L3 | Code intelligence | `.gitnexus/`, `.lancedb/`, `.memory/cache/` (gitignored) | Local only | None — rebuildable |
+| L4 | Global memory | `agent-memory` repo, with global content at root and project-scoped content under `projects/<id>/` | Personal | None — terminal layer |
+| L5 | Web research cache | `agent-memory/web/` (global) or `agent-memory/projects/<id>/web/` (project) | Personal | None — captures only |
+
+### L0 — Ephemeral Session Memory
+
+In-session scratchpad: agent-internal todos, mid-conversation reasoning, draft
+prompts. Not persisted. Lost on session end.
+
+- Storage: agent chat context + the host's TODO mechanism (`todowrite` in OpenCode).
+- Promotion: agent must explicitly call `repo.write_scratch` (to L1 local) or
+  `global.write_project_session` (to L4 cross-machine) to persist anything from L0.
+
+### L1 — Project Local Scratch (`.scratch/`)
+
+A gitignored directory at the project repo root for ephemeral notes that don't
+need cross-machine sync.
+
+```
+<project>/
+  .scratch/                  (gitignored — local only)
+    sessions/                YYYY-MM-DD.md
+    experiments/             throwaway code spikes
+    drafts/                  WIP designs before promotion
+    transcripts/             chat captures
+```
+
+- **Why local-only and not synced**: most session notes are ephemeral context for
+  the machine you were working on. Cross-machine continuity for project work
+  belongs in L4 (`agent-memory/projects/<id>/`) where it's explicit.
+- **Why a directory in the project repo and not a separate repo**: avoids the
+  privacy leak risk for public repos (Fast Draft is public — anything tracked is
+  public; `.scratch/` is gitignored so nothing leaks), removes one repo's worth
+  of clone/pull/push overhead, eliminates the "where does this go?" decision
+  per file.
+- **Lifecycle**: agent or human prunes `.scratch/` periodically. Anything
+  worth keeping moves to L4 via `global.write_project_session` or
+  `promote.scratch_to_project_global`. Anything worth promoting to canonical
+  project docs moves via `promote.scratch_to_canonical` (opens draft PR).
+- **No `.scratch/` content is ever committed.** Verifier in CI rejects PRs that
+  add `.scratch/` paths.
+
+### L2 — Project Canonical
+
+The project repo itself, including:
+
+- `docs/REQUIREMENTS.md`, `docs/LESSONS.md`, `docs/CHANGELOG.md` — existing
+  registries.
+- `docs/specs/<feature>.md` — durable feature specs.
+- `docs/superpowers/specs/<date>-<topic>-design.md` — brainstorming snapshots
+  produced by the Superpowers brainstorming skill (process artifacts).
+- `openspec/changes/<change>/{proposal,design,tasks}.md` — in-flight changes.
+- `openspec/specs/<capability>/` — capability specifications.
+- `.memory/config.yml` — committed memory harness config.
+- `.agents/shared/canonical.md` and `.agents/overrides/repo.md` — agent surface
+  source files.
+- Generated `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — never hand-edited.
+
+### L3 — Code Intelligence
+
+Local, regenerable indexes. Always gitignored.
+
+- **ripgrep** — canonical exact text search.
+- **ast-grep** — structural code search.
+- **GitNexus** — code graph (definitions, references, call chains, blast radius).
+  Index in `.gitnexus/`. License: PolyForm Noncommercial 1.0.0; flagged in
+  `agent-memory/projects/khangnghiem__fast-draft/README.md` as "license review
+  required before monetization."
+- **LanceDB** (optional) — embedded vector + FTS for semantic retrieval. Index in
+  `.memory/cache/lancedb/`. Apache 2.0. Used only when ripgrep + ast-grep + GitNexus
+  prove insufficient.
+
+### L4 — Global Memory (`agent-memory`)
+
+Single private GitHub repo, cloned to `~/.config/agent-memory/`. Holds both
+truly global content (reusable across projects) and project-scoped content that
+must survive across machines.
+
+```
+~/.config/agent-memory/
+  README.md
+  preferences.md                       (durable user preferences)
+  lessons/         YYYY-MM-DD-<slug>.md   (cross-project lessons)
+  snippets/        <topic>.md             (reusable code snippets)
+  web/             <source>/<slug>.md     (global web captures)
+  inbox/                                  (unsorted captures awaiting promotion)
+  templates/                              (lesson/snippet templates)
+  schemas/                                (JSON schemas for tool args)
+  projects/                               (project-scoped content, namespaced by id)
+    <owner>__<repo>/
+      README.md                           (project overview, license flags, deploy quirks)
+      lessons/      YYYY-MM-DD-<slug>.md  (project-specific; promote up to ../../lessons/ if generalizable)
+      sessions/     YYYY-MM-DD.md         (cross-machine session logs)
+      drafts/                             (WIP designs)
+      transcripts/                        (chat/meeting captures)
+      web/          <source>/<slug>.md    (project-scoped web captures)
+      attachments/                        (screenshots, diagrams, binaries)
+  cli/             index.ts               (agentmem CLI entry)
+  mcp-server/      index.ts               (MCP wrapper entry)
+  scripts/         check-secrets.sh       (pre-commit secret scanner)
+  package.json
+  tsconfig.json
+  .gitignore
+```
+
+- **Sync**: `git pull` at session start, `git push` at session end. No daemons.
+- **Naming**: lessons use `YYYY-MM-DD-<slug>.md`; project subtrees use
+  `<owner>__<repo>/` (double-underscore separator avoids collision with
+  `repo.subpath`-style names).
+- **Generalization promotion**: a lesson in `projects/<id>/lessons/` that proves
+  generalizable moves up to `lessons/` (drop the project tag) via
+  `promote.lesson_to_global`.
+- **No frontmatter.** Optional HTML-comment tag block at top of file:
+  `<!-- tags: rust, wgpu, async -->`.
+
+### L5 — Web Research Cache
+
+Web captures from Tavily MCP or manual snapshots. Routing:
+
+- **Global captures** (general references, language idioms, library docs) →
+  `~/.config/agent-memory/web/<source>/<slug>.md`.
+- **Project captures** (one-off research tied to a specific project) →
+  `~/.config/agent-memory/projects/<id>/web/<source>/<slug>.md`.
+
+Routing decided by the `web.capture` tool's `target` argument
+(`"global" | "project" | "both"`), defaulted from `.memory/config.yml`'s
+`web_capture_target` key. The `project_id` for project routing comes from
+`.memory/config.yml`'s `project_id` key.
+
+## 4. Retrieval Order
+
+When an agent answers a question about the project or code, it consults sources
+in this order. Stop at the first sufficient answer.
+
+1. **OpenSpec change context** (if `openspec/changes/<active>/` exists):
+   skim `proposal.md` and `design.md` to understand current intent and scope.
+2. **Project canonical**: `docs/REQUIREMENTS.md`, `docs/LESSONS.md`, `docs/specs/`,
+   plus relevant `.agents/` content.
+3. **Project scratch (local)**: `.scratch/sessions/`, `.scratch/drafts/`.
+4. **Project content in global memory**: `agent-memory/projects/<id>/sessions/`,
+   `agent-memory/projects/<id>/lessons/`.
+5. **Code search**: `ripgrep` for exact strings; `ast-grep` for structural patterns;
+   `GitNexus` for code graph queries (definitions, references, blast radius).
+6. **Global memory**: `agent-memory/lessons/`, `agent-memory/snippets/`,
+   `agent-memory/projects/<id>/README.md`.
+7. **Semantic** (optional): LanceDB query over project + global if exact and
+   structural search fail.
+8. **Web cache**: `agent-memory/projects/<id>/web/` then `agent-memory/web/`.
+9. **External fallback**: web search via Tavily, GitHub Code Search.
+
+## 5. Configuration: `.memory/config.yml`
+
+Committed to project repo root. Schema v1:
+
+```yaml
+schema: 1
+
+# Project identity. Used to namespace project content under
+# agent-memory/projects/<project_id>/.
+project_id: khangnghiem__fast-draft
+
+# Local scratch directory (gitignored, not synced).
+scratch_dir: .scratch
+
+# Project-canonical doc paths the agent should read first.
+canonical_doc_paths:
+  - docs/REQUIREMENTS.md
+  - docs/LESSONS.md
+  - docs/CHANGELOG.md
+  - docs/specs/
+  - docs/superpowers/specs/
+  - openspec/
+
+# Optional vector/cache paths. All gitignored.
+lancedb_path: .memory/cache/lancedb
+gitnexus_path: .gitnexus
+
+# OpenSpec config root.
+openspec_dir: openspec
+
+# Web capture default routing: project | global | both.
+web_capture_target: project
+
+# Path to the global agent-memory clone on this machine. Defaults to
+# ~/.config/agent-memory if unset.
+agent_memory_path: ~/.config/agent-memory
+```
+
+### Discoverability
+
+No agent host (Claude Code, OpenCode, Cursor, Copilot, Aider, Cline, Windsurf)
+auto-loads `.memory/config.yml` as of 2026. We make it discoverable two ways:
+
+1. **AGENTS.md (generated) instructs the agent** to read `.memory/config.yml`
+   before working.
+2. **`repo.read_config` MCP tool** exposes parsed config for agents that prefer
+   tool calls over file reads.
+
+## 6. Tool Surface
+
+`agentmem` CLI is the source of truth. The MCP server is a thin wrapper that
+imports the CLI's library functions and exposes them as MCP tools. One
+implementation, two surfaces.
+
+### Namespaces
+
+| Namespace | Purpose |
+|-----------|---------|
+| `global.*` | Read/write `agent-memory` repo |
+| `repo.*`   | Read/write project repo + scratch + OpenSpec ops |
+| `sync.*`   | Git pull/push/status |
+| `promote.*` | Open draft PRs to promote scratch → canonical or project → global |
+| `web.*`    | Capture web pages via Tavily |
+| `lance.*`  | Optional LanceDB index/query/rebuild |
+
+### Tools
+
+#### `global.*`
+
+Operates over `agent-memory/`. The project subtree
+(`agent-memory/projects/<id>/`) is addressed via the same tools using a
+`project_id` argument; when omitted, operations target the truly global root.
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `read_lesson` | `{ path, project_id? }` | Returns lesson markdown from global or project subtree |
+| `list_lessons` | `{ tag?, project_id?, limit? }` | Lists lesson files; project-scoped when `project_id` set |
+| `read_snippet` | `{ path }` | Returns snippet markdown |
+| `read_preferences` | `{}` | Returns `preferences.md` content |
+| `write_preferences` | `{ content }` | Writes `preferences.md` |
+| `write_draft` | `{ path?, title?, content, project_id? }` | Writes to `inbox/` (or `projects/<id>/inbox/`) for later promotion |
+| `write_project_session` | `{ project_id, date?, content, mode? }` | Writes a cross-machine project session log to `projects/<id>/sessions/<date>.md` |
+| `read_project_readme` | `{ project_id }` | Returns the project subtree's `README.md` |
+| `search` | `{ query, regex?, pathGlobs?, project_id?, limit? }` | Ripgrep over `agent-memory/`; scoped to project subtree if `project_id` set |
+
+#### `repo.*`
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `read_config` | `{}` | Parses and returns `.memory/config.yml` |
+| `read_canonical` | `{ scope }` | Reads canonical paths (`docs`, `openspec`, both) |
+| `read_scratch` | `{ path? }` | Reads from local `.scratch/` |
+| `write_scratch` | `{ path, content, mode }` | Writes to local `.scratch/` (`replace` or `append`); never commits |
+| `search` | `{ query, includeGlobal?, includeScratch?, pathGlobs?, limit? }` | Ripgrep over project canon (+ optional `.scratch/` and global) |
+| `openspec_status` | `{ change? }` | Shells `openspec status` (or named change) |
+| `openspec_propose` | `{ title, description, schema?, mode? }` | Shells `openspec propose` |
+| `openspec_apply` | `{ change }` | Shells `openspec apply` |
+| `openspec_archive` | `{ change, sync? }` | Shells `openspec archive` |
+
+#### `sync.*`
+
+`scratch` is intentionally absent — `.scratch/` is local-only by design.
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `status` | `{ scope: "global" \| "project" \| "both" }` | Git status for selected repos |
+| `pull` | `{ scope }` | `git pull --ff-only` for selected repos |
+| `push` | `{ scope }` | `git push` for selected repos |
+
+#### `promote.*`
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `scratch_to_canonical` | `{ paths, prDraft? }` | Copies `.scratch/` files to project `docs/` and opens draft PR |
+| `scratch_to_project_global` | `{ paths, project_id? }` | Copies `.scratch/` files into `agent-memory/projects/<id>/`; commits in agent-memory but does not push (caller invokes `sync.push`) |
+| `lesson_to_global` | `{ path, project_id?, tags?, overwrite? }` | Copies project-scoped lesson up to top-level `agent-memory/lessons/` (drops project tag) and opens draft PR in `agent-memory` |
+
+Promotion always opens a **draft PR**. Never merges. Human review remains the gate.
+
+#### `web.*`
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `capture` | `{ url, title?, target?, format?, cache? }` | Fetches via Tavily or webfetch, writes markdown to global or project `web/` |
+
+#### `lance.*` (optional)
+
+| Tool | Args | Effect |
+|------|------|--------|
+| `status` | `{ scope }` | LanceDB index status |
+| `index` | `{ scope, paths?, rebuild? }` | (Re)indexes selected paths |
+| `query` | `{ scope, text, topK?, filters? }` | Vector + FTS query |
+| `rebuild` | `{ scope }` | Drop and rebuild index |
+
+### CLI usage
+
+CLI mirrors the namespaces:
+
+```bash
+agentmem global search "wgpu render pipeline"
+agentmem repo openspec status
+agentmem sync push --scope both
+agentmem promote scratch-to-canonical --paths sessions/2026-04-26.md
+agentmem web capture --url https://example.com --target project
+```
+
+### Distribution
+
+- **Install**: clone `agent-memory` repo to `~/.config/agent-memory/`. Add shell
+  alias to `~/.zshrc`:
+  ```bash
+  alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'
+  ```
+- **Updates**: `git pull` in `agent-memory` repo. No npm publish step.
+- **MCP registration**: per-project `.opencode/mcp.json` (or equivalent for other
+  hosts) points to `npx tsx ~/.config/agent-memory/mcp-server/index.ts`.
+
+## 7. OpenSpec ↔ Superpowers Integration
+
+Both tools use their **own default folders**. No cross-writing. Coexistence rules:
+
+| Concern | OpenSpec (canonical) | Superpowers (process) |
+|---------|---------------------|----------------------|
+| Default location | `openspec/changes/<change>/` | `docs/superpowers/specs/<date>-<topic>-design.md` |
+| Lifecycle | `propose / apply / archive` | None (markdown files persist as written) |
+| Role | Living artifacts (intent, design, tasks) | Brainstorming snapshots, plans |
+| Update model | Edited as work progresses | Frozen at brainstorming time |
+| Promotion to durable | Archive content → `docs/specs/<feature>.md` if durable | Stays in place as historical record |
+
+### Drift prevention
+
+When a Superpowers brainstorming session produces both a snapshot and an OpenSpec
+change:
+
+- The Superpowers snapshot **MUST** include a header pointing to the OpenSpec
+  change and its current `design.md`.
+- The Superpowers snapshot **MUST NOT** be updated after the OpenSpec change is
+  created — it's a frozen artifact.
+- The OpenSpec `design.md` **MUST** include a back-reference to the Superpowers
+  snapshot in its first section.
+
+### Promotion of OpenSpec content to `docs/specs/`
+
+On `openspec archive`:
+
+1. Review the change's `design.md` for content that represents durable feature
+   documentation (vs change-specific reasoning).
+2. If durable, copy to `docs/specs/<feature>.md` (or update existing spec) via PR.
+3. Archive the OpenSpec change. Archived changes remain in `openspec/changes/`
+   for history but are not edited further.
+
+### Plannotator
+
+Plannotator (annotation tool) annotates artifacts but never owns them. It can
+annotate OpenSpec design.md, OpenSpec tasks.md, Superpowers snapshots, or
+`docs/specs/` files. Annotations live alongside the source artifact (e.g., as
+adjacent `.annotations.json` or inline HTML comments — implementation detail).
+
+## 8. Generated Agent Surfaces
+
+### Split between canonical and override
+
+| Location | Content |
+|----------|---------|
+| `.agents/shared/canonical.md` | Generic Memory Harness section: read `.memory/config.yml` first, retrieval order, prefer scratch over canonical writes, promotion requires PR, secret hygiene rules |
+| `.agents/overrides/repo.md` | Fast Draft repo-specific paths and commands: `~/.config/agent-memory/` location, `.scratch/` gitignored scratch dir, MCP launch command, project_id `khangnghiem__fast-draft` |
+
+After editing either source, run `npm run render:agent-surfaces` to regenerate
+`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`. Verifier runs in CI via
+`npm run verify:agent-surfaces`.
+
+### What the rendered AGENTS.md tells the agent (excerpt)
+
+> **Memory Harness**
+>
+> Before working on any task, read `.memory/config.yml` (or call
+> `repo.read_config` via the agentmem MCP). Then consult sources in retrieval
+> order: OpenSpec active change → project canonical → project scratch → code
+> search → global memory → semantic → web cache → external fallback.
+>
+> Persist durable lessons to global memory via `promote.lesson_to_global`. Never
+> write secret-shaped strings; reference environment variable names only. All
+> promotions open draft PRs — never merge directly.
+
+## 9. Sync Protocol
+
+### Session start
+
+```
+1. cd ~/.config/agent-memory && git pull --ff-only
+2. cd <project>              && git pull --ff-only
+3. agent reads .memory/config.yml
+```
+
+### Session end
+
+```
+1. agent or human reviews uncommitted changes in agent-memory (project repo
+   commits/pushes happen via normal PR flow, not via sync.push)
+2. agent calls sync.push --scope global
+3. push fails fast if non-fast-forward; user resolves manually
+```
+
+### Conflict resolution
+
+- All repos use **simple linear history**. No rebase from MCP tools.
+- If `git pull --ff-only` fails, the MCP returns an error and the agent stops.
+  Human runs `git pull --rebase` or `git merge` manually.
+- Sync is **best-effort**, not strictly required. Stale memory is acceptable;
+  silent merge corruption is not.
+
+## 10. Secret Hygiene
+
+- **Source of secrets**: `~/.zshrc.secrets` (gitignored, sourced from `~/.zshrc`).
+- **Agent rule**: never write secret-shaped strings (anything matching common
+  token patterns like `sk-*`, `ghp_*`, `xoxb-*`, base64 longer than 32 chars in
+  a context that suggests credentials) into any memory layer.
+- **Allowed**: reference env var names only. E.g., write
+  `Tavily API key in $TAVILY_API_KEY` — never the literal value.
+- **Enforcement**: pre-commit hook in the `agent-memory` repo
+  scans staged content for secret patterns. Hook source vendored in
+  `agent-memory/scripts/check-secrets.sh`.
+
+## 11. Risk Register
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|------------|--------|------------|
+| R1 | Tool name collision (multiple memory plugins claiming `memory_*`) | M | M | Strict namespacing (`global.*` etc.); document in AGENTS.md; avoid generic memory plugins in production |
+| R2 | Index drift across machines (LanceDB, GitNexus caches diverge) | H | L | All indexes gitignored; canonical is markdown; rebuild from source on demand |
+| R3 | Secret leakage into memory files | M | H | Pre-commit hook scans for secret patterns; agents instructed via canonical to use env var names only |
+| R4 | GitNexus license trap (PolyForm Noncommercial) | L | M | Noted in `agent-memory/projects/khangnghiem__fast-draft.md`; license review required before monetization; swap to permissive code-intel tool if commercial use planned |
+| R5 | Plugin abandonment (OpenSpec, GitNexus, LanceDB upstream changes) | M | M | Storage formats are simple and exportable; CLI is the source of truth and survives any plugin loss |
+| R6 | Prompt pollution (agents promote noise to global memory) | M | M | Promotion gate is PR review; `promote.*` opens drafts only |
+| R7 | YAML/TOML config drift (legacy `.opencode-memory.toml` or `.agentmemory.toml` files appear) | L | L | Spec mandates `.memory/config.yml` as the only valid config; verifier rejects legacy filenames |
+| R8 | OpenSpec adoption breaking existing `docs/specs/` | L | M | Coexistence rule: `openspec/` for in-flight, `docs/specs/` for durable; no migration of existing specs |
+| R9 | LanceDB file format churn (pre-1.0 in some surfaces) | M | L | Treated as cache; rebuildable from source; data never canonical |
+| R10 | Hand-edits to generated `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` | M | L | Files contain a "GENERATED — DO NOT EDIT" header; CI verifier (`verify:agent-surfaces`) catches drift |
+| R11 | Sync conflict during multi-machine session overlap | L | M | Use `--ff-only` pulls; fail loudly; human resolves manually |
+| R12 | OpenSpec change directory accumulates (no archive discipline) | M | L | Linter checks for changes older than N days; archived changes remain in `changes/` for history but are excluded from active scans |
+
+## 12. Migration Path
+
+### From current state (no harness)
+
+1. Create `agent-memory` private GitHub repo. Initialize with template structure
+   (Section 3.5).
+2. Clone to `~/.config/agent-memory/` on each machine.
+3. Add shell alias `agentmem` in `~/.zshrc`.
+4. Implement `agentmem` CLI in `agent-memory/cli/` (TS).
+5. Implement MCP wrapper in `agent-memory/mcp-server/`.
+6. Add `.memory/config.yml` to Fast Draft repo root with `project_id:
+   khangnghiem__fast-draft`.
+7. Add `.gitignore` entries for `.scratch/`, `.memory/cache/`, `.gitnexus/`,
+   `.lancedb/`.
+8. Run `openspec init` at Fast Draft repo root. Verify this `agent-memory-harness`
+   change directory remains intact.
+9. Patch `.agents/shared/canonical.md` with generic Memory Harness section.
+10. Patch `.agents/overrides/repo.md` with Fast Draft-specific paths.
+11. Run `npm run render:agent-surfaces`. Commit regenerated AGENTS.md / CLAUDE.md
+    / GEMINI.md.
+12. Register MCP in `.opencode/mcp.json`.
+13. Smoke test: agent reads config, runs `repo.search`, writes a `.scratch/`
+    note, promotes it via `promote.scratch_to_project_global` to
+    `agent-memory/projects/khangnghiem__fast-draft/`.
+
+### Future migrations
+
+- **Adding a new project**: add `.memory/config.yml` to project root with new
+  `project_id`. Create `agent-memory/projects/<new_id>/` subtree with template
+  structure. No new repo to create.
+- **Adding a team member**: invite them to `agent-memory` repo; they clone to
+  their own `~/.config/agent-memory/`. Project content under
+  `agent-memory/projects/<id>/` is shared automatically. `.scratch/` remains
+  local-only per machine and per developer.
+- **Swapping LanceDB for another vector DB**: rebuild index from markdown source;
+  update `.memory/config.yml` `lancedb_path` key (or rename); update
+  `lance.*` MCP tools to wrap new backend.
+- **Dropping GitNexus** (e.g., on license concern for commercial use): remove
+  `.gitnexus/` ignore entry; install permissive replacement; no canonical data
+  is lost since GitNexus produces only an index.
+
+## 13. Open Questions
+
+1. **Plannotator integration shape** — annotation file format (sidecar JSON vs
+   inline HTML comments vs separate annotation tool repo). Defer to follow-up
+   change.
+2. **Team-scale namespace** — when a second contributor joins, do we need
+   `team.*` MCP tools, or does shared `agent-memory` access suffice? Defer.
+3. **Tavily MCP wiring** — is the existing Tavily MCP package sufficient, or do
+   we need a thin `web.*` wrapper that handles routing to project vs global?
+   Defer to first web capture session.
+4. **OpenSpec capability spec format** — the `openspec/specs/agent-memory-
+   harness/` spec deltas need to follow OpenSpec's capability conventions; the
+   exact format is decided when running `openspec apply`.
+
+## 14. Acceptance Criteria
+
+This change is complete when:
+
+- [ ] `agent-memory` repo exists with template structure including
+      `projects/<id>/` subtree shape.
+- [ ] `agentmem` CLI implements all tools in Section 6.
+- [ ] MCP wrapper implements all tools in Section 6.
+- [ ] `.memory/config.yml` exists at Fast Draft repo root with valid schema v1
+      (includes `project_id`).
+- [ ] `.gitignore` excludes `.scratch/`, `.memory/cache/`, `.gitnexus/`,
+      `.lancedb/`.
+- [ ] `openspec/` directory initialized; this change archives cleanly.
+- [ ] `.agents/shared/canonical.md` includes Memory Harness section.
+- [ ] `.agents/overrides/repo.md` includes Fast Draft-specific paths and
+      `project_id`.
+- [ ] `AGENTS.md` regenerated and committed.
+- [ ] `npm run verify:agent-surfaces` passes.
+- [ ] Pre-commit secret-scanning hook installed in `agent-memory`.
+- [ ] CI verifier rejects PRs that add files under `.scratch/`.
+- [ ] Smoke test passes: read config → search → write `.scratch/` → promote to
+      `agent-memory/projects/<id>/` via `promote.scratch_to_project_global`.
+- [ ] `docs/REQUIREMENTS.md` includes a Memory Harness entry.
+- [ ] `docs/CHANGELOG.md` records the harness introduction.
+
+## 15. References
+
+- Brainstorming snapshot: `docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md`
+- Parity precedent: `docs/specs/agent-surface-parity.md` (after move) or
+  `docs/superpowers/specs/2026-04-22-opencode-claude-parity-design.md` (current)
+- Agent surface renderer: `fd-vscode/src/agent-surfaces.ts`,
+  `scripts/agent-surfaces.mjs`
+- Existing canonical: `.agents/shared/canonical.md`
+- Existing override: `.agents/overrides/repo.md`
+- OpenSpec docs: https://github.com/(OpenSpec org)/openspec
+- GitNexus: https://github.com/(author)/gitnexus (PolyForm Noncommercial 1.0.0)
+- LanceDB: https://github.com/lancedb/lancedb (Apache 2.0)
+- Tavily MCP: https://github.com/tavily-ai/tavily-mcp

--- a/openspec/changes/agent-memory-harness/design.md
+++ b/openspec/changes/agent-memory-harness/design.md
@@ -476,7 +476,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 | R1 | Tool name collision (multiple memory plugins claiming `memory_*`) | M | M | Strict namespacing (`global.*` etc.); document in AGENTS.md; avoid generic memory plugins in production |
 | R2 | Index drift across machines (LanceDB, GitNexus caches diverge) | H | L | All indexes gitignored; canonical is markdown; rebuild from source on demand |
 | R3 | Secret leakage into memory files | M | H | Pre-commit hook scans for secret patterns; agents instructed via canonical to use env var names only |
-| R4 | GitNexus license trap (PolyForm Noncommercial) | L | M | Noted in `agent-memory/projects/khangnghiem__fast-draft.md`; license review required before monetization; swap to permissive code-intel tool if commercial use planned |
+| R4 | GitNexus license trap (PolyForm Noncommercial) | L | M | Noted in `agent-memory/projects/khangnghiem__fast-draft/README.md`; license review required before monetization; swap to permissive code-intel tool if commercial use planned |
 | R5 | Plugin abandonment (OpenSpec, GitNexus, LanceDB upstream changes) | M | M | Storage formats are simple and exportable; CLI is the source of truth and survives any plugin loss |
 | R6 | Prompt pollution (agents promote noise to global memory) | M | M | Promotion gate is PR review; `promote.*` opens drafts only |
 | R7 | YAML/TOML config drift (legacy `.opencode-memory.toml` or `.agentmemory.toml` files appear) | L | L | Spec mandates `.memory/config.yml` as the only valid config; verifier rejects legacy filenames |
@@ -491,7 +491,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 ### From current state (no harness)
 
 1. Create `agent-memory` private GitHub repo. Initialize with template structure
-   (Section 3.5).
+   (Section 3, L4 subsection).
 2. Clone to `~/.config/agent-memory/` on each machine.
 3. Add shell alias `agentmem` in `~/.zshrc`.
 4. Implement `agentmem` CLI in `agent-memory/cli/` (TS).

--- a/openspec/changes/agent-memory-harness/proposal.md
+++ b/openspec/changes/agent-memory-harness/proposal.md
@@ -14,7 +14,7 @@ specs but offers no proposal/design/tasks separation, no archive history, and no
 to scaffold consistent change shapes. Multiple parallel changes would muddle a single
 specs directory.
 
-This change introduces a tool-agnostic, multi-machine, three-repo memory architecture
+This change introduces a tool-agnostic, multi-machine, two-repo memory architecture
 plus an OpenSpec-driven change lifecycle, so agents have durable memory and humans
 have explicit change tracking.
 

--- a/openspec/changes/agent-memory-harness/proposal.md
+++ b/openspec/changes/agent-memory-harness/proposal.md
@@ -1,0 +1,93 @@
+# Proposal: Agent Memory Harness
+
+## Why
+
+AI coding agents in this monorepo (OpenCode now, future Claude Code / Cursor / Aider /
+Copilot CLI) currently have no persistent memory across sessions or machines. Every
+session starts cold: lessons learned in one debugging run vanish, project conventions
+must be rediscovered from `docs/`, web research is recaptured per session, and there
+is no shared substrate for cross-project knowledge (Rust idioms, wgpu patterns,
+deployment recipes) that recurs across personal repos.
+
+The repo also lacks an explicit spec lifecycle. `docs/specs/` holds 9 stable feature
+specs but offers no proposal/design/tasks separation, no archive history, and no CLI
+to scaffold consistent change shapes. Multiple parallel changes would muddle a single
+specs directory.
+
+This change introduces a tool-agnostic, multi-machine, three-repo memory architecture
+plus an OpenSpec-driven change lifecycle, so agents have durable memory and humans
+have explicit change tracking.
+
+## What Changes
+
+1. **Two-repo memory model**
+   - `agent-memory` (new private repo, cloned to `~/.config/agent-memory/`) for all
+     durable knowledge — both global (reusable across projects) and project-scoped
+     (per-project sessions, drafts, web captures, lessons) under
+     `agent-memory/projects/<owner>__<repo>/`.
+   - The project repo gains a gitignored `.scratch/` directory for local ephemeral
+     notes that don't need cross-machine sync, plus a committed `.memory/config.yml`
+     declaring canonical doc paths and optional cache settings. **No separate
+     `<project>.notes` repo.** Project content that must survive across machines
+     gets promoted from `.scratch/` to `agent-memory/projects/<id>/`. This avoids
+     a privacy leak risk (Fast Draft is a public repo; nothing tracked = nothing
+     leaked) and removes one repo's worth of sync overhead.
+
+2. **OpenSpec adoption** at `openspec/` (repo root). All future architectural and
+   feature changes flow through `openspec propose / apply / archive`. Existing
+   `docs/specs/` remains the durable archive for feature documentation; durable
+   content from archived OpenSpec changes can be promoted to `docs/specs/<feature>.md`.
+
+3. **Custom `agentmem` CLI** vendored in `agent-memory/cli/` (TypeScript, run via
+   `npx tsx`). Tool surface namespaced as `global.* / repo.* / sync.* / promote.* /
+   web.* / lance.*`. Distributed via shell alias, no npm publishing.
+
+4. **Thin MCP wrapper** in `agent-memory/mcp-server/` calling into the CLI's library
+   functions. Gives OpenCode-native tool discovery without duplicating logic.
+
+5. **Code intelligence layer**: GitNexus (PolyForm Noncommercial, accepted for
+   personal/dev use) for code graph + tree-sitter; ripgrep canonical for exact
+   search; ast-grep for structural search; LanceDB optional for semantic vector
+   search if/when needed.
+
+6. **Generated agent surfaces**: memory-harness rules added to
+   `.agents/shared/canonical.md` (generic policy) and `.agents/overrides/repo.md`
+   (Fast Draft repo-specific paths). Regenerated AGENTS.md / CLAUDE.md / GEMINI.md
+   tells agents to read `.memory/config.yml` first and call `repo.read_config` via
+   the MCP.
+
+7. **Sync model**: `git pull` at session start, `git push` at session end. No
+   daemons. All caches (`.gitnexus/`, `.memory/cache/`) gitignored.
+
+8. **Promotion gate**: PR review remains the only real promotion gate. OpenSpec
+   `apply / archive` and `promote.*` MCP tools open draft PRs but never merge.
+
+## Impact
+
+- **Affected specs**: introduces `agent-memory-harness` capability; adds
+  `openspec/specs/agent-memory-harness/` with the canonical specification deltas
+  for memory layer, MCP tool surface, and config schema.
+- **Affected code**:
+  - `.agents/shared/canonical.md` — add Memory Harness section.
+  - `.agents/overrides/repo.md` — add Fast Draft memory paths and MCP launch
+    command.
+  - `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` — regenerated via `npm run
+    render:agent-surfaces`.
+  - New `.memory/config.yml` at repo root (tracked).
+  - New `.gitignore` entries for `.scratch/`, `.memory/cache/`, `.gitnexus/`,
+    `.lancedb/`.
+  - New `openspec/` tree at repo root with `config.yaml`, `changes/`, `specs/`.
+  - `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md` — note the new harness.
+- **Affected external repos** (not part of this change, listed for completeness):
+  - `agent-memory` repo created on user's GitHub with `lessons/`, `snippets/`,
+    `preferences.md`, `projects/<id>/{README.md,sessions/,drafts/,transcripts/,
+    web/,attachments/,lessons/}`, `web/`, `inbox/`, `templates/`, `schemas/`,
+    `cli/`, `mcp-server/`.
+- **Risk**: GitNexus is PolyForm Noncommercial — license review required before any
+  monetization. LanceDB is pre-1.0 in some surfaces — file format may churn. Cache
+  drift across machines if `git pull` discipline slips. Tool collision if other
+  memory plugins are installed alongside. All mitigated in design.md risk register.
+- **Backout**: Memory harness is additive. Removing `.memory/config.yml`, deleting
+  `openspec/`, deleting `.scratch/` (already gitignored), and reverting
+  `.agents/overrides/repo.md` patches restores the prior state. The `agent-memory`
+  repo remains usable as a plain markdown vault even if the CLI/MCP is uninstalled.

--- a/openspec/changes/agent-memory-harness/tasks.md
+++ b/openspec/changes/agent-memory-harness/tasks.md
@@ -1,0 +1,202 @@
+# Agent Memory Harness — Implementation Tasks
+
+> **Change:** `agent-memory-harness`
+> **Design:** [`design.md`](./design.md)
+> **Proposal:** [`proposal.md`](./proposal.md)
+>
+> Tasks ordered by dependency. Each task has explicit acceptance and a
+> verification command. Mark `[x]` when complete.
+
+## Phase 0 — Prerequisites
+
+- [ ] **0.1** Confirm topic branch `feat/agent-memory-harness` is checked out.
+  - Verify: `git branch --show-current` prints `feat/agent-memory-harness`.
+- [ ] **0.2** Confirm `gh` CLI authenticated.
+  - Verify: `gh auth status` succeeds.
+- [ ] **0.3** Confirm `npx tsx` available.
+  - Verify: `npx --yes tsx --version` succeeds.
+
+## Phase 1 — Global `agent-memory` Repo
+
+- [ ] **1.1** Create private GitHub repo `agent-memory` under `khangnghiem`.
+  - Command: `gh repo create khangnghiem/agent-memory --private --description "Personal agent memory harness"`.
+  - Verify: `gh repo view khangnghiem/agent-memory --json visibility -q .visibility` prints `PRIVATE`.
+- [ ] **1.2** Clone to `~/.config/agent-memory/`.
+  - Command: `git clone git@github.com:khangnghiem/agent-memory.git ~/.config/agent-memory`.
+- [ ] **1.3** Initialize template directory structure per design Section 3.5:
+  ```
+  README.md preferences.md .gitignore
+  lessons/ snippets/ web/ inbox/ templates/ schemas/
+  projects/
+  cli/index.ts mcp-server/index.ts scripts/check-secrets.sh
+  package.json tsconfig.json
+  ```
+  - Verify: `find ~/.config/agent-memory -maxdepth 2 -type d` lists all required dirs.
+- [ ] **1.4** Add `.gitignore`: `node_modules/`, `*.log`, `.DS_Store`, any
+  per-machine cache paths.
+- [ ] **1.5** First commit + push.
+  - Verify: `cd ~/.config/agent-memory && git log --oneline | head -1` shows initial commit.
+
+## Phase 2 — Secrets Hygiene Foundation
+
+- [ ] **2.1** Confirm `~/.zshrc.secrets` exists and is sourced from `~/.zshrc`.
+  Create if missing.
+- [ ] **2.2** Write `agent-memory/scripts/check-secrets.sh` per design Section 10.
+  Patterns: `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, generic 32+ base64 in
+  credential context.
+  - Verify: `bash ~/.config/agent-memory/scripts/check-secrets.sh < <(echo "ghp_abc123...")` exits non-zero.
+- [ ] **2.3** Install pre-commit hook in `agent-memory` invoking
+  `scripts/check-secrets.sh` over staged files.
+  - Verify: attempt to commit a file containing `ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` is blocked.
+
+## Phase 3 — `agentmem` CLI
+
+- [ ] **3.1** Initialize `package.json` and `tsconfig.json` in `agent-memory/`.
+  Dependencies: `tsx`, `yaml`, `zod`, `simple-git`, `commander` (or `cac`).
+- [ ] **3.2** Implement `cli/lib/config.ts`: load + validate `.memory/config.yml`
+  with Zod schema v1 from design Section 5.
+  - Verify: unit test loads valid config; invalid config throws schema error.
+- [ ] **3.3** Implement `cli/lib/paths.ts`: resolve `agent_memory_path`,
+  `scratch_dir`, `lancedb_path`, `gitnexus_path` from config + env.
+- [ ] **3.4** Implement `cli/lib/global.ts`: `read_lesson`, `list_lessons`,
+  `read_snippet`, `read_preferences`, `write_preferences`, `write_draft`,
+  `write_project_session`, `read_project_readme`, `search` per design 6.
+- [ ] **3.5** Implement `cli/lib/repo.ts`: `read_config`, `read_canonical`,
+  `read_scratch`, `write_scratch`, `search`, `openspec_status`,
+  `openspec_propose`, `openspec_apply`, `openspec_archive` per design 6.
+- [ ] **3.6** Implement `cli/lib/sync.ts`: `status`, `pull` (`--ff-only`),
+  `push` per design 6 + 9. Scope: `global` | `project` | `both`.
+- [ ] **3.7** Implement `cli/lib/promote.ts`: `scratch_to_canonical`,
+  `scratch_to_project_global`, `lesson_to_global`. All open draft PRs via `gh`
+  except `scratch_to_project_global` which commits in `agent-memory` only.
+- [ ] **3.8** Implement `cli/lib/web.ts`: `capture` via webfetch fallback;
+  Tavily MCP integration deferred.
+- [ ] **3.9** Implement `cli/lib/lance.ts`: stubs returning "not enabled" unless
+  `lancedb_path` set.
+- [ ] **3.10** Implement `cli/index.ts`: command router for namespaces
+  `global / repo / sync / promote / web / lance`.
+  - Verify: `npx tsx ~/.config/agent-memory/cli/index.ts repo read-config`
+    in Fast Draft repo prints parsed config.
+- [ ] **3.11** Add shell alias to `~/.zshrc`:
+  `alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'`.
+  - Verify: new shell, `agentmem --help` prints usage.
+
+## Phase 4 — MCP Wrapper
+
+- [ ] **4.1** Add MCP SDK dependency: `@modelcontextprotocol/sdk`.
+- [ ] **4.2** Implement `mcp-server/index.ts` importing CLI library functions
+  and exposing them as MCP tools with namespaces from design Section 6.
+  - Tool ID format: `<namespace>__<tool>` (e.g., `global__read_lesson`).
+- [ ] **4.3** JSON schemas for each tool live in `agent-memory/schemas/`.
+  Wire via Zod `.zodToJsonSchema`.
+- [ ] **4.4** Smoke test: launch MCP via `npx tsx mcp-server/index.ts`, send
+  `tools/list` over stdio, verify all tools enumerated.
+
+## Phase 5 — Fast Draft Project Wiring
+
+- [ ] **5.1** Add `.memory/config.yml` at repo root with schema v1 content from
+  design Section 5 (`project_id: khangnghiem__fast-draft`).
+- [ ] **5.2** Append to `.gitignore`:
+  ```
+  .scratch/
+  .memory/cache/
+  .gitnexus/
+  .lancedb/
+  ```
+  Keep `.memory/config.yml` tracked.
+  - Verify: `git check-ignore .scratch/foo` succeeds; `git check-ignore .memory/config.yml` fails.
+- [ ] **5.3** Create empty `.scratch/` with placeholder `.gitkeep` is NOT done —
+  directory created on first write only.
+- [ ] **5.4** Create `agent-memory/projects/khangnghiem__fast-draft/` subtree:
+  `README.md` (license flags including GitNexus PolyForm note), `lessons/`,
+  `sessions/`, `drafts/`, `transcripts/`, `web/`, `attachments/`. Commit + push
+  in `agent-memory`.
+
+## Phase 6 — OpenSpec Initialization
+
+- [ ] **6.1** Run `npx -y openspec init` at Fast Draft repo root.
+  - Verify: `openspec/config.yaml` exists; existing `openspec/changes/agent-memory-harness/` intact.
+- [ ] **6.2** Create capability spec deltas under
+  `openspec/specs/agent-memory-harness/` per OpenSpec conventions discovered
+  during init.
+- [ ] **6.3** Verify `openspec status` lists this change as in-flight.
+
+## Phase 7 — Agent Surfaces
+
+- [ ] **7.1** Add a generic "Memory Harness" section to
+  `.agents/shared/canonical.md` per design Section 8 (read `.memory/config.yml`
+  first, retrieval order, promotion via PR, secret hygiene).
+- [ ] **7.2** Add Fast Draft-specific paths to `.agents/overrides/repo.md`:
+  `~/.config/agent-memory/`, `.memory/config.yml`, MCP launch command,
+  `project_id: khangnghiem__fast-draft`.
+- [ ] **7.3** Run `npm run render:agent-surfaces`. Commit regenerated
+  `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`.
+  - Verify: `npm run verify:agent-surfaces` passes.
+- [ ] **7.4** Register MCP in `.opencode/mcp.json` (create file if absent):
+  ```json
+  {
+    "mcpServers": {
+      "agentmem": {
+        "command": "npx",
+        "args": ["tsx", "/Users/khangnghiem/.config/agent-memory/mcp-server/index.ts"]
+      }
+    }
+  }
+  ```
+
+## Phase 8 — CI Verifier for `.scratch/`
+
+- [ ] **8.1** Add CI job (extend existing GitHub Actions workflow) that fails if
+  any PR adds files matching `.scratch/**`.
+  - Implementation: `git diff --name-only origin/main...HEAD | grep -E '^\.scratch/' && exit 1 || exit 0`.
+  - Verify: open a test PR adding `.scratch/test.md`; CI fails. Remove file; CI passes.
+
+## Phase 9 — Smoke Test (acceptance gate)
+
+- [ ] **9.1** Open OpenCode session in Fast Draft repo.
+- [ ] **9.2** Agent calls `repo.read_config` via MCP. Verify parsed config returned.
+- [ ] **9.3** Agent calls `repo.search { query: "wgpu" }`. Verify project hits.
+- [ ] **9.4** Agent calls `repo.write_scratch { path: "sessions/smoke-test.md", content: "...", mode: "replace" }`.
+  - Verify: file exists at `.scratch/sessions/smoke-test.md`; not staged in git.
+- [ ] **9.5** Agent calls `promote.scratch_to_project_global { paths: ["sessions/smoke-test.md"] }`.
+  - Verify: file copied to `agent-memory/projects/khangnghiem__fast-draft/sessions/smoke-test.md`; commit present in `agent-memory` log.
+- [ ] **9.6** Agent calls `sync.push { scope: "global" }`.
+  - Verify: `agent-memory` remote has new commit.
+- [ ] **9.7** Agent calls `global.list_lessons { project_id: "khangnghiem__fast-draft" }`.
+  - Verify: returns project lessons (empty list acceptable).
+
+## Phase 10 — Documentation
+
+- [ ] **10.1** Add Memory Harness entry to `docs/REQUIREMENTS.md`.
+- [ ] **10.2** Add changelog entry to `docs/CHANGELOG.md`.
+- [ ] **10.3** Update root `README.md` with one-paragraph pointer to
+  `MEMORY_INIT.md` and `.memory/config.yml`.
+
+## Phase 11 — Land + Archive
+
+- [ ] **11.1** Push topic branch.
+- [ ] **11.2** Open PR with summary linking proposal + design + tasks.
+  - PR title: `feat: agent memory harness`.
+- [ ] **11.3** After merge: run `openspec archive agent-memory-harness`.
+  - Verify: archived change remains under `openspec/changes/` for history;
+    `openspec status` no longer lists it as in-flight.
+- [ ] **11.4** Tag release point: `git tag harness-v1`.
+
+## Verification matrix (acceptance criteria from design Section 14)
+
+| Criterion | Phase | Verified by |
+|----------|-------|-------------|
+| `agent-memory` repo with template structure | 1 | 1.3 |
+| CLI implements all tools | 3 | 3.10 |
+| MCP wrapper implements all tools | 4 | 4.4 |
+| `.memory/config.yml` valid schema v1 | 5 | 5.1 + 9.2 |
+| `.gitignore` excludes scratch + caches | 5 | 5.2 |
+| `openspec/` initialized; this change archives cleanly | 6, 11 | 11.3 |
+| Canonical and override agent surface sections | 7 | 7.1, 7.2 |
+| `AGENTS.md` regenerated | 7 | 7.3 |
+| `verify:agent-surfaces` passes | 7 | 7.3 |
+| Pre-commit secret hook installed | 2 | 2.3 |
+| CI rejects `.scratch/` files | 8 | 8.1 |
+| Smoke test (read → search → write → promote) | 9 | 9.2–9.7 |
+| `docs/REQUIREMENTS.md` entry | 10 | 10.1 |
+| `docs/CHANGELOG.md` entry | 10 | 10.2 |

--- a/openspec/changes/agent-memory-harness/tasks.md
+++ b/openspec/changes/agent-memory-harness/tasks.md
@@ -23,7 +23,7 @@
   - Verify: `gh repo view khangnghiem/agent-memory --json visibility -q .visibility` prints `PRIVATE`.
 - [ ] **1.2** Clone to `~/.config/agent-memory/`.
   - Command: `git clone git@github.com:khangnghiem/agent-memory.git ~/.config/agent-memory`.
-- [ ] **1.3** Initialize template directory structure per design Section 3.5:
+- [ ] **1.3** Initialize template directory structure per design Section 3 (L4 subsection):
   ```
   README.md preferences.md .gitignore
   lessons/ snippets/ web/ inbox/ templates/ schemas/


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `agent-memory-harness` (proposal, design, tasks) defining a layered, multi-machine, multi-project agent memory + code-intelligence harness.
- Adds project-agnostic `MEMORY_INIT.md` at repo root for bootstrapping the harness in future repos.
- Adds frozen Superpowers brainstorming snapshot under `docs/superpowers/specs/` pointing to the canonical OpenSpec design.

## Architecture (locked)

- **Two repos**: project repo + private \`agent-memory\` (cloned to \`~/.config/agent-memory/\`). No \`<project>.notes\` repo.
- **Layer cake**: L0 ephemeral → L1 \`.scratch/\` (gitignored, local-only) → L2 project canonical → L3 code intel (gitignored caches) → L4 \`agent-memory\` (global root + \`projects/<id>/\`) → L5 web cache.
- **Markdown canonical, ripgrep canonical search.** LanceDB optional vector cache; GitNexus optional code graph; ast-grep for structural.
- **Custom \`agentmem\` CLI** (TS, vendored in \`agent-memory/cli/\`) is source of truth; thin MCP wrapper imports CLI library directly.
- **OpenSpec** for in-flight changes; **Superpowers** for brainstorming process; both use their own default folders, no cross-writing.
- **Sync** via \`git pull --ff-only\` at session start, \`git push\` at session end. No daemons.
- **Promotion** always opens draft PRs; never auto-merges.

## What's NOT in this PR

This PR ships the **design and plan only**. Implementation (Phases 1–11 in \`tasks.md\`) lands in follow-up PRs after the design is approved here.

## Files

- \`openspec/changes/agent-memory-harness/proposal.md\`
- \`openspec/changes/agent-memory-harness/design.md\` (15 sections)
- \`openspec/changes/agent-memory-harness/tasks.md\` (11 phases, ~50 tasks)
- \`docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md\` (frozen snapshot)
- \`MEMORY_INIT.md\` (per-project bootstrap guide)

## Test plan

Design-only PR. Verification matrix in \`tasks.md\` covers acceptance once implementation lands.