### PR TITLE
feat(memory): openspec + agent surfaces + CI guard + docs (Phases 6-10)

### DIFF
--- a/.agents/overrides/repo.md
+++ b/.agents/overrides/repo.md
@@ -114,6 +114,16 @@ When adding a new browser script, follow the existing `import { chromium } from 
 - `.agents/workflows/yolo.md` — full yolo pipeline (TDD → build → PR → merge → verify)
 - `.agents/workflows/` generally use dual-path format; look for `Antigravity:` and `OpenCode:` labels where present
 
+### Memory harness — Fast Draft specifics
+
+- **Project ID**: `khangnghiem__fast-draft`
+- **Config**: [`.memory/config.yml`](../../.memory/config.yml) (committed). Canonical scope = `AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`. `web_capture_target: project`.
+- **Per-project subtree**: `~/.config/agent-memory/projects/khangnghiem__fast-draft/` (lessons, sessions, drafts, transcripts, web, attachments, inbox).
+- **CLI**: `agentmem` alias → `~/.config/agent-memory/bin/agentmem`. MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp` (stdio).
+- **Lesson routing**: prefer the per-project `lessons/` for fast-draft-internal pitfalls (bounds ownership chain, pointer-event hijack, WASM build sync). Promote to global only when the pattern generalizes.
+- **First-time setup**: see [`MEMORY_INIT.md`](../../MEMORY_INIT.md) for the project-agnostic adoption guide. The `~/.config/agent-memory/projects/khangnghiem__fast-draft/README.md` documents fast-draft-specific quirks.
+- **CI guard**: `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+
 ### User shortcuts
 
 - `yolo <feature>` → follow `.agents/workflows/yolo.md`

--- a/.agents/shared/canonical.md
+++ b/.agents/shared/canonical.md
@@ -87,6 +87,19 @@ When delegating or performing broad codebase exploration, optimize for an eviden
 - Keep visual verification short and focused. Reuse an existing browser session or page when the host supports it.
 - If a browser rule must reach a secondary executor, place it directly in the verification instructions instead of relying only on a higher-level policy file.
 
+### Memory harness
+
+This repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness (`~/.config/agent-memory/`). When working in a project with `.memory/config.yml`, follow this contract.
+
+- **Read `.memory/config.yml` first.** It declares `project_id`, `canonical_doc_paths`, `scratch_dir`, and optional indices. Use the host's `agentmem repo read-config` (CLI) or `repo__read_config` (MCP) — never re-derive paths.
+- **Retrieval order**: open files → canonical docs (via `repo.search`, scoped by `canonical_doc_paths`) → per-project subtree under `~/.config/agent-memory/projects/<project_id>/` → global lessons / snippets / web → external web (last resort, `web.capture`).
+- **Use `.scratch/` as ephemeral working memory.** It is gitignored. Write freely with `agentmem repo write-scratch <path>` (stdin = body). Promote to the per-project subtree with `agentmem promote scratch_to_project_global` when worth keeping; promote to canonical docs via draft PR with `agentmem promote scratch_to_canonical`.
+- **Never bypass the promotion contract.** Writes flow upward: `.scratch/` → per-project subtree → global. Cross-repo promotions go through draft PRs in the destination repo, never direct pushes to `main`.
+- **Secret hygiene is shared.** The harness pre-commit hook rejects `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char base64 in credential context. Do not stage `.env` files or tokens in either repo.
+- **Sync model**: `git pull --ff-only` at session start in `~/.config/agent-memory`; `git push` at session end. No daemons.
+
+If `.memory/config.yml` is absent, the repo has not adopted the harness — fall back to `docs/` and `openspec/` directly and do not invent paths.
+
 ### Completion checklist
 
 - Relevant build, test, lint, and format checks passed, or were skipped with a stated reason.

