### PR TITLE
chore(opencode): bump plugin to 1.14.25

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -4,6 +4,6 @@
     "test:observer": "node --test plugins/agent-observer/test/*.test.mjs"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.14.17"
+    "@opencode-ai/plugin": "1.14.25"
   }
 }


### PR DESCRIPTION
## Summary
- Align `.opencode/package.json` with the existing 1.14.25 plugin lockfile entry.

## Test Plan
- [x] `npm install --package-lock-only` in `.opencode`
- [x] `npm audit --audit-level=high` in `.opencode` (no high/critical vulnerabilities; existing moderate advisory remains)