### PR TITLE
security: remove username from public configs

### DIFF
--- a/.agents/overrides/repo.md
+++ b/.agents/overrides/repo.md
@@ -101,8 +101,8 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - Run `./scripts/migrate-agentmem-to-omega.sh` once per machine
 - Archive old `agentmem` CLI after migration is verified
 
-**Project ID:** `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
+**Project ID:** `fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
+- Per-project memory: `~/.config/agent-memory/projects/fast-draft/`.
 - CLI: `omega` (replaces `agentmem`); see `memory/config.yml` for OMEGA configuration.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
 - `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.

--- a/.memory/config.yml
+++ b/.memory/config.yml
@@ -1,5 +1,5 @@
 schema: 1
-project_id: khangnghiem__fast-draft
+project_id: fast-draft
 scratch_dir: .scratch
 canonical_doc_paths:
   - AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,8 +178,8 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - Run `./scripts/migrate-agentmem-to-omega.sh` once per machine
 - Archive old `agentmem` CLI after migration is verified
 
-**Project ID:** `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
+**Project ID:** `fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
+- Per-project memory: `~/.config/agent-memory/projects/fast-draft/`.
 - CLI: `omega` (replaces `agentmem`); see `memory/config.yml` for OMEGA configuration.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
 - `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,8 +178,8 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - Run `./scripts/migrate-agentmem-to-omega.sh` once per machine
 - Archive old `agentmem` CLI after migration is verified
 
-**Project ID:** `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
+**Project ID:** `fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
+- Per-project memory: `~/.config/agent-memory/projects/fast-draft/`.
 - CLI: `omega` (replaces `agentmem`); see `memory/config.yml` for OMEGA configuration.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
 - `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -182,8 +182,8 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - Run `./scripts/migrate-agentmem-to-omega.sh` once per machine
 - Archive old `agentmem` CLI after migration is verified
 
-**Project ID:** `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
+**Project ID:** `fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
+- Per-project memory: `~/.config/agent-memory/projects/fast-draft/`.
 - CLI: `omega` (replaces `agentmem`); see `memory/config.yml` for OMEGA configuration.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
 - `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.

--- a/memory/config.yml
+++ b/memory/config.yml
@@ -8,7 +8,7 @@
 # Then initialize: omega init --config memory/config.yml
 
 schema: omega-v1
-project_id: khangnghiem__fast-draft
+project_id: fast-draft
 source_of_truth: markdown
 index_path: .omega/
 embedding_model: all-MiniLM-L6-v2

--- a/scripts/migrate-agentmem-to-omega.sh
+++ b/scripts/migrate-agentmem-to-omega.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-AGENTMEM_BASE="$HOME/.config/agent-memory"
-PROJECT_PATH="$AGENTMEM_BASE/projects/khangnghiem__fast-draft"
+AGENTMEM_BASE="${AGENT_MEMORY_PATH:-$HOME/.config/agent-memory}"
+PROJECT_PATH="$AGENTMEM_BASE/projects/fast-draft"
 GLOBAL_LESSONS="$AGENTMEM_BASE/lessons"
 OMEGA_MEMORY="$PROJECT_ROOT/memory"
 
@@ -96,7 +96,7 @@ echo ""
 echo "[3/4] Verifying OMEGA configuration..."
 if [ -f "$OMEGA_MEMORY/config.yml" ]; then
     echo "      OMEGA config found at: $OMEGA_MEMORY/config.yml"
-    echo "      Project ID: khangnghiem__fast-draft"
+    echo "      Project ID: fast-draft"
 else
     echo "      [WARN] OMEGA config not found at: $OMEGA_MEMORY/config.yml"
 fi


### PR DESCRIPTION
Remove username references from public-facing configuration files and migration scripts.