### PR TITLE
feat(memory): initialize fast-draft as memory-aware repo (Phase 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ fd-canvas-ui/dist/
 # GitHub Pages WASM build output (built by CI)
 site/wasm/
 
+# Agent memory ephemeral scratch (.memory/config.yml IS committed)
+.scratch/
+
 # Environment secrets
 .env
 serve.log

--- a/.memory/config.yml
+++ b/.memory/config.yml
@@ -1,0 +1,15 @@
+schema: 1
+project_id: khangnghiem__fast-draft
+scratch_dir: .scratch
+canonical_doc_paths:
+  - AGENTS.md
+  - docs/ARCHITECTURE.md
+  - docs/REQUIREMENTS.md
+  - docs/LESSONS.md
+  - docs/SHORTCUTS.md
+  - docs/CHANGELOG.md
+  - docs/specs
+  - openspec
+openspec_dir: openspec
+web_capture_target: project
+agent_memory_path: ~/.config/agent-memory


### PR DESCRIPTION
## Summary
- Adds `.memory/config.yml` declaring this repo as `khangnghiem__fast-draft` for the [agent-memory](https://github.com/khangnghiem/agent-memory) harness; canonical docs scope covers `AGENTS.md`, the `docs/` knowledge files, `docs/specs/`, and `openspec/`.
- Adds `.scratch/` to `.gitignore` (ephemeral agent working memory) while keeping `.memory/` tracked.
- Companion project subtree pushed to agent-memory@f597294 with a fast-draft-specific README documenting build quirks (WASM manual build, `wasm-opt -O1`, pnpm vs npm split) and lesson-routing conventions.

## Verification
- `agentmem repo read-config` from repo root: clean parse, all paths resolved against `~/.config/agent-memory/projects/khangnghiem__fast-draft`.
- `agentmem repo write-scratch` then `read-scratch`: round-trip OK against `.scratch/`.
- `agentmem repo search SceneGraph`: returns hits restricted to canonical scope (`AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/SHORTCUTS.md`) — confirms canonical_doc_paths is honored.

## Follow-ups
- LanceDB and gitnexus paths are intentionally unset; enable per-machine when those backends are wired.
- `MEMORY_INIT.md` (the project-agnostic template from #1143) is unchanged and remains the reusable adoption guide for future repos.

## Related
- Tracks Phase 5 of the agent-memory rollout. Phases 0–4 (harness bootstrap, CLI, MCP server) live in [agent-memory](https://github.com/khangnghiem/agent-memory).