### PR TITLE
🎨 Palette: Add `aria-label` to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-02 - Icon-Only Button Accessibility
+**Learning:** Found a widespread pattern in `site/index.html` where numerous icon-only buttons (like modals closes, chat actions, floating bar controls) lacked `aria-label`s. This is a common accessibility gap in web apps relying heavily on SVG icons.
+**Action:** Always verify icon-only buttons (`<button><svg/></button>` or `<button>✕</button>`) have explicit `aria-label` attributes to ensure screen reader users understand their function.

--- a/site/index.html
+++ b/site/index.html
@@ -307,7 +307,7 @@
               <input type="range" id="fab-opacity" aria-label="Opacity" class="fab-slider" min="0" max="1" step="0.05" value="1" title="Opacity">
               <span id="fab-opacity-val" style="font-size:10px;min-width:24px">100%</span>
               <div class="fab-sep"></div>
-              <button class="fab-delete-btn" id="fab-delete" title="Delete (⌫)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
+              <button class="fab-delete-btn" id="fab-delete" title="Delete (⌫)" aria-label="Delete"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3" y1="3" x2="11" y2="11"/><line x1="11" y1="3" x2="3" y2="11"/></svg></button>
             </div>
             <!-- Minimap (Google Maps pill) -->
             <div id="minimap-container">
@@ -332,9 +332,9 @@
                   <button class="rp-tab active" data-rtab="agent" title="AI Agent"><span class="tab-icon">✦</span><span class="tab-label">Agent</span></button>
                   <button class="rp-tab" data-rtab="search" title="Search"><span class="tab-icon">🔍</span><span class="tab-label">Search</span></button>
                 </div>
-                <button class="ai-chat-clear" id="ai-chat-clear" title="Clear chat" style="font-size:12px;background:none;border:none;cursor:pointer;padding:4px;opacity:0.5;margin-left:auto;margin-right:4px;">🗑</button>
+                <button class="ai-chat-clear" id="ai-chat-clear" title="Clear chat" aria-label="Clear chat" style="font-size:12px;background:none;border:none;cursor:pointer;padding:4px;opacity:0.5;margin-left:auto;margin-right:4px;">🗑</button>
                 <button class="mobile-panel-close" id="rp-mobile-close" aria-label="Close panel">✕</button>
-                <button class="rp-tab-toggle" id="rp-sidebar-toggle" title="Toggle right panel">
+                <button class="rp-tab-toggle" id="rp-sidebar-toggle" title="Toggle right panel" aria-label="Toggle right panel">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><rect x="1" y="2" width="14" height="12" rx="2"/><line x1="10" y1="2" x2="10" y2="14"/></svg>
                 </button>
               </div>
@@ -363,10 +363,10 @@
                       <div class="ai-chat-context-badge hidden" id="ai-chat-context-badge">
                         <span class="context-pin">📌</span>
                         <span id="ai-chat-context-text"></span>
-                        <button id="ai-chat-context-clear" title="Clear context">×</button>
+                        <button id="ai-chat-context-clear" title="Clear context" aria-label="Clear context">×</button>
                       </div>
                       <div class="ai-chat-input-main-row">
-                        <button class="ai-chat-upload-btn" id="ai-chat-upload" title="Add context (Docs, Images, Camera)">
+                        <button class="ai-chat-upload-btn" id="ai-chat-upload" title="Add context (Docs, Images, Camera)" aria-label="Add context">
                           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M12 5v14M5 12h14"/>
                           </svg>
@@ -378,7 +378,7 @@
                           <span id="ai-model-badge" class="ai-model-badge">✦ Gemma 4</span>
                         </div>
                         <span id="ai-rate-limit-text" class="ai-rate-limit-text"></span>
-                        <button class="ai-chat-send" id="ai-chat-send" title="Send">→</button>
+                        <button class="ai-chat-send" id="ai-chat-send" title="Send" aria-label="Send">→</button>
                       </div>
                     </div>
                   </div>
@@ -446,7 +446,7 @@
     <div class="share-card" style="width: 480px; max-width: 90vw;">
       <div class="share-header">
         <span class="share-title">📦 Import Module</span>
-        <button class="share-close" id="import-modal-close">✕</button>
+        <button class="share-close" id="import-modal-close" aria-label="Close">✕</button>
       </div>
       <p class="share-hint" style="text-align: left; margin: 0 0 12px 0;">Paste Fast Draft code below. It will be safely wrapped in a group and namespaced.</p>
       <textarea id="import-textarea" class="share-url" style="height: 200px; resize: vertical; font-family: monospace; white-space: pre; margin-bottom: 12px;" placeholder="rect @my_component { ... }"></textarea>
@@ -462,7 +462,7 @@
     <div class="share-card">
       <div class="share-header">
         <span class="share-title">🔗 Share this design</span>
-        <button class="share-close" id="share-modal-close">✕</button>
+        <button class="share-close" id="share-modal-close" aria-label="Close">✕</button>
       </div>
       <div class="share-url-row">
         <input type="text" id="share-url-input" class="share-url" readonly>
@@ -476,7 +476,7 @@
   <!-- Presentation Mode -->
   <div id="presentation-overlay" class="presentation-overlay hidden">
     <div class="presentation-counter" id="presentation-counter">1 / 1</div>
-    <button class="presentation-exit" id="presentation-exit" title="Exit (Esc)">✕ Exit</button>
+    <button class="presentation-exit" id="presentation-exit" title="Exit (Esc)" aria-label="Exit presentation">✕ Exit</button>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to multiple icon-only buttons in `site/index.html` (e.g., chat controls, modal close buttons, delete buttons).
🎯 Why: Without these labels, screen reader users cannot determine the function of these buttons, as they only contain symbols (like '✕' or '🗑') or SVGs.
📸 Before/After: Visuals remain unchanged, but screen readers will now announce the buttons correctly.
♿ Accessibility: Improved WCAG compliance by ensuring all interactive icon-only elements have accessible text.

---
*PR created automatically by Jules for task [15122730095276055126](https://jules.google.com/task/15122730095276055126) started by @khangnghiem*