### PR TITLE
fix(vscode): export frame specs

### DIFF
--- a/fd-vscode/CHANGELOG.md
+++ b/fd-vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Export Spec**: now includes `frame` nodes, supports Unicode node IDs, and preserves inline node descriptions in generated Markdown.
+
 ## [0.10.145] — 2026-03-31
 
 ### Changed

--- a/fd-vscode/src/exportSpec.test.ts
+++ b/fd-vscode/src/exportSpec.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { buildSpecMarkdown } from "./exportSpec";
+
+describe("exportSpec", () => {
+  it("should format nodes correctly", () => {
+    const source = `
+rect @btn1 "this is a button" {
+  spec {
+    status: active
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @btn1 `rect`");
+    expect(md).toContain("> this is a button");
+    expect(md).toContain("- **Status:** active");
+  });
+
+  it("should handle inline spec", () => {
+    const source = `
+ellipse @avatar {
+  spec "user avatar image"
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @avatar `ellipse`");
+    expect(md).toContain("> user avatar image");
+  });
+
+  it("should handle frame nodes", () => {
+    const source = `
+frame @dashboard "main dashboard" {
+  spec {
+    priority: high
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @dashboard `frame`");
+    expect(md).toContain("> main dashboard");
+    expect(md).toContain("- **Priority:** high");
+  });
+
+  it("should handle unicode IDs", () => {
+    const source = `
+rect @ボタン "a button" {
+  spec {
+    tag: ui
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @ボタン `rect`");
+    expect(md).toContain("> a button");
+    expect(md).toContain("- **Tags:** ui");
+  });
+
+  it("should parse multiple annotations", () => {
+    const source = `
+rect @btn {
+  spec {
+    "desc line 1"
+    accept: "criterion 1"
+    status: wip
+    priority: low
+    tag: experimental
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("> desc line 1");
+    expect(md).toContain("- [ ] criterion 1");
+    expect(md).toContain("- **Status:** wip");
+    expect(md).toContain("- **Priority:** low");
+    expect(md).toContain("- **Tags:** experimental");
+  });
+
+  it("should ignore empty documents", () => {
+    const md = buildSpecMarkdown("   \n\n  ", "empty.fd");
+    expect(md).toBe("# Spec: empty.fd\n\n");
+  });
+
+  it("should format nested structures correctly", () => {
+    const source = `
+group @parent "the parent" {
+  rect @child "the child" {
+    spec "child note"
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @parent `group`");
+    expect(md).toContain("> the parent");
+    expect(md).toContain("### @child `rect`");
+    expect(md).toContain("> the child");
+    expect(md).toContain("> child note");
+  });
+
+  it("should handle edges", () => {
+    const source = `
+edge @flow1 {
+  from: @a
+  to: @b
+  label: "clicks"
+  spec {
+    "edge description"
+  }
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## Flows");
+    expect(md).toContain("- **@a** → **@b** — clicks");
+    expect(md).toContain("> edge description");
+  });
+});

--- a/fd-vscode/src/exportSpec.ts
+++ b/fd-vscode/src/exportSpec.ts
@@ -181,13 +181,16 @@ function processClosingBrace(trimmed: string, state: any): boolean {
 }
 
 function processNodeDecl(trimmed: string, state: any, doFlush: (s: any) => void): boolean {
-  const nodeMatch = trimmed.match(/^(group|rect|ellipse|path|text)\s+@(\w+)(?:\s+"[^"]*")?\s*\{?/);
+  const nodeMatch = trimmed.match(/^(group|rect|ellipse|path|text|frame)\s+@([^\s\{]+)(?:\s+"([^"]*)")?\s*\{?/);
   if (!nodeMatch) return false;
 
   doFlush(state); // Flush PREVIOUS node before starting this new one
 
   state.currentNodeKind = nodeMatch[1];
   state.currentNodeId = nodeMatch[2];
+  if (nodeMatch[3]) {
+    state.currentAnnotations.push({ type: "description", value: nodeMatch[3] });
+  }
   if (trimmed.endsWith("{")) {
     state.braceDepth += 1;
     state.depthStack.push(state.braceDepth);


### PR DESCRIPTION
## Summary
- keep the useful exportSpec pieces from #1121 without the CI wasm-pack installer regression
- add coverage for frame nodes, Unicode IDs, inline descriptions, nested nodes, annotations, edges, and empty docs
- document the exportSpec behavior change in the VS Code changelog

## Test Plan
- [x] pnpm test (fd-vscode)