### PR TITLE
fix(vscode): tighten export spec ids

### DIFF
--- a/fd-vscode/CHANGELOG.md
+++ b/fd-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Export Spec**: now includes `frame` nodes, supports Unicode node IDs, and preserves inline node descriptions in generated Markdown.
+- **Export Spec**: now includes `frame` nodes, supports Unicode IDs across known/generic node and edge parsing, preserves inline node descriptions in generated Markdown, and avoids trailing punctuation leakage in malformed known-node declarations (for example `@btn,` now exports as `@btn`).
 
 ## [0.10.145] — 2026-03-31
 

--- a/fd-vscode/src/exportSpec.test.ts
+++ b/fd-vscode/src/exportSpec.test.ts
@@ -51,6 +51,38 @@ rect @ボタン "a button" {
     expect(md).toContain("- **Tags:** ui");
   });
 
+  it("should trim trailing punctuation from known node IDs", () => {
+    const source = `
+rect @btn, "button with malformed id punctuation" {
+  spec "button spec"
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @btn `rect`");
+    expect(md).not.toContain("## @btn, `rect`");
+  });
+
+  it("should handle unicode IDs for generic nodes", () => {
+    const source = `
+@ボタン {
+  spec "generic unicode"
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## @ボタン `spec`");
+    expect(md).toContain("> generic unicode");
+  });
+
+  it("should handle unicode IDs in edge refs", () => {
+    const source = `
+edge @流れ {
+  from: @開始
+  to: @終了
+  label: "進む"
+}`;
+    const md = buildSpecMarkdown(source, "test.fd");
+    expect(md).toContain("## Flows");
+    expect(md).toContain("- **@開始** → **@終了** — 進む");
+  });
+
   it("should parse multiple annotations", () => {
     const source = `
 rect @btn {

--- a/fd-vscode/src/exportSpec.ts
+++ b/fd-vscode/src/exportSpec.ts
@@ -1,5 +1,16 @@
 import * as vscode from "vscode";
 
+// One capture group. Keep this contract when composing regexes below.
+const ID_TOKEN = String.raw`([\p{L}\p{N}_]+)`;
+const EDGE_START_RE = new RegExp(String.raw`^edge\s+@${ID_TOKEN}\s*\{`, "u");
+const EDGE_FROM_RE = new RegExp(String.raw`^from:\s*@${ID_TOKEN}`, "u");
+const EDGE_TO_RE = new RegExp(String.raw`^to:\s*@${ID_TOKEN}`, "u");
+const KNOWN_NODE_RE = new RegExp(
+  String.raw`^(group|rect|ellipse|path|text|frame)\s+@${ID_TOKEN}(?=[\s,{]|$)(?:\s*,?\s+"([^"]*)")?\s*\{?`,
+  "u"
+);
+const GENERIC_NODE_RE = new RegExp(String.raw`^@${ID_TOKEN}\s*\{`, "u");
+
 export function exportSpecMarkdown(): void {
   const editor = vscode.window.activeTextEditor;
   if (!editor || editor.document.languageId !== "fd") {
@@ -135,7 +146,7 @@ function processSpecBlockMultiline(lines: string[], i: number, state: any) {
 }
 
 function processEdgeStart(trimmed: string, state: any): boolean {
-  const edgeMatch = trimmed.match(/^edge\s+@(\w+)\s*\{/);
+  const edgeMatch = trimmed.match(EDGE_START_RE);
   if (!edgeMatch) return false;
   state.insideEdge = true;
   state.edgeFrom = "";
@@ -148,8 +159,8 @@ function processEdgeStart(trimmed: string, state: any): boolean {
 
 function processEdgeBody(trimmed: string, state: any): boolean {
   if (!state.insideEdge) return false;
-  const fromMatch = trimmed.match(/^from:\s*@(\w+)/);
-  const toMatch = trimmed.match(/^to:\s*@(\w+)/);
+  const fromMatch = trimmed.match(EDGE_FROM_RE);
+  const toMatch = trimmed.match(EDGE_TO_RE);
   const labelMatch = trimmed.match(/^label:\s*"([^"]*)"/);
   if (fromMatch) state.edgeFrom = fromMatch[1];
   if (toMatch) state.edgeTo = toMatch[1];
@@ -181,7 +192,7 @@ function processClosingBrace(trimmed: string, state: any): boolean {
 }
 
 function processNodeDecl(trimmed: string, state: any, doFlush: (s: any) => void): boolean {
-  const nodeMatch = trimmed.match(/^(group|rect|ellipse|path|text|frame)\s+@([^\s\{]+)(?:\s+"([^"]*)")?\s*\{?/);
+  const nodeMatch = trimmed.match(KNOWN_NODE_RE);
   if (!nodeMatch) return false;
 
   doFlush(state); // Flush PREVIOUS node before starting this new one
@@ -200,7 +211,7 @@ function processNodeDecl(trimmed: string, state: any, doFlush: (s: any) => void)
 }
 
 function processGenericNode(trimmed: string, state: any, doFlush: (s: any) => void): boolean {
-  const genericMatch = trimmed.match(/^@(\w+)\s*\{/);
+  const genericMatch = trimmed.match(GENERIC_NODE_RE);
   if (!genericMatch) return false;
 
   doFlush(state); // Flush PREVIOUS node


### PR DESCRIPTION
## Summary
- tighten exportSpec ID parsing to avoid trailing punctuation in malformed known-node IDs
- align Unicode ID support across known/generic node parsing and edge refs
- update VS Code changelog wording and add regression coverage

## Test Plan
- [x] pnpm test (fd-vscode)
- [x] just smoke