--- a/.github/workflows/memory-scratch-guard.yml
+++ b/.github/workflows/memory-scratch-guard.yml
@@ -1,0 +1,32 @@
+name: memory-scratch-guard
+
+# Reject PRs that add files under .scratch/. Per the agent memory harness
+# contract, .scratch/ is ephemeral working memory and must never be committed.
+# See: openspec/specs/agent-memory-harness/spec.md
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Reject .scratch/ additions
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          offenders=$(git diff --name-only --diff-filter=A "$base...$head" | grep -E '^\.scratch/' || true)
+          if [ -n "$offenders" ]; then
+            echo "::error::PR adds files under .scratch/ which is gitignored ephemeral agent memory:"
+            echo "$offenders" | sed 's/^/  /'
+            echo ""
+            echo "Promote useful content to ~/.config/agent-memory/projects/khangnghiem__fast-draft/"
+            echo "via 'agentmem promote scratch_to_project_global', then drop the .scratch/ entries."
+            exit 1
+          fi
+          echo "OK: no .scratch/ additions in this PR."

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ site/wasm/
 
 # Agent memory ephemeral scratch (.memory/config.yml IS committed)
 .scratch/
+.memory/cache/
+.gitnexus/
+.lancedb/
 
 # Environment secrets
 .env

--- a/.opencode/mcp.json
+++ b/.opencode/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "agentmem": {
+      "command": "/Users/khangnghiem/.config/agent-memory/bin/agentmem-mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,19 @@ When delegating or performing broad codebase exploration, optimize for an eviden
 - Keep visual verification short and focused. Reuse an existing browser session or page when the host supports it.
 - If a browser rule must reach a secondary executor, place it directly in the verification instructions instead of relying only on a higher-level policy file.
 
+### Memory harness
+
+This repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness (`~/.config/agent-memory/`). When working in a project with `.memory/config.yml`, follow this contract.
+
+- **Read `.memory/config.yml` first.** It declares `project_id`, `canonical_doc_paths`, `scratch_dir`, and optional indices. Use the host's `agentmem repo read-config` (CLI) or `repo__read_config` (MCP) — never re-derive paths.
+- **Retrieval order**: open files → canonical docs (via `repo.search`, scoped by `canonical_doc_paths`) → per-project subtree under `~/.config/agent-memory/projects/<project_id>/` → global lessons / snippets / web → external web (last resort, `web.capture`).
+- **Use `.scratch/` as ephemeral working memory.** It is gitignored. Write freely with `agentmem repo write-scratch <path>` (stdin = body). Promote to the per-project subtree with `agentmem promote scratch_to_project_global` when worth keeping; promote to canonical docs via draft PR with `agentmem promote scratch_to_canonical`.
+- **Never bypass the promotion contract.** Writes flow upward: `.scratch/` → per-project subtree → global. Cross-repo promotions go through draft PRs in the destination repo, never direct pushes to `main`.
+- **Secret hygiene is shared.** The harness pre-commit hook rejects `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char base64 in credential context. Do not stage `.env` files or tokens in either repo.
+- **Sync model**: `git pull --ff-only` at session start in `~/.config/agent-memory`; `git push` at session end. No daemons.
+
+If `.memory/config.yml` is absent, the repo has not adopted the harness — fall back to `docs/` and `openspec/` directly and do not invent paths.
+
 ### Completion checklist
 
 - Relevant build, test, lint, and format checks passed, or were skipped with a stated reason.
@@ -234,6 +247,16 @@ When adding a new browser script, follow the existing `import { chromium } from 
 - `docs/SHORTCUTS.md` — keyboard shortcuts; source of truth is `crates/fd-editor/src/shortcuts.rs`
 - `.agents/workflows/yolo.md` — full yolo pipeline (TDD → build → PR → merge → verify)
 - `.agents/workflows/` generally use dual-path format; look for `Antigravity:` and `OpenCode:` labels where present
+
+### Memory harness — Fast Draft specifics
+
+- **Project ID**: `khangnghiem__fast-draft`
+- **Config**: [`.memory/config.yml`](../../.memory/config.yml) (committed). Canonical scope = `AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`. `web_capture_target: project`.
+- **Per-project subtree**: `~/.config/agent-memory/projects/khangnghiem__fast-draft/` (lessons, sessions, drafts, transcripts, web, attachments, inbox).
+- **CLI**: `agentmem` alias → `~/.config/agent-memory/bin/agentmem`. MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp` (stdio).
+- **Lesson routing**: prefer the per-project `lessons/` for fast-draft-internal pitfalls (bounds ownership chain, pointer-event hijack, WASM build sync). Promote to global only when the pattern generalizes.
+- **First-time setup**: see [`MEMORY_INIT.md`](../../MEMORY_INIT.md) for the project-agnostic adoption guide. The `~/.config/agent-memory/projects/khangnghiem__fast-draft/README.md` documents fast-draft-specific quirks.
+- **CI guard**: `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
 
 ### User shortcuts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,19 @@ When delegating or performing broad codebase exploration, optimize for an eviden
 - Keep visual verification short and focused. Reuse an existing browser session or page when the host supports it.
 - If a browser rule must reach a secondary executor, place it directly in the verification instructions instead of relying only on a higher-level policy file.
 
+### Memory harness
+
+This repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness (`~/.config/agent-memory/`). When working in a project with `.memory/config.yml`, follow this contract.
+
+- **Read `.memory/config.yml` first.** It declares `project_id`, `canonical_doc_paths`, `scratch_dir`, and optional indices. Use the host's `agentmem repo read-config` (CLI) or `repo__read_config` (MCP) — never re-derive paths.
+- **Retrieval order**: open files → canonical docs (via `repo.search`, scoped by `canonical_doc_paths`) → per-project subtree under `~/.config/agent-memory/projects/<project_id>/` → global lessons / snippets / web → external web (last resort, `web.capture`).
+- **Use `.scratch/` as ephemeral working memory.** It is gitignored. Write freely with `agentmem repo write-scratch <path>` (stdin = body). Promote to the per-project subtree with `agentmem promote scratch_to_project_global` when worth keeping; promote to canonical docs via draft PR with `agentmem promote scratch_to_canonical`.
+- **Never bypass the promotion contract.** Writes flow upward: `.scratch/` → per-project subtree → global. Cross-repo promotions go through draft PRs in the destination repo, never direct pushes to `main`.
+- **Secret hygiene is shared.** The harness pre-commit hook rejects `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char base64 in credential context. Do not stage `.env` files or tokens in either repo.
+- **Sync model**: `git pull --ff-only` at session start in `~/.config/agent-memory`; `git push` at session end. No daemons.
+
+If `.memory/config.yml` is absent, the repo has not adopted the harness — fall back to `docs/` and `openspec/` directly and do not invent paths.
+
 ### Completion checklist
 
 - Relevant build, test, lint, and format checks passed, or were skipped with a stated reason.
@@ -234,6 +247,16 @@ When adding a new browser script, follow the existing `import { chromium } from 
 - `docs/SHORTCUTS.md` — keyboard shortcuts; source of truth is `crates/fd-editor/src/shortcuts.rs`
 - `.agents/workflows/yolo.md` — full yolo pipeline (TDD → build → PR → merge → verify)
 - `.agents/workflows/` generally use dual-path format; look for `Antigravity:` and `OpenCode:` labels where present
+
+### Memory harness — Fast Draft specifics
+
+- **Project ID**: `khangnghiem__fast-draft`
+- **Config**: [`.memory/config.yml`](../../.memory/config.yml) (committed). Canonical scope = `AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`. `web_capture_target: project`.
+- **Per-project subtree**: `~/.config/agent-memory/projects/khangnghiem__fast-draft/` (lessons, sessions, drafts, transcripts, web, attachments, inbox).
+- **CLI**: `agentmem` alias → `~/.config/agent-memory/bin/agentmem`. MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp` (stdio).
+- **Lesson routing**: prefer the per-project `lessons/` for fast-draft-internal pitfalls (bounds ownership chain, pointer-event hijack, WASM build sync). Promote to global only when the pattern generalizes.
+- **First-time setup**: see [`MEMORY_INIT.md`](../../MEMORY_INIT.md) for the project-agnostic adoption guide. The `~/.config/agent-memory/projects/khangnghiem__fast-draft/README.md` documents fast-draft-specific quirks.
+- **CI guard**: `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
 
 ### User shortcuts
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -111,6 +111,19 @@ When delegating or performing broad codebase exploration, optimize for an eviden
 - Keep visual verification short and focused. Reuse an existing browser session or page when the host supports it.
 - If a browser rule must reach a secondary executor, place it directly in the verification instructions instead of relying only on a higher-level policy file.
 
+### Memory harness
+
+This repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness (`~/.config/agent-memory/`). When working in a project with `.memory/config.yml`, follow this contract.
+
+- **Read `.memory/config.yml` first.** It declares `project_id`, `canonical_doc_paths`, `scratch_dir`, and optional indices. Use the host's `agentmem repo read-config` (CLI) or `repo__read_config` (MCP) — never re-derive paths.
+- **Retrieval order**: open files → canonical docs (via `repo.search`, scoped by `canonical_doc_paths`) → per-project subtree under `~/.config/agent-memory/projects/<project_id>/` → global lessons / snippets / web → external web (last resort, `web.capture`).
+- **Use `.scratch/` as ephemeral working memory.** It is gitignored. Write freely with `agentmem repo write-scratch <path>` (stdin = body). Promote to the per-project subtree with `agentmem promote scratch_to_project_global` when worth keeping; promote to canonical docs via draft PR with `agentmem promote scratch_to_canonical`.
+- **Never bypass the promotion contract.** Writes flow upward: `.scratch/` → per-project subtree → global. Cross-repo promotions go through draft PRs in the destination repo, never direct pushes to `main`.
+- **Secret hygiene is shared.** The harness pre-commit hook rejects `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char base64 in credential context. Do not stage `.env` files or tokens in either repo.
+- **Sync model**: `git pull --ff-only` at session start in `~/.config/agent-memory`; `git push` at session end. No daemons.
+
+If `.memory/config.yml` is absent, the repo has not adopted the harness — fall back to `docs/` and `openspec/` directly and do not invent paths.
+
 ### Completion checklist
 
 - Relevant build, test, lint, and format checks passed, or were skipped with a stated reason.
@@ -238,6 +251,16 @@ When adding a new browser script, follow the existing `import { chromium } from 
 - `docs/SHORTCUTS.md` — keyboard shortcuts; source of truth is `crates/fd-editor/src/shortcuts.rs`
 - `.agents/workflows/yolo.md` — full yolo pipeline (TDD → build → PR → merge → verify)
 - `.agents/workflows/` generally use dual-path format; look for `Antigravity:` and `OpenCode:` labels where present
+
+### Memory harness — Fast Draft specifics
+
+- **Project ID**: `khangnghiem__fast-draft`
+- **Config**: [`.memory/config.yml`](../../.memory/config.yml) (committed). Canonical scope = `AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`. `web_capture_target: project`.
+- **Per-project subtree**: `~/.config/agent-memory/projects/khangnghiem__fast-draft/` (lessons, sessions, drafts, transcripts, web, attachments, inbox).
+- **CLI**: `agentmem` alias → `~/.config/agent-memory/bin/agentmem`. MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp` (stdio).
+- **Lesson routing**: prefer the per-project `lessons/` for fast-draft-internal pitfalls (bounds ownership chain, pointer-event hijack, WASM build sync). Promote to global only when the pattern generalizes.
+- **First-time setup**: see [`MEMORY_INIT.md`](../../MEMORY_INIT.md) for the project-agnostic adoption guide. The `~/.config/agent-memory/projects/khangnghiem__fast-draft/README.md` documents fast-draft-specific quirks.
+- **CI guard**: `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
 
 ### User shortcuts
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ rect @login_btn {
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for architecture, crate structure, build instructions, and development setup.
 
+For AI-agent contributors: this repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness. The committed [`.memory/config.yml`](.memory/config.yml) declares the project's canonical doc scope and per-project memory subtree; new machines and new agents follow the project-agnostic adoption checklist in [`MEMORY_INIT.md`](MEMORY_INIT.md).
+
 ## License
 
 MIT — see [LICENSE](LICENSE)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### Agent Memory Harness — full rollout (Phases 0–10)
+- **FEAT (Memory)**: Bootstrapped the [`agent-memory`](https://github.com/khangnghiem/agent-memory) global harness (CLI + MCP server) and wired Fast Draft as its first memory-aware project (`project_id: khangnghiem__fast-draft`).
+- **FEAT (Memory)**: Added `agentmem` CLI (`global / repo / sync / promote / web / lance` namespaces) and `agentmem-mcp` stdio wrapper exposing the same surface as `<namespace>__<tool>` MCP tools. Registered for OpenCode in `.opencode/mcp.json`.
+- **FEAT (Memory)**: `.memory/config.yml` declares canonical doc scope, `scratch_dir`, and per-project subtree path. `.scratch/`, `.memory/cache/`, `.gitnexus/`, `.lancedb/` gitignored.
+- **FEAT (Memory)**: OpenSpec capability spec at `openspec/specs/agent-memory-harness/spec.md` codifies retrieval order, promotion contract, secret hygiene, and verification matrix. `openspec/config.yaml` declares the directory-based lifecycle.
+- **FEAT (Memory)**: Agent surfaces — added "Memory harness" section to `.agents/shared/canonical.md` and Fast Draft specifics to `.agents/overrides/repo.md`. Regenerated `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`.
+- **FEAT (CI)**: `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+- **DOCS (Memory)**: Added R8.1–R8.4 to `docs/REQUIREMENTS.md` and root `README.md` pointer.
+
 ### v0.11.384 — Fix Ollama Cloud API (Tier 2 Fallback)
 - **FIX (AI)**: Migrated Ollama Cloud from deprecated `/api/chat` to OpenAI-compatible `/v1/chat/completions` endpoint. Old endpoint returned `200` with empty body, causing "AI returned an empty response" errors.
 - **FIX (AI)**: Updated request format from Ollama-native (`options.temperature`, `options.num_predict`) to OpenAI-standard (`temperature`, `max_tokens`).

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -403,11 +403,33 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 
 ---
 
+## Agent Memory Harness
+
+> **Status:** done (Phases 0–10). **Spec:** [`openspec/specs/agent-memory-harness/spec.md`](../openspec/specs/agent-memory-harness/spec.md). **Init guide:** [`MEMORY_INIT.md`](../MEMORY_INIT.md).
+
+### R8.1 — Memory-aware repo configuration _(done)_
+
+- `.memory/config.yml` (committed) declares `project_id: khangnghiem__fast-draft`, canonical doc paths (`AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`), `scratch_dir: .scratch`, and `web_capture_target: project`.
+- `.scratch/`, `.memory/cache/`, `.gitnexus/`, `.lancedb/` are gitignored — ephemeral or per-machine state never lands in `main`.
+
+### R8.2 — agentmem CLI + MCP discovery _(done)_
+
+- `agentmem` CLI (`~/.config/agent-memory/bin/agentmem`) exposes `global / repo / sync / promote / web / lance` namespaces.
+- `agentmem-mcp` stdio MCP wrapper exposes the same operations as `<namespace>__<tool>` tools, registered for OpenCode in [`.opencode/mcp.json`](../.opencode/mcp.json).
+
+### R8.3 — Promotion contract _(done)_
+
+- `.scratch/` → `~/.config/agent-memory/projects/khangnghiem__fast-draft/<bucket>/` via `agentmem promote scratch-to-project-global`.
+- Project lessons → global lessons via draft PR (`agentmem promote lesson-to-global`).
+- `.scratch/` → `docs/` via draft PR (`agentmem promote scratch-to-canonical`). All cross-repo promotions go through PRs in the destination repo.
+
+### R8.4 — CI guard _(done)_
+
+- [`.github/workflows/memory-scratch-guard.yml`](../.github/workflows/memory-scratch-guard.yml) rejects any PR that adds files under `.scratch/`.
+
 ## Future Requirements (Deferred)
 
 ### R7.1 — Real-Time Collaboration
-
-**Priority**: Low (multi-week project)
 **Inspired by**: Excalidraw live collaboration
 
 Requirements:

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,28 @@
+# OpenSpec configuration for fast-draft.
+#
+# OpenSpec lifecycle in this repo is directory-based (no installed CLI). Use the
+# layout here as the source of truth.
+#
+# Layout:
+#   openspec/changes/<slug>/{proposal,design,tasks}.md  - in-flight changes
+#   openspec/specs/<capability>/spec.md                 - durable capability spec
+#   openspec/changes/archive/<slug>/                    - archived (post-merge) changes
+#
+# Lifecycle:
+#   1. propose   - create openspec/changes/<slug>/{proposal,design,tasks}.md on a
+#                  topic branch.
+#   2. apply     - merge the change PR. Capability spec deltas land in
+#                  openspec/specs/<capability>/spec.md.
+#   3. archive   - move openspec/changes/<slug>/ -> openspec/changes/archive/<slug>/
+#                  in a follow-up commit; durable content lives in
+#                  openspec/specs/<capability>/spec.md and (optionally)
+#                  docs/specs/<feature>.md.
+#
+# Conventions:
+#   - One <slug> per topic branch; slugs are kebab-case.
+#   - <capability> is a stable noun (e.g., agent-memory-harness, scenegraph-core).
+#   - Archived changes are immutable history; never edit in place.
+schema: 1
+specs_dir: openspec/specs
+changes_dir: openspec/changes
+archive_dir: openspec/changes/archive

--- a/openspec/specs/agent-memory-harness/spec.md
+++ b/openspec/specs/agent-memory-harness/spec.md
@@ -1,0 +1,96 @@
+# Capability: Agent Memory Harness
+
+> **Status:** stable (introduced by `openspec/changes/agent-memory-harness/`,
+> incrementally rolled out across PRs #1143, #1145, and the Phases 6–10 PR).
+> **Owner:** khangnghiem
+> **Related**: [`MEMORY_INIT.md`](../../../MEMORY_INIT.md), [`.memory/config.yml`](../../../.memory/config.yml)
+
+## Purpose
+
+Give AI coding agents in this repo durable, multi-machine memory and a clean
+contract for routing reads and writes between:
+
+- the project repo (canonical docs, ephemeral `.scratch/`),
+- the global harness at `~/.config/agent-memory/` (cross-project lessons,
+  per-project subtree at `projects/khangnghiem__fast-draft/`).
+
+## Components
+
+### 1. Project-side contract
+
+| Path | Tracked? | Role |
+| --- | --- | --- |
+| `.memory/config.yml` | yes | Schema-v1 declaration: `project_id`, canonical doc paths, scratch dir, optional `lancedb_path` / `gitnexus_path`, `web_capture_target`, `agent_memory_path`. |
+| `.scratch/` | no (gitignored) | Ephemeral agent working memory. Promoted to the agent-memory subtree when worth keeping. |
+| `.memory/cache/`, `.gitnexus/`, `.lancedb/` | no (gitignored) | Per-machine indices; never committed. |
+
+### 2. Global harness contract
+
+Lives at `~/.config/agent-memory/` (repo: `khangnghiem/agent-memory`).
+
+| Subtree | Role |
+| --- | --- |
+| `lessons/`, `snippets/`, `web/`, `inbox/` | Cross-project durable knowledge. |
+| `projects/khangnghiem__fast-draft/` | This repo's per-project subtree: `README.md`, `lessons/`, `sessions/`, `drafts/`, `transcripts/`, `web/`, `attachments/`, `inbox/`. |
+| `cli/` | `agentmem` CLI (TypeScript, run via tsx). |
+| `mcp-server/` | Stdio MCP wrapper exposing the CLI library as `<namespace>__<tool>` MCP tools. |
+| `scripts/check-secrets.sh` | Pre-commit secret scanner. |
+
+### 3. Tool surface
+
+Namespaced. Both the CLI and the MCP wrapper expose the same operations:
+
+- `global.*` — `read_lesson`, `list_lessons`, `read_snippet`, `read_preferences`, `write_preferences`, `write_draft`, `write_project_session`, `read_project_readme`, `search`.
+- `repo.*` — `read_config`, `read_canonical`, `read_scratch`, `write_scratch`, `search`, `openspec_status`, `openspec_propose`, `openspec_apply`, `openspec_archive`.
+- `sync.*` — `status`, `pull` (`--ff-only`), `push`, scoped `global` | `project` | `both`.
+- `promote.*` — `scratch_to_canonical` (opens draft PR), `scratch_to_project_global` (commits in agent-memory only), `lesson_to_global` (opens draft PR).
+- `web.*` — `capture` via webfetch fallback (Tavily MCP deferred).
+- `lance.*` — stubs returning `{status: "NOT_ENABLED"}` until `lancedb_path` is set.
+
+## Retrieval order (agent contract)
+
+When an agent needs context, it MUST consult sources in this order and stop as
+soon as the question is answered:
+
+1. **Open files in the current task** — local working set.
+2. **`.memory/config.yml` canonical_doc_paths** — `AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs`, `openspec/`. Use `repo.search` (ripgrep, restricted to canonical scope by default).
+3. **Per-project subtree** (`projects/khangnghiem__fast-draft/{lessons,sessions,drafts,...}`) via `global.*` tools.
+4. **Global lessons / snippets / web** via `global.search` or `global.list_lessons`.
+5. **External web** via `web.capture` (fallback only; cache to project or global per `web_capture_target`).
+
+## Promotion contract
+
+Writes flow strictly upward, never sideways:
+
+```
+.scratch/  ->  agent-memory/projects/<id>/<bucket>/   (promote.scratch_to_project_global)
+agent-memory/projects/<id>/lessons/<file>  ->  agent-memory/lessons/<file>   (promote.lesson_to_global, draft PR)
+.scratch/<file>  ->  docs/<canonical>/<file>   (promote.scratch_to_canonical, draft PR)
+```
+
+All cross-repo promotions go through draft PRs in the **destination** repo,
+never direct pushes to `main`.
+
+## Secret hygiene
+
+- Pre-commit hook in `agent-memory` runs `scripts/check-secrets.sh` on staged
+  blobs and rejects on `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char
+  base64-in-credential-context.
+- Fast-draft adopts the same scanner via the `.githooks/pre-commit` chain.
+- `.env`, tokens, API keys are never staged in either repo.
+
+## Sync model
+
+- No daemons. `git pull --ff-only` at session start, `git push` at session end.
+- The agent-memory repo lives on `main`; project-subtree commits land directly.
+- Fast-draft uses topic branches and PRs (no direct pushes to `main`).
+
+## Verification
+
+| Aspect | Verifier |
+| --- | --- |
+| Config parses | `agentmem repo read-config` exits 0 and prints resolved paths. |
+| Scratch round-trip | `agentmem repo write-scratch <p>` then `agentmem repo read-scratch <p>` returns body. |
+| Canonical search scope | `agentmem repo search <q>` only hits paths in `canonical_doc_paths`. |
+| MCP discovery | `agentmem-mcp` over stdio responds to `tools/list` with all `<ns>__<tool>` IDs. |
+| `.scratch/` not staged | CI workflow `memory-scratch-guard` rejects PRs adding `.scratch/**`. |


### PR DESCRIPTION
## Summary

Closes Phases 6-10 of the agent-memory-harness rollout (proposal/design in `openspec/changes/agent-memory-harness/`). Phases 0-5 already merged in #1143 + #1145.

## What changes

- **OpenSpec capability spec** (`openspec/specs/agent-memory-harness/spec.md`) codifies retrieval order, promotion contract, secret hygiene, sync model, and verification matrix. `openspec/config.yaml` documents the directory-based lifecycle convention used in this repo.
- **Agent surfaces**: new `Memory harness` section in `.agents/shared/canonical.md` (project-agnostic contract) and Fast Draft specifics in `.agents/overrides/repo.md`. Regenerated `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` via `npm run render:agent-surfaces`.
- **MCP discovery**: `.opencode/mcp.json` registers `agentmem-mcp` (stdio) so OpenCode auto-discovers all `<namespace>__<tool>` tools (e.g. `repo__read_config`, `global__list_lessons`).
- **CI guard**: `.github/workflows/memory-scratch-guard.yml` rejects PRs adding files under `.scratch/`, with an actionable message pointing at `agentmem promote scratch-to-project-global`.
- **Docs**: `docs/REQUIREMENTS.md` gains R8.1-R8.4; `docs/CHANGELOG.md` [Unreleased] entry; root `README.md` Contributing section now points AI-agent contributors at `MEMORY_INIT.md` + `.memory/config.yml`.
- **Phase 5.2 follow-up**: `.gitignore` also excludes `.memory/cache/`, `.gitnexus/`, `.lancedb/` (per-machine indices, never committed).

## Verification

- `npm run verify:agent-surfaces` -> `canonical lint issues: 0`, render idempotent, no stale outputs.
- Phase 9 smoke test (manual, not committed):
  - `agentmem repo read-config` -> clean parse + resolved paths
  - `agentmem repo search wgpu --limit 3` -> hits ARCHITECTURE.md, AGENTS.md (canonical scope only)
  - `agentmem repo write-scratch sessions/smoke-test.md` -> file at `.scratch/`, not staged in git
  - `agentmem promote scratch-to-project-global --paths sessions/smoke-test.md --subdir sessions` -> landed at `agent-memory@dcec1ea`, pushed to origin/main
  - `agentmem sync push --scope global` -> pushed cleanly (`f597294..dcec1ea`)
  - `agentmem global list-lessons` -> `[]` (no lessons yet, expected)
- Skipped `just smoke` (workspace `cargo check`) - no Rust changed.

## Notes

- `openspec` package on npm is a 0.0.0 stub - this repo treats `openspec/` as a directory convention (proposal/design/tasks under `changes/<slug>/`, durable specs under `specs/<capability>/`). `config.yaml` documents that contract explicitly.
- `MEMORY_INIT.md` (the project-agnostic adoption guide from #1143) is unchanged and remains the canonical onboarding doc.