### PR TITLE
⚡ Bolt: Optimize node.annotations array filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-05-24 - [Avoid O(N^2) Vector Membership Checks in Layout]
 **Learning:** Using `!flow_children.contains(&child_idx)` within a loop over all children in `Column`, `Row`, and `Grid` layout algorithms (`crates/fd-core/src/layout.rs`) introduces an O(N^2) complexity.
 **Action:** Replace `Vec::contains()` in loops by doing a single pass over the collection to partition it into separate vectors (e.g., `flow_children` and `abs_children`) using `.push()`, eliminating the bottleneck while preserving order.
+## 2024-05-15 - Fast Draft Completion Optimization Retrospective
+**Learning:** In Rust string processing, optimizing `text.lines()` by eagerly collecting it into a `Vec<&str>` (`text.lines().collect()`) causes a significant performance and memory regression. The original lazy iteration `text.lines().nth(...)` is O(pos.line) and zero-allocation, whereas `.collect()` is O(Total Document Lines) and allocates memory.
+**Action:** Do not collect iterators prematurely. Always prefer using lazy iterator combinations (`nth`, `take`, `find`) in Rust to avoid unnecessary allocations, especially when parsing large text documents on every keystroke.

--- a/fd-vscode/webview/main.js
+++ b/fd-vscode/webview/main.js
@@ -5785,11 +5785,27 @@ function refreshSpecsSummary(panel) {
   html += `<div class="layers-body">`;
   for (const node of filtered) {
     const isSelected = node.id === selectedId;
-    const descriptions = node.annotations.filter(a => a.type === "description");
-    const statuses = node.annotations.filter(a => a.type === "status");
-    const priorities = node.annotations.filter(a => a.type === "priority");
-    const accepts = node.annotations.filter(a => a.type === "accept");
-    const tags = node.annotations.filter(a => a.type === "tag");
+    // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+    // to prevent redundant iterations over node annotations.
+    const descriptions = [];
+    const statuses = [];
+    const priorities = [];
+    const accepts = [];
+    const tags = [];
+
+    for (const a of node.annotations) {
+      if (a.type === "description") {
+        descriptions.push(a);
+      } else if (a.type === "status") {
+        statuses.push(a);
+      } else if (a.type === "priority") {
+        priorities.push(a);
+      } else if (a.type === "accept") {
+        accepts.push(a);
+      } else if (a.type === "tag") {
+        tags.push(a);
+      }
+    }
 
     html += `<div class="spec-summary-card${isSelected ? ' selected' : ''}" data-spec-id="${escapeAttr(node.id)}">`;
     html += `<div class="spec-card-header">`;
@@ -5882,11 +5898,27 @@ function exportSpecReport(annotated) {
   md += `> Generated from FD canvas\n\n`;
 
   for (const node of annotated) {
-    const desc = node.annotations.find(a => a.type === "description");
-    const status = node.annotations.find(a => a.type === "status");
-    const priority = node.annotations.find(a => a.type === "priority");
-    const accepts = node.annotations.filter(a => a.type === "accept");
-    const tags = node.annotations.filter(a => a.type === "tag");
+    // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+    // to prevent redundant iterations over node annotations.
+    let desc = undefined;
+    let status = undefined;
+    let priority = undefined;
+    const accepts = [];
+    const tags = [];
+
+    for (const a of node.annotations) {
+      if (a.type === "description" && !desc) {
+        desc = a;
+      } else if (a.type === "status" && !status) {
+        status = a;
+      } else if (a.type === "priority" && !priority) {
+        priority = a;
+      } else if (a.type === "accept") {
+        accepts.push(a);
+      } else if (a.type === "tag") {
+        tags.push(a);
+      }
+    }
 
     md += `## @${node.id}`;
     if (node.kind) md += ` (${node.kind})`;
@@ -9479,9 +9511,16 @@ function showSpecTooltip(nodeId, clientX, clientY) {
     return;
   }
 
-  const descs = node.annotations.filter(a => a.type === "description");
-  const statuses = node.annotations.filter(a => a.type === "status");
-  const priorities = node.annotations.filter(a => a.type === "priority");
+  // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+  // to prevent redundant iterations over node annotations.
+  const descs = [];
+  const statuses = [];
+  const priorities = [];
+  for (const a of node.annotations) {
+    if (a.type === "description") descs.push(a);
+    else if (a.type === "status") statuses.push(a);
+    else if (a.type === "priority") priorities.push(a);
+  }
 
   let html = `<div class="spec-tip-id">◇ @${escapeHtml(node.id)}</div>`;
   if (descs.length > 0) {

--- a/fd-vscode/webview/src/drag-drop.js
+++ b/fd-vscode/webview/src/drag-drop.js
@@ -315,9 +315,16 @@ function showSpecTooltip(nodeId, clientX, clientY) {
     return;
   }
 
-  const descs = node.annotations.filter(a => a.type === "description");
-  const statuses = node.annotations.filter(a => a.type === "status");
-  const priorities = node.annotations.filter(a => a.type === "priority");
+  // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+  // to prevent redundant iterations over node annotations.
+  const descs = [];
+  const statuses = [];
+  const priorities = [];
+  for (const a of node.annotations) {
+    if (a.type === "description") descs.push(a);
+    else if (a.type === "status") statuses.push(a);
+    else if (a.type === "priority") priorities.push(a);
+  }
 
   let html = `<div class="spec-tip-id">◇ @${escapeHtml(node.id)}</div>`;
   if (descs.length > 0) {

--- a/fd-vscode/webview/src/panels.js
+++ b/fd-vscode/webview/src/panels.js
@@ -491,11 +491,27 @@ function refreshSpecsSummary(panel) {
   html += `<div class="layers-body">`;
   for (const node of filtered) {
     const isSelected = node.id === selectedId;
-    const descriptions = node.annotations.filter(a => a.type === "description");
-    const statuses = node.annotations.filter(a => a.type === "status");
-    const priorities = node.annotations.filter(a => a.type === "priority");
-    const accepts = node.annotations.filter(a => a.type === "accept");
-    const tags = node.annotations.filter(a => a.type === "tag");
+    // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+    // to prevent redundant iterations over node annotations.
+    const descriptions = [];
+    const statuses = [];
+    const priorities = [];
+    const accepts = [];
+    const tags = [];
+
+    for (const a of node.annotations) {
+      if (a.type === "description") {
+        descriptions.push(a);
+      } else if (a.type === "status") {
+        statuses.push(a);
+      } else if (a.type === "priority") {
+        priorities.push(a);
+      } else if (a.type === "accept") {
+        accepts.push(a);
+      } else if (a.type === "tag") {
+        tags.push(a);
+      }
+    }
 
     html += `<div class="spec-summary-card${isSelected ? ' selected' : ''}" data-spec-id="${escapeAttr(node.id)}">`;
     html += `<div class="spec-card-header">`;
@@ -588,11 +604,27 @@ function exportSpecReport(annotated) {
   md += `> Generated from FD canvas\n\n`;
 
   for (const node of annotated) {
-    const desc = node.annotations.find(a => a.type === "description");
-    const status = node.annotations.find(a => a.type === "status");
-    const priority = node.annotations.find(a => a.type === "priority");
-    const accepts = node.annotations.filter(a => a.type === "accept");
-    const tags = node.annotations.filter(a => a.type === "tag");
+    // ⚡ Bolt Optimization: Refactored multiple O(N) array methods into a single pass
+    // to prevent redundant iterations over node annotations.
+    let desc = undefined;
+    let status = undefined;
+    let priority = undefined;
+    const accepts = [];
+    const tags = [];
+
+    for (const a of node.annotations) {
+      if (a.type === "description" && !desc) {
+        desc = a;
+      } else if (a.type === "status" && !status) {
+        status = a;
+      } else if (a.type === "priority" && !priority) {
+        priority = a;
+      } else if (a.type === "accept") {
+        accepts.push(a);
+      } else if (a.type === "tag") {
+        tags.push(a);
+      }
+    }
 
     md += `## @${node.id}`;
     if (node.kind) md += ` (${node.kind})`;


### PR DESCRIPTION
💡 What: Refactored multiple `.filter()` and `.find()` array methods operating on `node.annotations` into single-pass `for...of` loops across `fd-vscode/webview/src/panels.js` and `fd-vscode/webview/src/drag-drop.js`.
🎯 Why: In components that render lists of annotations (like the Spec Report, Spec Card, and Hover Tooltip), calling `.filter()` up to five times per node causes redundant iteration over the array. Combining these into a single loop eliminates O(K * N) overhead.
📊 Impact: Reduces array iteration passes over annotations by ~80% during node rendering.
🔬 Measurement: Verified by `vitest` tests maintaining perfect 100% pass rate. Load large FD files with many annotations to observe slight render frame drop improvements.

---
*PR created automatically by Jules for task [4493454306943302468](https://jules.google.com/task/4493454306943302468) started by @khangnghiem*