### PR TITLE
🛡️ Sentinel: [security improvement] Refactor showWasmErrorToast to use textContent

### DIFF
--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -10138,7 +10138,26 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
+  toast.innerHTML = '';
+
+  const icon = document.createElement('span');
+  icon.style.fontSize = '18px';
+  icon.textContent = '⚠️';
+  toast.appendChild(icon);
+
+  const container = document.createElement('div');
+  const bold = document.createElement('b');
+  bold.textContent = 'WASM Bridge Error';
+  container.appendChild(bold);
+  container.appendChild(document.createElement('br'));
+
+  const msgSpan = document.createElement('span');
+  msgSpan.style.opacity = '0.9';
+  msgSpan.textContent = msg;
+  container.appendChild(msgSpan);
+
+  toast.appendChild(container);
+
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 

--- a/fd-vscode/webview/src/main.js
+++ b/fd-vscode/webview/src/main.js
@@ -31,7 +31,26 @@ function showWasmErrorToast(msg) {
     `;
     document.body.appendChild(toast);
   }
-  toast.innerHTML = `<span style="font-size: 18px">⚠️</span> <div><b>WASM Bridge Error</b><br/><span style="opacity:0.9">${escapeHtml(msg)}</span></div>`;
+  toast.innerHTML = '';
+
+  const icon = document.createElement('span');
+  icon.style.fontSize = '18px';
+  icon.textContent = '⚠️';
+  toast.appendChild(icon);
+
+  const container = document.createElement('div');
+  const bold = document.createElement('b');
+  bold.textContent = 'WASM Bridge Error';
+  container.appendChild(bold);
+  container.appendChild(document.createElement('br'));
+
+  const msgSpan = document.createElement('span');
+  msgSpan.style.opacity = '0.9';
+  msgSpan.textContent = msg;
+  container.appendChild(msgSpan);
+
+  toast.appendChild(container);
+
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 6000);
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential DOM-based XSS or unhandled `ReferenceError` during WebAssembly bridge failures where `escapeHtml` might be unavailable. 
🎯 Impact: Unsafe DOM interpolation into `innerHTML` could lead to XSS execution or UI crashing.
🔧 Fix: Replaced `innerHTML` template string interpolation with safer `document.createElement`, `appendChild`, and `textContent` manipulations.
✅ Verification: Ran `pnpm run build:webview` and `pnpm test` in the `fd-vscode` directory to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [7171690981249394111](https://jules.google.com/task/7171690981249394111) started by @khangnghiem*