### PR TITLE
fix(vscode): resolve canvas selection toolbar regressions

### DIFF
--- a/fd-vscode/src/webview-regressions.test.ts
+++ b/fd-vscode/src/webview-regressions.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(__dirname, "..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+describe("VS Code webview regressions", () => {
+  it("keeps canvas multi-selection messages handled by the extension host", () => {
+    const syncSource = readRepoFile("webview/src/sync.js");
+    const extensionSource = readRepoFile("src/extension.ts");
+
+    expect(syncSource).toContain('type: "nodesSelected"');
+    expect(syncSource).toContain('type: "nodeSelected"');
+    expect(extensionSource).toMatch(/case "nodeSelected":\s*case "nodesSelected":/s);
+    expect(extensionSource).toContain("message.ids ?? (message.id ? [message.id] : [])");
+  });
+
+  it("positions the floating action bar from width/height bounds fields", () => {
+    const contextMenuSource = readRepoFile("webview/src/context-menu.js");
+    const generatedMainSource = readRepoFile("webview/main.js");
+
+    expect(contextMenuSource).toContain("bounds.width * zoomLevel");
+    expect(contextMenuSource).not.toContain("bounds.w * zoomLevel");
+    expect(generatedMainSource).toContain("bounds.width * zoomLevel");
+    expect(generatedMainSource).not.toContain("bounds.w * zoomLevel");
+  });
+
+  it("clears locked state from both docked and floating toolbars on keyboard tool switch", () => {
+    const shortcutsSource = readRepoFile("webview/src/shortcuts.js");
+    const generatedMainSource = readRepoFile("webview/main.js");
+    const toolbarSelector = '".tool-btn[data-tool], .ft-tool-btn[data-tool]"';
+
+    expect(shortcutsSource).toContain(toolbarSelector);
+    expect(generatedMainSource).toContain(toolbarSelector);
+    expect(shortcutsSource).not.toContain('".tool-btn[data-tool]"');
+    expect(generatedMainSource).not.toContain('".tool-btn[data-tool]"');
+  });
+});

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -3720,7 +3720,7 @@ document.addEventListener("keydown", (e) => {
       // Switching to a new tool via keyboard clears previous lock
       if (lockedTool && result.tool !== lockedTool) {
         lockedTool = null;
-        document.querySelectorAll(".tool-btn[data-tool]").forEach((b) => b.classList.remove("locked"));
+        document.querySelectorAll(".tool-btn[data-tool], .ft-tool-btn[data-tool]").forEach((b) => b.classList.remove("locked"));
       }
       updateToolbarActive(result.tool);
     }
@@ -4162,7 +4162,6 @@ function nudgeSelected(arrowKey, step) {
     }
   } catch (_) { /* skip */ }
 }
-
 // ─── Annotation Card ───────────────────────────────────────────────────────
 
 // ─── Unified Context Menu Class ────────────────────────────────────────────
@@ -4355,7 +4354,7 @@ function updateFloatingBar() {
   const rect = canvas.getBoundingClientRect();
   const screenX = bounds.x * zoomLevel + panX + rect.left;
   const screenY = bounds.y * zoomLevel + panY + rect.top;
-  const screenW = bounds.w * zoomLevel;
+  const screenW = bounds.width * zoomLevel;
 
   // Position bar centered above node, 36px gap
   const barX = screenX + screenW / 2;
@@ -5295,7 +5294,6 @@ function setupSpecBadgeToggle() {
 
   btn.addEventListener("click", toggleSpecBadges);
 }
-
 // ─── Properties Panel ────────────────────────────────────────────────────
 
 let propsSuppressSync = false;

--- a/fd-vscode/webview/src/context-menu.js
+++ b/fd-vscode/webview/src/context-menu.js
@@ -194,7 +194,7 @@ function updateFloatingBar() {
   const rect = canvas.getBoundingClientRect();
   const screenX = bounds.x * zoomLevel + panX + rect.left;
   const screenY = bounds.y * zoomLevel + panY + rect.top;
-  const screenW = bounds.w * zoomLevel;
+  const screenW = bounds.width * zoomLevel;
 
   // Position bar centered above node, 36px gap
   const barX = screenX + screenW / 2;
@@ -1134,4 +1134,3 @@ function setupSpecBadgeToggle() {
 
   btn.addEventListener("click", toggleSpecBadges);
 }
-

--- a/fd-vscode/webview/src/shortcuts.js
+++ b/fd-vscode/webview/src/shortcuts.js
@@ -295,7 +295,7 @@ document.addEventListener("keydown", (e) => {
       // Switching to a new tool via keyboard clears previous lock
       if (lockedTool && result.tool !== lockedTool) {
         lockedTool = null;
-        document.querySelectorAll(".tool-btn[data-tool]").forEach((b) => b.classList.remove("locked"));
+        document.querySelectorAll(".tool-btn[data-tool], .ft-tool-btn[data-tool]").forEach((b) => b.classList.remove("locked"));
       }
       updateToolbarActive(result.tool);
     }
@@ -737,4 +737,3 @@ function nudgeSelected(arrowKey, step) {
     }
   } catch (_) { /* skip */ }
 }
-


### PR DESCRIPTION
## Summary
- Fixes floating action bar placement by using `get_node_bounds().width` instead of the nonexistent `w` field.
- Clears locked tool state from both docked and floating toolbar buttons when keyboard shortcuts switch away from a locked tool.
- Adds VS Code webview regression coverage for multi-selection message handling, floating-bar bounds fields, and toolbar lock cleanup.

## Verification
- Red check: `pnpm test src/webview-regressions.test.ts` initially failed for `bounds.w` and the docked-only locked selector.
- `pnpm run build:webview`
- `pnpm test src/webview-regressions.test.ts` → 3 passed
- `pnpm test` → 221 passed
- `pnpm lint` → `tsc --noEmit` passed

## Notes
- The reported `nodesSelected`/`nodeSelected` mismatch was already resolved on current `main`; this PR adds a regression test to keep the webview sender and extension host handler aligned.