### PR TITLE
docs: sync workflow + memory harness hardening

### DIFF
--- a/.agents/overrides/repo.md
+++ b/.agents/overrides/repo.md
@@ -88,11 +88,11 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 ### Memory harness — Fast Draft specifics
 
 - Project ID: `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
-- CLI: `agentmem` (`~/.config/agent-memory/bin/agentmem`); MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp`.
+- Per-project memory: `~/.config/memory/projects/khangnghiem__fast-draft/`.
+- CLI: `mem` (`~/.config/memory/bin/mem`); MCP wrapper: `~/.config/memory/bin/mem-mcp`.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
-- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.
-- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/memory`, never project changes.
+- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/` or `.memory/` (other than `.memory/config.yml`).
 
 ### User shortcuts
 
@@ -100,4 +100,4 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - `smoke` → run `just smoke`.
 - Local caveman helpers: `/caveman`, `/caveman-help`, `/caveman-review`, `/caveman-commit`, `/caveman:compress <file>`.
 - `/memory-status` → inspect Fast Draft memory state without writes.
-- `/memory-sync` → push durable agent-memory changes only; never project changes.
+- `/memory-sync` → push durable memory changes only; never project changes.

--- a/.agents/shared/canonical.md
+++ b/.agents/shared/canonical.md
@@ -40,10 +40,10 @@
 
 ### Memory harness
 
-- If `.memory/config.yml` exists, start by running `git -C ~/.config/agent-memory pull --ff-only` and `agentmem repo read-config`; continue with local memory if the pull fails and fresh cross-machine context is not required.
-- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `agentmem repo search` plus relevant project/global lessons.
-- Use `.scratch/` only for ephemeral notes; promote durable lessons through `agentmem promote`, never by bypassing the scratch → project/global → canonical flow.
-- `/memory-sync` is only for `~/.config/agent-memory`; keep it separate from project git operations.
+- If `.memory/config.yml` exists, run `mem context bootstrap` at session start to pull the latest memory and receive a digest of relevant project lessons and canonical docs.
+- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `mem repo search` plus relevant project/global lessons.
+- Use `.scratch/` only for ephemeral notes; promote durable lessons through `mem promote`, never by bypassing the scratch → project/global → canonical flow.
+- `/memory-sync` is only for `~/.config/memory`; keep it separate from project git operations.
 - Secret hygiene applies to both the project repo and memory repo.
 
 ### Completion

--- a/.agents/workflows/memory-status.md
+++ b/.agents/workflows/memory-status.md
@@ -1,5 +1,5 @@
 ---
-description: Read-only summary of project and agent-memory state
+description: Read-only summary of project and memory state
 ---
 
 # /memory-status - Memory State Summary
@@ -11,18 +11,18 @@ $ARGUMENTS
 // turbo-all
 
 1. **Read project config**
-   - Run `agentmem repo read-config` from the current project root.
+   - Run `mem repo read-config` from the current project root.
    - Report `project_id`, `scratch_dir`, `canonical_doc_paths`, and resolved `projectSubtree`.
 
 2. **Check memory repository state**
-   - Run `git -C ~/.config/agent-memory status -sb`.
+   - Run `git -C ~/.config/memory status -sb`.
    - Report whether memory is clean, ahead/behind, or dirty.
    - Do not pull, commit, or push from this command unless the user explicitly upgrades to `/memory-sync`.
 
 3. **Summarize useful counts**
    - Count project scratch files under `.scratch/` if present.
-   - List or count project lessons with `agentmem global list-lessons --project-id <project_id>`.
-   - List or count global lessons with `agentmem global list-lessons`.
+    - List or count project lessons with `mem global list-lessons --project-id <project_id>`.
+    - List or count global lessons with `mem global list-lessons`.
 
 4. **Report next action**
    - If clean: say memory is ready.

--- a/.agents/workflows/memory-sync.md
+++ b/.agents/workflows/memory-sync.md
@@ -1,37 +1,37 @@
 ---
-description: Sync durable agent-memory state without touching project branches
+description: Sync durable memory state without touching project branches
 ---
 
 # /memory-sync - Durable Memory Sync
 
 $ARGUMENTS
 
-> **Purpose**: Synchronize `~/.config/agent-memory` independently from project `/sync-push`. Never commit or push `.scratch/` directly.
+> **Purpose**: Synchronize `~/.config/memory` independently from project `/sync-push`. Never commit or push `.scratch/` directly.
 
 // turbo-all
 
 1. **Scope guard**
-   - This command operates only on `~/.config/agent-memory`.
+   - This command operates only on `~/.config/memory`.
    - Do not push the current project repo unless the user separately asks for `/sync-push`.
 
 2. **Inspect before pulling**
-   - Run `git -C ~/.config/agent-memory status -sb` before any pull.
+   - Run `git -C ~/.config/memory status -sb` before any pull.
    - If unknown dirty files, generated cache/index files, credentials, or ambiguous files are present, stop and ask before staging anything.
 
 3. **Commit known durable memory outputs only**
-   - If every dirty path is a recognized durable memory output from `agentmem promote` or normal memory edits (`projects/**`, `lessons/**`, `snippets/**`, `web/**`, `inbox/**`, `drafts/**`, `preferences.md`, `README.md`), scan the exact candidate paths with `bash ~/.config/agent-memory/scripts/check-secrets.sh <paths>`.
+    - If every dirty path is a recognized durable memory output from `mem promote` or normal memory edits (`projects/**`, `lessons/**`, `snippets/**`, `web/**`, `inbox/**`, `drafts/**`, `preferences.md`, `README.md`), scan the exact candidate paths with `bash ~/.config/memory/scripts/check-secrets.sh <paths>`.
    - Stage only those candidate paths.
-   - Run `bash ~/.config/agent-memory/scripts/check-secrets.sh` again in staged-diff mode.
+    - Run `bash ~/.config/memory/scripts/check-secrets.sh` again in staged-diff mode.
    - Commit with a concise memory-focused message.
 
 4. **Pull latest memory only from a clean worktree**
-   - Run `git -C ~/.config/agent-memory pull --ff-only`.
+   - Run `git -C ~/.config/memory pull --ff-only`.
    - If this fails due to non-fast-forward or conflicts, stop and ask the user to resolve; do not rebase or merge automatically.
 
 5. **Push committed memory**
-   - Run `git -C ~/.config/agent-memory status -sb`.
+   - Run `git -C ~/.config/memory status -sb`.
    - Clean and not ahead: report no memory sync needed.
-   - Clean and ahead: push with `git -C ~/.config/agent-memory push`.
+   - Clean and ahead: push with `git -C ~/.config/memory push`.
    - Ahead plus dirty: inspect dirty state first; do not push until the working tree is clean or the user decides what to do.
 
 6. **Forbidden**

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# pre-commit hook: scan staged files for secret-shaped strings
+# Delegates to ~/.config/memory/scripts/check-secrets.sh
+# Part of FD project git safety rules (see GEMINI.md / AGENTS.md)
+
+set -euo pipefail
+
+MEM_HOME="${MEM_HOME:-$HOME/.config/memory}"
+SCANNER="$MEM_HOME/scripts/check-secrets.sh"
+
+if [ ! -x "$SCANNER" ]; then
+  echo "⚠️  Secret scanner not found at $SCANNER"
+  echo "    Run: bash $MEM_HOME/scripts/install.sh"
+  exit 1
+fi
+
+# Run scanner in pre-commit mode (staged diff)
+exec bash "$SCANNER"

--- a/.github/workflows/memory-scratch-guard.yml
+++ b/.github/workflows/memory-scratch-guard.yml
@@ -1,7 +1,8 @@
 name: memory-scratch-guard
 
-# Reject PRs that add files under .scratch/. Per the agent memory harness
-# contract, .scratch/ is ephemeral working memory and must never be committed.
+# Reject PRs that add files under .scratch/ or under .memory/ (except for the
+# tracked .memory/config.yml). Per the agent memory harness contract, those
+# paths are ephemeral / local-only / personal and must never enter the OSS repo.
 # See: openspec/specs/agent-memory-harness/spec.md
 
 on:
@@ -15,18 +16,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Reject .scratch/ additions
+      - name: Reject .scratch/ and .memory/ additions
         run: |
           set -euo pipefail
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
-          offenders=$(git diff --name-only --diff-filter=A "$base...$head" | grep -E '^\.scratch/' || true)
+          added=$(git diff --name-only --diff-filter=A "$base...$head")
+          bad_scratch=$(printf '%s\n' "$added" | grep -E '^\.scratch/' || true)
+          bad_memory=$(printf '%s\n' "$added" | grep -E '^\.memory/' | grep -v '^\.memory/config\.yml$' || true)
+          offenders=$(printf '%s\n%s\n' "$bad_scratch" "$bad_memory" | grep -v '^$' || true)
           if [ -n "$offenders" ]; then
-            echo "::error::PR adds files under .scratch/ which is gitignored ephemeral agent memory:"
+            echo "::error::PR adds files under .scratch/ or .memory/ (other than .memory/config.yml):"
             echo "$offenders" | sed 's/^/  /'
             echo ""
-            echo "Promote useful content to ~/.config/agent-memory/projects/khangnghiem__fast-draft/"
-            echo "via 'agentmem promote scratch_to_project_global', then drop the .scratch/ entries."
+            echo "These paths are local-only / personal memory."
+            echo "Promote useful content to ~/.config/memory/projects/khangnghiem__fast-draft/"
+            echo "via 'mem promote scratch_to_project_global', then drop the entries."
             exit 1
           fi
-          echo "OK: no .scratch/ additions in this PR."
+          echo "OK: no .scratch/ or stray .memory/ additions in this PR."

--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,10 @@ fd-canvas-ui/dist/
 # GitHub Pages WASM build output (built by CI)
 site/wasm/
 
-# Agent memory ephemeral scratch (.memory/config.yml IS committed)
+# Agent memory harness — only .memory/config.yml is tracked.
 .scratch/
-.memory/cache/
-.gitnexus/
+.memory/*
+!.memory/config.yml
 .lancedb/
 
 # Ephemeral local/debug artifacts

--- a/.memory/config.yml
+++ b/.memory/config.yml
@@ -12,4 +12,4 @@ canonical_doc_paths:
   - openspec
 openspec_dir: openspec
 web_capture_target: project
-agent_memory_path: ~/.config/agent-memory
+memory_path: ~/.config/memory

--- a/.opencode/mcp.json
+++ b/.opencode/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
-    "agentmem": {
-      "command": "/Users/khangnghiem/.config/agent-memory/bin/agentmem-mcp"
+    "mem": {
+      "command": "/Users/khangnghiem/.config/memory/bin/mem-mcp"
     }
   }
 }

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -4,6 +4,6 @@
     "test:observer": "node --test plugins/agent-observer/test/*.test.mjs"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.14.25"
+    "@opencode-ai/plugin": "1.14.32"
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,10 @@ Keep policy meaning aligned with the Claude and Gemini surfaces.
 
 ### Memory harness
 
-- If `.memory/config.yml` exists, start by running `git -C ~/.config/agent-memory pull --ff-only` and `agentmem repo read-config`; continue with local memory if the pull fails and fresh cross-machine context is not required.
-- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `agentmem repo search` plus relevant project/global lessons.
-- Use `.scratch/` only for ephemeral notes; promote durable lessons through `agentmem promote`, never by bypassing the scratch → project/global → canonical flow.
-- `/memory-sync` is only for `~/.config/agent-memory`; keep it separate from project git operations.
+- If `.memory/config.yml` exists, run `mem context bootstrap` at session start to pull the latest memory and receive a digest of relevant project lessons and canonical docs.
+- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `mem repo search` plus relevant project/global lessons.
+- Use `.scratch/` only for ephemeral notes; promote durable lessons through `mem promote`, never by bypassing the scratch → project/global → canonical flow.
+- `/memory-sync` is only for `~/.config/memory`; keep it separate from project git operations.
 - Secret hygiene applies to both the project repo and memory repo.
 
 ### Completion
@@ -165,11 +165,11 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 ### Memory harness — Fast Draft specifics
 
 - Project ID: `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
-- CLI: `agentmem` (`~/.config/agent-memory/bin/agentmem`); MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp`.
+- Per-project memory: `~/.config/memory/projects/khangnghiem__fast-draft/`.
+- CLI: `mem` (`~/.config/memory/bin/mem`); MCP wrapper: `~/.config/memory/bin/mem-mcp`.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
-- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.
-- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/memory`, never project changes.
+- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/` or `.memory/` (other than `.memory/config.yml`).
 
 ### User shortcuts
 
@@ -177,4 +177,4 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - `smoke` → run `just smoke`.
 - Local caveman helpers: `/caveman`, `/caveman-help`, `/caveman-review`, `/caveman-commit`, `/caveman:compress <file>`.
 - `/memory-status` → inspect Fast Draft memory state without writes.
-- `/memory-sync` → push durable agent-memory changes only; never project changes.
+- `/memory-sync` → push durable memory changes only; never project changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ Keep policy meaning aligned with the OpenCode and Gemini surfaces.
 
 ### Memory harness
 
-- If `.memory/config.yml` exists, start by running `git -C ~/.config/agent-memory pull --ff-only` and `agentmem repo read-config`; continue with local memory if the pull fails and fresh cross-machine context is not required.
-- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `agentmem repo search` plus relevant project/global lessons.
-- Use `.scratch/` only for ephemeral notes; promote durable lessons through `agentmem promote`, never by bypassing the scratch → project/global → canonical flow.
-- `/memory-sync` is only for `~/.config/agent-memory`; keep it separate from project git operations.
+- If `.memory/config.yml` exists, run `mem context bootstrap` at session start to pull the latest memory and receive a digest of relevant project lessons and canonical docs.
+- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `mem repo search` plus relevant project/global lessons.
+- Use `.scratch/` only for ephemeral notes; promote durable lessons through `mem promote`, never by bypassing the scratch → project/global → canonical flow.
+- `/memory-sync` is only for `~/.config/memory`; keep it separate from project git operations.
 - Secret hygiene applies to both the project repo and memory repo.
 
 ### Completion
@@ -165,11 +165,11 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 ### Memory harness — Fast Draft specifics
 
 - Project ID: `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
-- CLI: `agentmem` (`~/.config/agent-memory/bin/agentmem`); MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp`.
+- Per-project memory: `~/.config/memory/projects/khangnghiem__fast-draft/`.
+- CLI: `mem` (`~/.config/memory/bin/mem`); MCP wrapper: `~/.config/memory/bin/mem-mcp`.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
-- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.
-- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/memory`, never project changes.
+- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/` or `.memory/` (other than `.memory/config.yml`).
 
 ### User shortcuts
 
@@ -177,4 +177,4 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - `smoke` → run `just smoke`.
 - Local caveman helpers: `/caveman`, `/caveman-help`, `/caveman-review`, `/caveman-commit`, `/caveman:compress <file>`.
 - `/memory-status` → inspect Fast Draft memory state without writes.
-- `/memory-sync` → push durable agent-memory changes only; never project changes.
+- `/memory-sync` → push durable memory changes only; never project changes.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -64,10 +64,10 @@ Keep policy meaning aligned with the OpenCode and Claude surfaces.
 
 ### Memory harness
 
-- If `.memory/config.yml` exists, start by running `git -C ~/.config/agent-memory pull --ff-only` and `agentmem repo read-config`; continue with local memory if the pull fails and fresh cross-machine context is not required.
-- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `agentmem repo search` plus relevant project/global lessons.
-- Use `.scratch/` only for ephemeral notes; promote durable lessons through `agentmem promote`, never by bypassing the scratch → project/global → canonical flow.
-- `/memory-sync` is only for `~/.config/agent-memory`; keep it separate from project git operations.
+- If `.memory/config.yml` exists, run `mem context bootstrap` at session start to pull the latest memory and receive a digest of relevant project lessons and canonical docs.
+- For every new feature, bug, refactor, or investigation, search memory first with 2–4 concrete terms via `mem repo search` plus relevant project/global lessons.
+- Use `.scratch/` only for ephemeral notes; promote durable lessons through `mem promote`, never by bypassing the scratch → project/global → canonical flow.
+- `/memory-sync` is only for `~/.config/memory`; keep it separate from project git operations.
 - Secret hygiene applies to both the project repo and memory repo.
 
 ### Completion
@@ -169,11 +169,11 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 ### Memory harness — Fast Draft specifics
 
 - Project ID: `khangnghiem__fast-draft`; config: `.memory/config.yml`; canonical scope includes `AGENTS.md`, key `docs/`, `docs/specs/`, and `openspec/`.
-- Per-project memory: `~/.config/agent-memory/projects/khangnghiem__fast-draft/`.
-- CLI: `agentmem` (`~/.config/agent-memory/bin/agentmem`); MCP wrapper: `~/.config/agent-memory/bin/agentmem-mcp`.
+- Per-project memory: `~/.config/memory/projects/khangnghiem__fast-draft/`.
+- CLI: `mem` (`~/.config/memory/bin/mem`); MCP wrapper: `~/.config/memory/bin/mem-mcp`.
 - Route Fast Draft lessons (bounds ownership, pointer hijack, WASM sync) to the project lessons subtree unless they generalize.
-- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/agent-memory`, never project changes.
-- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/`.
+- `/memory-status` is read-only; `/memory-sync` syncs only `~/.config/memory`, never project changes.
+- `.github/workflows/memory-scratch-guard.yml` rejects PRs that add files under `.scratch/` or `.memory/` (other than `.memory/config.yml`).
 
 ### User shortcuts
 
@@ -181,4 +181,4 @@ cp -a fd-vscode/webview/wasm/. site/wasm/
 - `smoke` → run `just smoke`.
 - Local caveman helpers: `/caveman`, `/caveman-help`, `/caveman-review`, `/caveman-commit`, `/caveman:compress <file>`.
 - `/memory-status` → inspect Fast Draft memory state without writes.
-- `/memory-sync` → push durable agent-memory changes only; never project changes.
+- `/memory-sync` → push durable memory changes only; never project changes.

--- a/MEMORY_INIT.md
+++ b/MEMORY_INIT.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** project-agnostic checklist to bring a new repo onto the agent
 > memory harness defined in
-> `openspec/changes/agent-memory-harness/design.md`.
+> `openspec/specs/agent-memory-harness/spec.md`.
 >
 > Use this when adding the harness to any future project. Replace
 > `<owner>`, `<repo>`, and `<owner>__<repo>` with your values.
@@ -13,19 +13,22 @@
 
 You only do this once per workstation. Skip if already done.
 
-1. **Global `agent-memory` repo** cloned to `~/.config/agent-memory/`.
+1. **Global `memory` repo** cloned to `~/.config/memory/`.
    ```bash
-   gh repo clone <owner>/agent-memory ~/.config/agent-memory
+   gh repo clone <owner>/memory ~/.config/memory
    ```
 2. **Shell alias** in `~/.zshrc`:
    ```bash
-   alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'
+   export MEM_HOME="$HOME/.config/memory"
+   alias mem="$MEM_HOME/bin/mem"
    ```
+   Then run `bash $MEM_HOME/scripts/install.sh` once to install npm deps and
+   wire the secret-scanning pre-commit hook (`core.hooksPath=.githooks`).
 3. **Secrets file** `~/.zshrc.secrets` exists and is sourced from `~/.zshrc`.
 4. **`gh`, `git`, `npx`** available on PATH.
 
 If any of these are missing, follow Phases 0–4 of
-`openspec/changes/agent-memory-harness/tasks.md` in any project that already
+`openspec/changes/archive/agent-memory-harness/tasks.md` in any project that already
 has the harness — those phases set up the global pieces, not the project.
 
 ---
@@ -48,7 +51,7 @@ Create `.memory/config.yml` at repo root with schema v1:
 schema: 1
 
 # Project identity. Used to namespace project content under
-# agent-memory/projects/<project_id>/.
+# memory/projects/<project_id>/.
 project_id: <owner>__<repo>
 
 # Local scratch directory (gitignored, not synced).
@@ -63,9 +66,8 @@ canonical_doc_paths:
   - docs/specs/
   - openspec/
 
-# Optional vector/cache paths. All gitignored.
+# Optional vector/cache paths. Gitignored.
 lancedb_path: .memory/cache/lancedb
-gitnexus_path: .gitnexus
 
 # OpenSpec config root.
 openspec_dir: openspec
@@ -73,8 +75,8 @@ openspec_dir: openspec
 # Web capture default routing: project | global | both.
 web_capture_target: project
 
-# Path to the global agent-memory clone on this machine.
-agent_memory_path: ~/.config/agent-memory
+# Path to the global memory clone on this machine.
+memory_path: ~/.config/memory
 ```
 
 ### Step 3 — `.gitignore` entries
@@ -82,20 +84,18 @@ agent_memory_path: ~/.config/agent-memory
 Append to `.gitignore`:
 
 ```
-# Agent memory harness — local-only
+# Agent memory harness — only .memory/config.yml is tracked.
 .scratch/
-.memory/cache/
-.gitnexus/
+.memory/*
+!.memory/config.yml
 .lancedb/
 ```
-
-Keep `.memory/config.yml` tracked.
 
 Verify:
 
 ```bash
-git check-ignore .scratch/foo .memory/cache/foo
-# both should print
+git check-ignore .scratch/foo .memory/cache/foo .memory/lessons/foo.md
+# all three should print
 git check-ignore .memory/config.yml
 # should print nothing (file is tracked)
 ```
@@ -103,17 +103,17 @@ git check-ignore .memory/config.yml
 ### Step 4 — Create the project subtree in global memory
 
 ```bash
-mkdir -p ~/.config/agent-memory/projects/<owner>__<repo>/{lessons,sessions,drafts,transcripts,web,attachments}
+mkdir -p ~/.config/memory/projects/<owner>__<repo>/{lessons,sessions,drafts,transcripts,web,attachments}
 ```
 
 Add a `README.md` for the project subtree:
 
 ```bash
-cat > ~/.config/agent-memory/projects/<owner>__<repo>/README.md <<'EOF'
+cat > ~/.config/memory/projects/<owner>__<repo>/README.md <<'EOF'
 # <owner>/<repo> — project memory
 
 ## License flags
-- (note any non-permissive deps used here, e.g., GitNexus PolyForm Noncommercial)
+- (note any non-permissive deps used here)
 
 ## Deploy quirks
 - (record one-off prod gotchas here)
@@ -123,10 +123,10 @@ cat > ~/.config/agent-memory/projects/<owner>__<repo>/README.md <<'EOF'
 EOF
 ```
 
-Commit and push in `agent-memory`:
+Commit and push in `memory`:
 
 ```bash
-cd ~/.config/agent-memory
+cd ~/.config/memory
 git add projects/<owner>__<repo>/
 git commit -m "chore: add <owner>__<repo> project subtree"
 git push
@@ -154,10 +154,10 @@ If the project uses the same surface renderer as Fast Draft
    ```markdown
    ## Memory Harness — project specifics
 
-   - Global memory repo: `~/.config/agent-memory/`
-   - Project subtree: `agent-memory/projects/<owner>__<repo>/`
-   - Project config: `.memory/config.yml`
-   - MCP launch: `npx tsx ~/.config/agent-memory/mcp-server/index.ts`
+    - Global memory repo: `~/.config/memory/`
+    - Project subtree: `memory/projects/<owner>__<repo>/`
+    - Project config: `.memory/config.yml`
+    - MCP launch: `node $MEM_HOME/mcp-server/index.ts` (or `npx tsx $MEM_HOME/mcp-server/index.ts`)
    - `project_id`: `<owner>__<repo>`
    ```
 3. Regenerate:
@@ -176,9 +176,9 @@ Create `.opencode/mcp.json` (or the equivalent for Claude Code, Cursor, etc.):
 ```json
 {
   "mcpServers": {
-    "agentmem": {
+    "mem": {
       "command": "npx",
-      "args": ["tsx", "/Users/<you>/.config/agent-memory/mcp-server/index.ts"]
+      "args": ["tsx", "/Users/<you>/.config/memory/mcp-server/index.ts"]
     }
   }
 }
@@ -186,16 +186,24 @@ Create `.opencode/mcp.json` (or the equivalent for Claude Code, Cursor, etc.):
 
 Restart the agent host to pick up the new MCP.
 
-### Step 8 — CI guard for `.scratch/`
+### Step 8 — CI guard for `.scratch/` and `.memory/`
 
-Add a CI job that rejects PRs touching `.scratch/`. Minimal GitHub Actions
-snippet:
+Add a CI job that rejects PRs adding files under `.scratch/` or `.memory/`
+(other than the tracked `.memory/config.yml`). Minimal GitHub Actions snippet:
 
 ```yaml
-- name: Block .scratch/ commits
+- name: Reject .scratch/ and .memory/ additions
   run: |
-    if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^\.scratch/'; then
-      echo "::error::.scratch/ files are local-only; do not commit."
+    set -euo pipefail
+    base="${{ github.event.pull_request.base.sha }}"
+    head="${{ github.event.pull_request.head.sha }}"
+    added=$(git diff --name-only --diff-filter=A "$base...$head")
+    bad_scratch=$(printf '%s\n' "$added" | grep -E '^\.scratch/' || true)
+    bad_memory=$(printf '%s\n' "$added" | grep -E '^\.memory/' | grep -v '^\.memory/config\.yml$' || true)
+    offenders=$(printf '%s\n%s\n' "$bad_scratch" "$bad_memory" | grep -v '^$' || true)
+    if [ -n "$offenders" ]; then
+      echo "::error::PR adds files under .scratch/ or .memory/ (other than .memory/config.yml):"
+      echo "$offenders" | sed 's/^/  /'
       exit 1
     fi
 ```
@@ -209,8 +217,8 @@ agent calls repo.read_config        → returns parsed config
 agent calls repo.search             → returns project hits
 agent calls repo.write_scratch      → file appears in .scratch/, not staged
 agent calls promote.scratch_to_project_global
-                                    → file copied to agent-memory/projects/<id>/
-                                    → commit present in agent-memory
+                                     → file copied to memory/projects/<id>/
+                                     → commit present in memory
 agent calls sync.push --scope global → push succeeds
 ```
 
@@ -229,23 +237,23 @@ If any step fails, see troubleshooting below.
 
 | When | What | How |
 |------|------|-----|
-| Session start | Pull latest memory | `agentmem sync pull --scope both` |
-| New feature/bug prompt | Retrieve relevant memory before planning | `agentmem repo search <keywords>` plus project/global lessons |
-| During work | Capture session notes | `agentmem repo write-scratch ...` |
-| During work | Look up past lessons | `agentmem global list-lessons` or via MCP |
-| Worth keeping | Promote to project memory | `agentmem promote scratch-to-project-global ...` |
-| Worth sharing | Promote to global lessons | `agentmem promote lesson-to-global ...` |
-| Install commands | Ensure global memory commands are present | `agentmem commands install` |
+| Session start | Pull latest memory | `mem sync pull --scope both` |
+| New feature/bug prompt | Retrieve relevant memory before planning | `mem repo search <keywords>` plus project/global lessons |
+| During work | Capture session notes | `mem repo write-scratch ...` |
+| During work | Look up past lessons | `mem global list-lessons` or via MCP |
+| Worth keeping | Promote to project memory | `mem promote scratch-to-project-global ...` |
+| Worth sharing | Promote to global lessons | `mem promote lesson-to-global ...` |
+| Install commands | Ensure global memory commands are present | `mem commands install` |
 | Inspect memory | Read-only status | `/memory-status` |
-| Session end | Push durable memory updates only | `/memory-sync` or `agentmem sync push --scope global` |
+| Session end | Push durable memory updates only | `/memory-sync` or `mem sync push --scope global` |
 
 `.scratch/` is local-only by design. If you change machines, anything you want
-to carry with you must already be promoted to `agent-memory/projects/<id>/`.
+to carry with you must already be promoted to `memory/projects/<id>/`.
 
 Keep memory sync separate from project `/sync-push`: project pushes should not
-implicitly commit or push `~/.config/agent-memory`. `/memory-sync` and
-`/memory-status` are global commands installed from `~/.config/agent-memory`;
-run `agentmem commands install` if your coding agent does not show them.
+implicitly commit or push `~/.config/memory`. `/memory-sync` and
+`/memory-status` are global commands installed from `~/.config/memory`;
+run `mem commands install` if your coding agent does not show them.
 
 ---
 
@@ -254,31 +262,31 @@ run `agentmem commands install` if your coding agent does not show them.
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `repo.read_config` fails | `.memory/config.yml` missing or schema invalid | Recreate from Step 2 template |
-| `sync.pull` fails with non-fast-forward | Concurrent edits on another machine | Manual `git pull --rebase` in `~/.config/agent-memory/`, resolve, retry |
+| `sync.pull` fails with non-fast-forward | Concurrent edits on another machine | Manual `git pull --rebase` in `~/.config/memory/`, resolve, retry |
 | MCP tools not visible | Agent host not restarted | Restart agent host after editing `.opencode/mcp.json` |
 | `.scratch/` files showing in `git status` | Missing `.gitignore` entry | Re-do Step 3 |
 | Pre-commit secret scanner false positive | Pattern matched legit content | Whitelist via env var name reference instead of literal value |
-| `agent-memory` push rejected | Branch protection or unconfigured remote | `cd ~/.config/agent-memory && git remote -v && git push -u origin main` |
+| `memory` push rejected | Branch protection or unconfigured remote | `cd ~/.config/memory && git remote -v && git push -u origin main` |
 
 ---
 
 ## What you do **NOT** do per project
 
 - Do **not** create a separate `<project>.notes` repo. Project content lives
-  under `agent-memory/projects/<owner>__<repo>/`.
+  under `memory/projects/<owner>__<repo>/`.
 - Do **not** commit anything under `.scratch/`. It is local-only.
 - Do **not** hand-edit generated `AGENTS.md` if a renderer exists.
 - Do **not** put secrets in any memory layer. Reference env var names only.
-- Do **not** publish `agentmem` to npm. Distribution is via `git pull` in
-  `~/.config/agent-memory/`.
+- Do **not** publish `mem` to npm. Distribution is via `git pull` in
+  `~/.config/memory/`.
 
 ---
 
 ## References
 
-- Canonical design: `openspec/changes/agent-memory-harness/design.md`
+- Canonical design: `openspec/specs/agent-memory-harness/spec.md`
   (lives in the Fast Draft repo; mirror or copy into your new project's
   OpenSpec changes if you want a local copy).
 - First-time bootstrap tasks (global pieces — only needed if no project on this
   machine has set up the harness yet):
-  `openspec/changes/agent-memory-harness/tasks.md` (Phases 0–4).
+  `openspec/changes/archive/agent-memory-harness/tasks.md` (Phases 0–4).

--- a/MEMORY_INIT.md
+++ b/MEMORY_INIT.md
@@ -246,6 +246,7 @@ If any step fails, see troubleshooting below.
 | Install commands | Ensure global memory commands are present | `mem commands install` |
 | Inspect memory | Read-only status | `/memory-status` |
 | Session end | Push durable memory updates only | `/memory-sync` or `mem sync push --scope global` |
+| Sync all configs | Push memory + other configs | `sync-all` (or `bash ~/.config/sync-all.sh`) |
 
 `.scratch/` is local-only by design. If you change machines, anything you want
 to carry with you must already be promoted to `memory/projects/<id>/`.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ rect @login_btn {
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for architecture, crate structure, build instructions, and development setup.
 
-For AI-agent contributors: this repo is wired into the [agent-memory](https://github.com/khangnghiem/agent-memory) harness. The committed [`.memory/config.yml`](.memory/config.yml) declares the project's canonical doc scope and per-project memory subtree; new machines and new agents follow the project-agnostic adoption checklist in [`MEMORY_INIT.md`](MEMORY_INIT.md).
+For AI-agent contributors: this repo is wired into the [memory](https://github.com/khangnghiem/memory) harness. The committed [`.memory/config.yml`](.memory/config.yml) declares the project's canonical doc scope and per-project memory subtree; new machines and new agents follow the project-agnostic adoption checklist in [`MEMORY_INIT.md`](MEMORY_INIT.md).
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ## [Unreleased]
 
+### Agent Memory Harness — pre-multi-machine-sync hardening
+- **FIX (Memory)**: Removed vestigial `gitnexus_path` config field and `.gitnexus/` references across `MEMORY_INIT.md`, `.gitignore`, and current `openspec/specs/agent-memory-harness/spec.md`. GitNexus was never implemented and carries a PolyForm Noncommercial license risk we don't need. Archived openspec docs left as historical record.
+- **FIX (Memory)**: Hardened `.gitignore` from `.memory/cache/` to `.memory/*` with `!.memory/config.yml` allow-list, so any agent-created subdir under `.memory/` (lessons, sessions, etc.) is automatically ignored.
+- **FIX (CI)**: Expanded `.github/workflows/memory-scratch-guard.yml` to reject PRs adding files under `.memory/` (other than `.memory/config.yml`) in addition to the existing `.scratch/` guard.
+- **FIX (Memory)**: Updated `MEMORY_INIT.md` shell alias from stale `npx tsx ~/.config/memory/cli/index.ts` to canonical `$MEM_HOME/bin/mem` and pointed installers at `bash $MEM_HOME/scripts/install.sh` for one-shot bootstrap (npm install + pre-commit hook wiring).
+
 ### Agent Memory Harness — automation commands
-- **FEAT (Memory)**: Added `/memory-status` (read-only memory readiness) and `/memory-sync` (durable agent-memory sync only) policy surfaces; global OpenCode/Claude command templates now live in `agent-memory` and install via `agentmem commands install`.
-- **DOCS (Memory)**: Codified automatic session-start memory retrieval and pre-plan canonical/project/global memory lookup while keeping project `/sync-push` separate from agent-memory pushes.
+- **FEAT (Memory)**: Added `/memory-status` (read-only memory readiness) and `/memory-sync` (durable memory sync only) policy surfaces; global OpenCode/Claude command templates now live in `memory` and install via `mem commands install`.
+- **DOCS (Memory)**: Codified automatic session-start memory retrieval and pre-plan canonical/project/global memory lookup while keeping project `/sync-push` separate from memory pushes.
 
 ### Agent Memory Harness — full rollout (Phases 0–10)
-- **FEAT (Memory)**: Bootstrapped the [`agent-memory`](https://github.com/khangnghiem/agent-memory) global harness (CLI + MCP server) and wired Fast Draft as its first memory-aware project (`project_id: khangnghiem__fast-draft`).
-- **FEAT (Memory)**: Added `agentmem` CLI (`global / repo / sync / promote / web / lance` namespaces) and `agentmem-mcp` stdio wrapper exposing the same surface as `<namespace>__<tool>` MCP tools. Registered for OpenCode in `.opencode/mcp.json`.
+- **FEAT (Memory)**: Bootstrapped the [`memory`](https://github.com/khangnghiem/memory) global harness (CLI + MCP server) and wired Fast Draft as its first memory-aware project (`project_id: khangnghiem__fast-draft`).
+- **FEAT (Memory)**: Added `mem` CLI (`global / repo / sync / promote / web / lance` namespaces) and `mem-mcp` stdio wrapper exposing the same surface as `<namespace>__<tool>` MCP tools. Registered for OpenCode in `.opencode/mcp.json`.
 - **FEAT (Memory)**: `.memory/config.yml` declares canonical doc scope, `scratch_dir`, and per-project subtree path. `.scratch/`, `.memory/cache/`, `.gitnexus/`, `.lancedb/` gitignored.
 - **FEAT (Memory)**: OpenSpec capability spec at `openspec/specs/agent-memory-harness/spec.md` codifies retrieval order, promotion contract, secret hygiene, and verification matrix. `openspec/config.yaml` declares the directory-based lifecycle.
 - **FEAT (Memory)**: Agent surfaces — added "Memory harness" section to `.agents/shared/canonical.md` and Fast Draft specifics to `.agents/overrides/repo.md`. Regenerated `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -419,28 +419,28 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for full crate map, dependency graph, dat
 ### R8.1 — Memory-aware repo configuration _(done)_
 
 - `.memory/config.yml` (committed) declares `project_id: khangnghiem__fast-draft`, canonical doc paths (`AGENTS.md`, `docs/{ARCHITECTURE,REQUIREMENTS,LESSONS,SHORTCUTS,CHANGELOG}.md`, `docs/specs/`, `openspec/`), `scratch_dir: .scratch`, and `web_capture_target: project`.
-- `.scratch/`, `.memory/cache/`, `.gitnexus/`, `.lancedb/` are gitignored — ephemeral or per-machine state never lands in `main`.
+- `.scratch/`, `.memory/*` (except `.memory/config.yml`), `.lancedb/` are gitignored — ephemeral or per-machine state never lands in `main`.
 
-### R8.2 — agentmem CLI + MCP discovery _(done)_
+### R8.2 — mem CLI + MCP discovery _(done)_
 
-- `agentmem` CLI (`~/.config/agent-memory/bin/agentmem`) exposes `global / repo / sync / promote / web / lance` namespaces.
-- `agentmem-mcp` stdio MCP wrapper exposes the same operations as `<namespace>__<tool>` tools, registered for OpenCode in [`.opencode/mcp.json`](../.opencode/mcp.json).
+- `mem` CLI (`~/.config/memory/bin/mem`) exposes `global / repo / sync / promote / web / lance` namespaces.
+- `mem-mcp` stdio MCP wrapper exposes the same operations as `<namespace>__<tool>` tools, registered for OpenCode in [`.opencode/mcp.json`](../.opencode/mcp.json).
 
 ### R8.3 — Promotion contract _(done)_
 
-- `.scratch/` → `~/.config/agent-memory/projects/khangnghiem__fast-draft/<bucket>/` via `agentmem promote scratch-to-project-global`.
-- Project lessons → global lessons via draft PR (`agentmem promote lesson-to-global`).
-- `.scratch/` → `docs/` via draft PR (`agentmem promote scratch-to-canonical`). All cross-repo promotions go through PRs in the destination repo.
+- `.scratch/` → `~/.config/memory/projects/khangnghiem__fast-draft/<bucket>/` via `mem promote scratch-to-project-global`.
+- Project lessons → global lessons via draft PR (`mem promote lesson-to-global`).
+- `.scratch/` → `docs/` via draft PR (`mem promote scratch-to-canonical`). All cross-repo promotions go through PRs in the destination repo.
 
 ### R8.4 — CI guard _(done)_
 
-- [`.github/workflows/memory-scratch-guard.yml`](../.github/workflows/memory-scratch-guard.yml) rejects any PR that adds files under `.scratch/`.
+- [`.github/workflows/memory-scratch-guard.yml`](../.github/workflows/memory-scratch-guard.yml) rejects any PR that adds files under `.scratch/` or `.memory/` (other than `.memory/config.yml`).
 
 ### R8.5 — Automatic retrieval and dedicated memory commands _(done)_
 
 - Agents automatically pull/read memory config at session start and consult canonical/project/global memory before planning new feature, bug, refactor, or investigation work.
-- `/memory-status` reports memory readiness without writes; its global OpenCode/Claude command templates are sourced from `~/.config/agent-memory` and installed with `agentmem commands install`.
-- `/memory-sync` synchronizes only `~/.config/agent-memory`; its global OpenCode/Claude command templates are sourced from `~/.config/agent-memory` and installed with `agentmem commands install`. Project `/sync-push` remains project-scoped and never implicitly pushes memory.
+- `/memory-status` reports memory readiness without writes; its global OpenCode/Claude command templates are sourced from `~/.config/memory` and installed with `mem commands install`.
+- `/memory-sync` synchronizes only `~/.config/memory`; its global OpenCode/Claude command templates are sourced from `~/.config/memory` and installed with `mem commands install`. Project `/sync-push` remains project-scoped and never implicitly pushes memory.
 - Durable promotions require judgment/confirmation; raw `.scratch/` is never synced directly.
 
 ## Future Requirements (Deferred)

--- a/docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md
+++ b/docs/superpowers/specs/2026-04-26-agent-memory-harness-design.md
@@ -24,11 +24,11 @@ audit) drove the locked architecture below.
 - **Project repo** (this repo, public): hosts canonical docs, OpenSpec changes,
   `.memory/config.yml`, and a gitignored `.scratch/` directory for local
   ephemeral notes.
-- **`agent-memory` repo** (private, cloned to `~/.config/agent-memory/`): hosts
+- **`memory` repo** (private, cloned to `~/.config/memory/`): hosts
   global content at root and per-project content under `projects/<owner>__<repo>/`.
 - **No third `<project>.notes` repo.** Rejected because Fast Draft is public so
   privacy via gitignore beats privacy via separate repo, and project-scoped
-  cross-machine content fits cleanly under `agent-memory/projects/<id>/`.
+  cross-machine content fits cleanly under `memory/projects/<id>/`.
 
 ### Layer cake
 
@@ -38,8 +38,8 @@ audit) drove the locked architecture below.
 | L1 project local scratch | `.scratch/` (gitignored, local-only) |
 | L2 project canonical | Project repo `docs/`, `openspec/`, `.memory/` |
 | L3 code intelligence | `.gitnexus/`, `.lancedb/`, `.memory/cache/` (gitignored) |
-| L4 global memory | `agent-memory` repo (global root + `projects/<id>/`) |
-| L5 web cache | `agent-memory/web/` or `agent-memory/projects/<id>/web/` |
+| L4 global memory | `memory` repo (global root + `projects/<id>/`) |
+| L5 web cache | `memory/web/` or `memory/projects/<id>/web/` |
 
 ### Storage and search
 
@@ -52,11 +52,11 @@ audit) drove the locked architecture below.
 
 ### Tooling
 
-- `agentmem` CLI vendored in `agent-memory/cli/` (TypeScript, run via
+- `mem` CLI vendored in `memory/cli/` (TypeScript, run via
   `npx tsx`). Source of truth.
-- MCP wrapper in `agent-memory/mcp-server/` imports CLI library functions
+- MCP wrapper in `memory/mcp-server/` imports CLI library functions
   directly.
-- Distribution: shell alias `agentmem` in `~/.zshrc`. No npm publish.
+- Distribution: shell alias `mem` in `~/.zshrc`. No npm publish.
 - Tool namespaces: `global.*`, `repo.*`, `sync.*`, `promote.*`, `web.*`,
   `lance.*`. No `spec.*` (OpenSpec ops fold under `repo.*`).
 
@@ -89,7 +89,7 @@ audit) drove the locked architecture below.
 
 - Secrets in `~/.zshrc.secrets` (gitignored, sourced from `~/.zshrc`).
 - Agents reference env var names only.
-- Pre-commit secret scanner in `agent-memory/scripts/check-secrets.sh`.
+- Pre-commit secret scanner in `memory/scripts/check-secrets.sh`.
 
 ## Priority order
 

--- a/openspec/changes/archive/agent-memory-harness/design.md
+++ b/openspec/changes/archive/agent-memory-harness/design.md
@@ -28,9 +28,9 @@
 - **Cloud memory services.** No Mem0 cloud, Zep cloud, Supermemory, Pinecone.
 - **Real-time sync daemons.** All sync is `git pull` at session start, `git push` at
   session end.
-- **Agent host parity beyond MCP and CLI.** We do not target proprietary memory
+- **  Agent host parity beyond MCP and CLI.** We do not target proprietary memory
   APIs of individual agents (e.g., Cursor `.cursorrules` auto-load, Claude Code
-  project files). AGENTS.md instructions and the `agentmem` CLI are the portable
+  project files). AGENTS.md instructions and the `mem` CLI are the portable
   contract.
 - **Knowledge graph / temporal memory.** Defer Graphiti / Zep until markdown +
   ripgrep + LanceDB demonstrably fall short.
@@ -57,8 +57,8 @@ When trade-offs collide:
 | L1 | Project local scratch | `.scratch/` in project repo (gitignored, local-only) | Local machine | L2 or L4 (selective, via PR or `global.write_project_*`) |
 | L2 | Project canonical | Project repo (`docs/`, `openspec/`, `.memory/config.yml`) | Project | L4 (cross-project lessons only) |
 | L3 | Code intelligence | `.gitnexus/`, `.lancedb/`, `.memory/cache/` (gitignored) | Local only | None — rebuildable |
-| L4 | Global memory | `agent-memory` repo, with global content at root and project-scoped content under `projects/<id>/` | Personal | None — terminal layer |
-| L5 | Web research cache | `agent-memory/web/` (global) or `agent-memory/projects/<id>/web/` (project) | Personal | None — captures only |
+| L4 | Global memory | `memory` repo, with global content at root and project-scoped content under `projects/<id>/` | Personal | None — terminal layer |
+| L5 | Web research cache | `memory/web/` (global) or `memory/projects/<id>/web/` (project) | Personal | None — captures only |
 
 ### L0 — Ephemeral Session Memory
 
@@ -85,7 +85,7 @@ need cross-machine sync.
 
 - **Why local-only and not synced**: most session notes are ephemeral context for
   the machine you were working on. Cross-machine continuity for project work
-  belongs in L4 (`agent-memory/projects/<id>/`) where it's explicit.
+  belongs in L4 (`memory/projects/<id>/`) where it's explicit.
 - **Why a directory in the project repo and not a separate repo**: avoids the
   privacy leak risk for public repos (Fast Draft is public — anything tracked is
   public; `.scratch/` is gitignored so nothing leaks), removes one repo's worth
@@ -122,20 +122,20 @@ Local, regenerable indexes. Always gitignored.
 - **ast-grep** — structural code search.
 - **GitNexus** — code graph (definitions, references, call chains, blast radius).
   Index in `.gitnexus/`. License: PolyForm Noncommercial 1.0.0; flagged in
-  `agent-memory/projects/khangnghiem__fast-draft/README.md` as "license review
+  `memory/projects/khangnghiem__fast-draft/README.md` as "license review
   required before monetization."
 - **LanceDB** (optional) — embedded vector + FTS for semantic retrieval. Index in
   `.memory/cache/lancedb/`. Apache 2.0. Used only when ripgrep + ast-grep + GitNexus
   prove insufficient.
 
-### L4 — Global Memory (`agent-memory`)
+### L4 — Global Memory (`memory`)
 
-Single private GitHub repo, cloned to `~/.config/agent-memory/`. Holds both
+Single private GitHub repo, cloned to `~/.config/memory/`. Holds both
 truly global content (reusable across projects) and project-scoped content that
 must survive across machines.
 
 ```
-~/.config/agent-memory/
+~/.config/memory/
   README.md
   preferences.md                       (durable user preferences)
   lessons/         YYYY-MM-DD-<slug>.md   (cross-project lessons)
@@ -153,7 +153,7 @@ must survive across machines.
       transcripts/                        (chat/meeting captures)
       web/          <source>/<slug>.md    (project-scoped web captures)
       attachments/                        (screenshots, diagrams, binaries)
-  cli/             index.ts               (agentmem CLI entry)
+  cli/             index.ts               (mem CLI entry)
   mcp-server/      index.ts               (MCP wrapper entry)
   scripts/         check-secrets.sh       (pre-commit secret scanner)
   package.json
@@ -176,9 +176,9 @@ must survive across machines.
 Web captures from Tavily MCP or manual snapshots. Routing:
 
 - **Global captures** (general references, language idioms, library docs) →
-  `~/.config/agent-memory/web/<source>/<slug>.md`.
+  `~/.config/memory/web/<source>/<slug>.md`.
 - **Project captures** (one-off research tied to a specific project) →
-  `~/.config/agent-memory/projects/<id>/web/<source>/<slug>.md`.
+  `~/.config/memory/projects/<id>/web/<source>/<slug>.md`.
 
 Routing decided by the `web.capture` tool's `target` argument
 (`"global" | "project" | "both"`), defaulted from `.memory/config.yml`'s
@@ -195,15 +195,15 @@ in this order. Stop at the first sufficient answer.
 2. **Project canonical**: `docs/REQUIREMENTS.md`, `docs/LESSONS.md`, `docs/specs/`,
    plus relevant `.agents/` content.
 3. **Project scratch (local)**: `.scratch/sessions/`, `.scratch/drafts/`.
-4. **Project content in global memory**: `agent-memory/projects/<id>/sessions/`,
-   `agent-memory/projects/<id>/lessons/`.
+4. **Project content in global memory**: `memory/projects/<id>/sessions/`,
+   `memory/projects/<id>/lessons/`.
 5. **Code search**: `ripgrep` for exact strings; `ast-grep` for structural patterns;
    `GitNexus` for code graph queries (definitions, references, blast radius).
-6. **Global memory**: `agent-memory/lessons/`, `agent-memory/snippets/`,
-   `agent-memory/projects/<id>/README.md`.
+6. **Global memory**: `memory/lessons/`, `memory/snippets/`,
+   `memory/projects/<id>/README.md`.
 7. **Semantic** (optional): LanceDB query over project + global if exact and
    structural search fail.
-8. **Web cache**: `agent-memory/projects/<id>/web/` then `agent-memory/web/`.
+8. **Web cache**: `memory/projects/<id>/web/` then `memory/web/`.
 9. **External fallback**: web search via Tavily, GitHub Code Search.
 
 ## 5. Configuration: `.memory/config.yml`
@@ -214,7 +214,7 @@ Committed to project repo root. Schema v1:
 schema: 1
 
 # Project identity. Used to namespace project content under
-# agent-memory/projects/<project_id>/.
+# memory/projects/<project_id>/.
 project_id: khangnghiem__fast-draft
 
 # Local scratch directory (gitignored, not synced).
@@ -239,9 +239,9 @@ openspec_dir: openspec
 # Web capture default routing: project | global | both.
 web_capture_target: project
 
-# Path to the global agent-memory clone on this machine. Defaults to
-# ~/.config/agent-memory if unset.
-agent_memory_path: ~/.config/agent-memory
+# Path to the global memory clone on this machine. Defaults to
+# ~/.config/memory if unset.
+memory_path: ~/.config/memory
 ```
 
 ### Discoverability
@@ -256,7 +256,7 @@ auto-loads `.memory/config.yml` as of 2026. We make it discoverable two ways:
 
 ## 6. Tool Surface
 
-`agentmem` CLI is the source of truth. The MCP server is a thin wrapper that
+`mem` CLI is the source of truth. The MCP server is a thin wrapper that
 imports the CLI's library functions and exposes them as MCP tools. One
 implementation, two surfaces.
 
@@ -264,7 +264,7 @@ implementation, two surfaces.
 
 | Namespace | Purpose |
 |-----------|---------|
-| `global.*` | Read/write `agent-memory` repo |
+| `global.*` | Read/write `memory` repo |
 | `repo.*`   | Read/write project repo + scratch + OpenSpec ops |
 | `sync.*`   | Git pull/push/status |
 | `promote.*` | Open draft PRs to promote scratch → canonical or project → global |
@@ -275,8 +275,8 @@ implementation, two surfaces.
 
 #### `global.*`
 
-Operates over `agent-memory/`. The project subtree
-(`agent-memory/projects/<id>/`) is addressed via the same tools using a
+Operates over `memory/`. The project subtree
+(`memory/projects/<id>/`) is addressed via the same tools using a
 `project_id` argument; when omitted, operations target the truly global root.
 
 | Tool | Args | Effect |
@@ -289,7 +289,7 @@ Operates over `agent-memory/`. The project subtree
 | `write_draft` | `{ path?, title?, content, project_id? }` | Writes to `inbox/` (or `projects/<id>/inbox/`) for later promotion |
 | `write_project_session` | `{ project_id, date?, content, mode? }` | Writes a cross-machine project session log to `projects/<id>/sessions/<date>.md` |
 | `read_project_readme` | `{ project_id }` | Returns the project subtree's `README.md` |
-| `search` | `{ query, regex?, pathGlobs?, project_id?, limit? }` | Ripgrep over `agent-memory/`; scoped to project subtree if `project_id` set |
+| `search` | `{ query, regex?, pathGlobs?, project_id?, limit? }` | Ripgrep over `memory/`; scoped to project subtree if `project_id` set |
 
 #### `repo.*`
 
@@ -320,8 +320,8 @@ Operates over `agent-memory/`. The project subtree
 | Tool | Args | Effect |
 |------|------|--------|
 | `scratch_to_canonical` | `{ paths, prDraft? }` | Copies `.scratch/` files to project `docs/` and opens draft PR |
-| `scratch_to_project_global` | `{ paths, project_id? }` | Copies `.scratch/` files into `agent-memory/projects/<id>/`; commits in agent-memory but does not push (caller invokes `sync.push`) |
-| `lesson_to_global` | `{ path, project_id?, tags?, overwrite? }` | Copies project-scoped lesson up to top-level `agent-memory/lessons/` (drops project tag) and opens draft PR in `agent-memory` |
+| `scratch_to_project_global` | `{ paths, project_id? }` | Copies `.scratch/` files into `memory/projects/<id>/`; commits in memory but does not push (caller invokes `sync.push`) |
+| `lesson_to_global` | `{ path, project_id?, tags?, overwrite? }` | Copies project-scoped lesson up to top-level `memory/lessons/` (drops project tag) and opens draft PR in `memory` |
 
 Promotion always opens a **draft PR**. Never merges. Human review remains the gate.
 
@@ -345,23 +345,23 @@ Promotion always opens a **draft PR**. Never merges. Human review remains the ga
 CLI mirrors the namespaces:
 
 ```bash
-agentmem global search "wgpu render pipeline"
-agentmem repo openspec status
-agentmem sync push --scope both
-agentmem promote scratch-to-canonical --paths sessions/2026-04-26.md
-agentmem web capture --url https://example.com --target project
+mem global search "wgpu render pipeline"
+mem repo openspec status
+mem sync push --scope both
+mem promote scratch-to-canonical --paths sessions/2026-04-26.md
+mem web capture --url https://example.com --target project
 ```
 
 ### Distribution
 
-- **Install**: clone `agent-memory` repo to `~/.config/agent-memory/`. Add shell
+- **Install**: clone `memory` repo to `~/.config/memory/`. Add shell
   alias to `~/.zshrc`:
   ```bash
-  alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'
+  alias mem='npx tsx ~/.config/memory/cli/index.ts'
   ```
-- **Updates**: `git pull` in `agent-memory` repo. No npm publish step.
+- **Updates**: `git pull` in `memory` repo. No npm publish step.
 - **MCP registration**: per-project `.opencode/mcp.json` (or equivalent for other
-  hosts) points to `npx tsx ~/.config/agent-memory/mcp-server/index.ts`.
+  hosts) points to `npx tsx ~/.config/memory/mcp-server/index.ts`.
 
 ## 7. OpenSpec ↔ Superpowers Integration
 
@@ -411,7 +411,7 @@ adjacent `.annotations.json` or inline HTML comments — implementation detail).
 | Location | Content |
 |----------|---------|
 | `.agents/shared/canonical.md` | Generic Memory Harness section: read `.memory/config.yml` first, retrieval order, prefer scratch over canonical writes, promotion requires PR, secret hygiene rules |
-| `.agents/overrides/repo.md` | Fast Draft repo-specific paths and commands: `~/.config/agent-memory/` location, `.scratch/` gitignored scratch dir, MCP launch command, project_id `khangnghiem__fast-draft` |
+| `.agents/overrides/repo.md` | Fast Draft repo-specific paths and commands: `~/.config/memory/` location, `.scratch/` gitignored scratch dir, MCP launch command, project_id `khangnghiem__fast-draft` |
 
 After editing either source, run `npm run render:agent-surfaces` to regenerate
 `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`. Verifier runs in CI via
@@ -422,7 +422,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 > **Memory Harness**
 >
 > Before working on any task, read `.memory/config.yml` (or call
-> `repo.read_config` via the agentmem MCP). Then consult sources in retrieval
+> `repo.read_config` via the mem MCP). Then consult sources in retrieval
 > order: OpenSpec active change → project canonical → project scratch → code
 > search → global memory → semantic → web cache → external fallback.
 >
@@ -435,7 +435,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 ### Session start
 
 ```
-1. cd ~/.config/agent-memory && git pull --ff-only
+1. cd ~/.config/memory && git pull --ff-only
 2. cd <project>              && git pull --ff-only
 3. agent reads .memory/config.yml
 ```
@@ -443,7 +443,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 ### Session end
 
 ```
-1. agent or human reviews uncommitted changes in agent-memory (project repo
+1. agent or human reviews uncommitted changes in memory (project repo
    commits/pushes happen via normal PR flow, not via sync.push)
 2. agent calls sync.push --scope global
 3. push fails fast if non-fast-forward; user resolves manually
@@ -465,9 +465,9 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
   a context that suggests credentials) into any memory layer.
 - **Allowed**: reference env var names only. E.g., write
   `Tavily API key in $TAVILY_API_KEY` — never the literal value.
-- **Enforcement**: pre-commit hook in the `agent-memory` repo
+- **Enforcement**: pre-commit hook in the `memory` repo
   scans staged content for secret patterns. Hook source vendored in
-  `agent-memory/scripts/check-secrets.sh`.
+  `memory/scripts/check-secrets.sh`.
 
 ## 11. Risk Register
 
@@ -476,7 +476,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 | R1 | Tool name collision (multiple memory plugins claiming `memory_*`) | M | M | Strict namespacing (`global.*` etc.); document in AGENTS.md; avoid generic memory plugins in production |
 | R2 | Index drift across machines (LanceDB, GitNexus caches diverge) | H | L | All indexes gitignored; canonical is markdown; rebuild from source on demand |
 | R3 | Secret leakage into memory files | M | H | Pre-commit hook scans for secret patterns; agents instructed via canonical to use env var names only |
-| R4 | GitNexus license trap (PolyForm Noncommercial) | L | M | Noted in `agent-memory/projects/khangnghiem__fast-draft/README.md`; license review required before monetization; swap to permissive code-intel tool if commercial use planned |
+| R4 | GitNexus license trap (PolyForm Noncommercial) | L | M | Noted in `memory/projects/khangnghiem__fast-draft/README.md`; license review required before monetization; swap to permissive code-intel tool if commercial use planned |
 | R5 | Plugin abandonment (OpenSpec, GitNexus, LanceDB upstream changes) | M | M | Storage formats are simple and exportable; CLI is the source of truth and survives any plugin loss |
 | R6 | Prompt pollution (agents promote noise to global memory) | M | M | Promotion gate is PR review; `promote.*` opens drafts only |
 | R7 | YAML/TOML config drift (legacy `.opencode-memory.toml` or `.agentmemory.toml` files appear) | L | L | Spec mandates `.memory/config.yml` as the only valid config; verifier rejects legacy filenames |
@@ -490,12 +490,12 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 
 ### From current state (no harness)
 
-1. Create `agent-memory` private GitHub repo. Initialize with template structure
+1. Create `memory` private GitHub repo. Initialize with template structure
    (Section 3, L4 subsection).
-2. Clone to `~/.config/agent-memory/` on each machine.
-3. Add shell alias `agentmem` in `~/.zshrc`.
-4. Implement `agentmem` CLI in `agent-memory/cli/` (TS).
-5. Implement MCP wrapper in `agent-memory/mcp-server/`.
+2. Clone to `~/.config/memory/` on each machine.
+3. Add shell alias `mem` in `~/.zshrc`.
+4. Implement `mem` CLI in `memory/cli/` (TS).
+5. Implement MCP wrapper in `memory/mcp-server/`.
 6. Add `.memory/config.yml` to Fast Draft repo root with `project_id:
    khangnghiem__fast-draft`.
 7. Add `.gitignore` entries for `.scratch/`, `.memory/cache/`, `.gitnexus/`,
@@ -509,16 +509,16 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 12. Register MCP in `.opencode/mcp.json`.
 13. Smoke test: agent reads config, runs `repo.search`, writes a `.scratch/`
     note, promotes it via `promote.scratch_to_project_global` to
-    `agent-memory/projects/khangnghiem__fast-draft/`.
+    `memory/projects/khangnghiem__fast-draft/`.
 
 ### Future migrations
 
 - **Adding a new project**: add `.memory/config.yml` to project root with new
-  `project_id`. Create `agent-memory/projects/<new_id>/` subtree with template
+  `project_id`. Create `memory/projects/<new_id>/` subtree with template
   structure. No new repo to create.
-- **Adding a team member**: invite them to `agent-memory` repo; they clone to
-  their own `~/.config/agent-memory/`. Project content under
-  `agent-memory/projects/<id>/` is shared automatically. `.scratch/` remains
+- **Adding a team member**: invite them to `memory` repo; they clone to
+  their own `~/.config/memory/`. Project content under
+  `memory/projects/<id>/` is shared automatically. `.scratch/` remains
   local-only per machine and per developer.
 - **Swapping LanceDB for another vector DB**: rebuild index from markdown source;
   update `.memory/config.yml` `lancedb_path` key (or rename); update
@@ -533,7 +533,7 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
    inline HTML comments vs separate annotation tool repo). Defer to follow-up
    change.
 2. **Team-scale namespace** — when a second contributor joins, do we need
-   `team.*` MCP tools, or does shared `agent-memory` access suffice? Defer.
+   `team.*` MCP tools, or does shared `memory` access suffice? Defer.
 3. **Tavily MCP wiring** — is the existing Tavily MCP package sufficient, or do
    we need a thin `web.*` wrapper that handles routing to project vs global?
    Defer to first web capture session.
@@ -545,9 +545,9 @@ After editing either source, run `npm run render:agent-surfaces` to regenerate
 
 This change is complete when:
 
-- [ ] `agent-memory` repo exists with template structure including
+- [ ] `memory` repo exists with template structure including
       `projects/<id>/` subtree shape.
-- [ ] `agentmem` CLI implements all tools in Section 6.
+- [ ] `mem` CLI implements all tools in Section 6.
 - [ ] MCP wrapper implements all tools in Section 6.
 - [ ] `.memory/config.yml` exists at Fast Draft repo root with valid schema v1
       (includes `project_id`).
@@ -559,10 +559,10 @@ This change is complete when:
       `project_id`.
 - [ ] `AGENTS.md` regenerated and committed.
 - [ ] `npm run verify:agent-surfaces` passes.
-- [ ] Pre-commit secret-scanning hook installed in `agent-memory`.
+- [ ] Pre-commit secret-scanning hook installed in `memory`.
 - [ ] CI verifier rejects PRs that add files under `.scratch/`.
 - [ ] Smoke test passes: read config → search → write `.scratch/` → promote to
-      `agent-memory/projects/<id>/` via `promote.scratch_to_project_global`.
+      `memory/projects/<id>/` via `promote.scratch_to_project_global`.
 - [ ] `docs/REQUIREMENTS.md` includes a Memory Harness entry.
 - [ ] `docs/CHANGELOG.md` records the harness introduction.
 

--- a/openspec/changes/archive/agent-memory-harness/proposal.md
+++ b/openspec/changes/archive/agent-memory-harness/proposal.md
@@ -21,15 +21,15 @@ have explicit change tracking.
 ## What Changes
 
 1. **Two-repo memory model**
-   - `agent-memory` (new private repo, cloned to `~/.config/agent-memory/`) for all
-     durable knowledge — both global (reusable across projects) and project-scoped
-     (per-project sessions, drafts, web captures, lessons) under
-     `agent-memory/projects/<owner>__<repo>/`.
+   - `memory` (new private repo, cloned to `~/.config/memory/`) for all
+      durable knowledge — both global (reusable across projects) and project-scoped
+      (per-project sessions, drafts, web captures, lessons) under
+      `memory/projects/<owner>__<repo>/`.
    - The project repo gains a gitignored `.scratch/` directory for local ephemeral
      notes that don't need cross-machine sync, plus a committed `.memory/config.yml`
      declaring canonical doc paths and optional cache settings. **No separate
      `<project>.notes` repo.** Project content that must survive across machines
-     gets promoted from `.scratch/` to `agent-memory/projects/<id>/`. This avoids
+      gets promoted from `.scratch/` to `memory/projects/<id>/`. This avoids
      a privacy leak risk (Fast Draft is a public repo; nothing tracked = nothing
      leaked) and removes one repo's worth of sync overhead.
 
@@ -38,11 +38,11 @@ have explicit change tracking.
    `docs/specs/` remains the durable archive for feature documentation; durable
    content from archived OpenSpec changes can be promoted to `docs/specs/<feature>.md`.
 
-3. **Custom `agentmem` CLI** vendored in `agent-memory/cli/` (TypeScript, run via
+3. **Custom `mem` CLI** vendored in `memory/cli/` (TypeScript, run via
    `npx tsx`). Tool surface namespaced as `global.* / repo.* / sync.* / promote.* /
    web.* / lance.*`. Distributed via shell alias, no npm publishing.
 
-4. **Thin MCP wrapper** in `agent-memory/mcp-server/` calling into the CLI's library
+4. **Thin MCP wrapper** in `memory/mcp-server/` calling into the CLI's library
    functions. Gives OpenCode-native tool discovery without duplicating logic.
 
 5. **Code intelligence layer**: GitNexus (PolyForm Noncommercial, accepted for
@@ -79,7 +79,7 @@ have explicit change tracking.
   - New `openspec/` tree at repo root with `config.yaml`, `changes/`, `specs/`.
   - `docs/REQUIREMENTS.md`, `docs/CHANGELOG.md` — note the new harness.
 - **Affected external repos** (not part of this change, listed for completeness):
-  - `agent-memory` repo created on user's GitHub with `lessons/`, `snippets/`,
+   - `memory` repo created on user's GitHub with `lessons/`, `snippets/`,
     `preferences.md`, `projects/<id>/{README.md,sessions/,drafts/,transcripts/,
     web/,attachments/,lessons/}`, `web/`, `inbox/`, `templates/`, `schemas/`,
     `cli/`, `mcp-server/`.
@@ -89,5 +89,5 @@ have explicit change tracking.
   memory plugins are installed alongside. All mitigated in design.md risk register.
 - **Backout**: Memory harness is additive. Removing `.memory/config.yml`, deleting
   `openspec/`, deleting `.scratch/` (already gitignored), and reverting
-  `.agents/overrides/repo.md` patches restores the prior state. The `agent-memory`
-  repo remains usable as a plain markdown vault even if the CLI/MCP is uninstalled.
+   `.agents/overrides/repo.md` patches restores the prior state. The `memory`
+   repo remains usable as a plain markdown vault even if the CLI/MCP is uninstalled.

--- a/openspec/changes/archive/agent-memory-harness/tasks.md
+++ b/openspec/changes/archive/agent-memory-harness/tasks.md
@@ -16,13 +16,13 @@
 - [ ] **0.3** Confirm `npx tsx` available.
   - Verify: `npx --yes tsx --version` succeeds.
 
-## Phase 1 — Global `agent-memory` Repo
+## Phase 1 — Global `memory` Repo
 
-- [ ] **1.1** Create private GitHub repo `agent-memory` under `khangnghiem`.
-  - Command: `gh repo create khangnghiem/agent-memory --private --description "Personal agent memory harness"`.
-  - Verify: `gh repo view khangnghiem/agent-memory --json visibility -q .visibility` prints `PRIVATE`.
-- [ ] **1.2** Clone to `~/.config/agent-memory/`.
-  - Command: `git clone git@github.com:khangnghiem/agent-memory.git ~/.config/agent-memory`.
+- [ ] **1.1** Create private GitHub repo `memory` under `khangnghiem`.
+  - Command: `gh repo create khangnghiem/memory --private --description "Personal memory harness"`.
+  - Verify: `gh repo view khangnghiem/memory --json visibility -q .visibility` prints `PRIVATE`.
+- [ ] **1.2** Clone to `~/.config/memory/`.
+  - Command: `git clone git@github.com:khangnghiem/memory.git ~/.config/memory`.
 - [ ] **1.3** Initialize template directory structure per design Section 3 (L4 subsection):
   ```
   README.md preferences.md .gitignore
@@ -31,32 +31,32 @@
   cli/index.ts mcp-server/index.ts scripts/check-secrets.sh
   package.json tsconfig.json
   ```
-  - Verify: `find ~/.config/agent-memory -maxdepth 2 -type d` lists all required dirs.
+  - Verify: `find ~/.config/memory -maxdepth 2 -type d` lists all required dirs.
 - [ ] **1.4** Add `.gitignore`: `node_modules/`, `*.log`, `.DS_Store`, any
   per-machine cache paths.
 - [ ] **1.5** First commit + push.
-  - Verify: `cd ~/.config/agent-memory && git log --oneline | head -1` shows initial commit.
+  - Verify: `cd ~/.config/memory && git log --oneline | head -1` shows initial commit.
 
 ## Phase 2 — Secrets Hygiene Foundation
 
 - [ ] **2.1** Confirm `~/.zshrc.secrets` exists and is sourced from `~/.zshrc`.
   Create if missing.
-- [ ] **2.2** Write `agent-memory/scripts/check-secrets.sh` per design Section 10.
+- [ ] **2.2** Write `memory/scripts/check-secrets.sh` per design Section 10.
   Patterns: `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, generic 32+ base64 in
   credential context.
-  - Verify: `bash ~/.config/agent-memory/scripts/check-secrets.sh < <(echo "ghp_abc123...")` exits non-zero.
-- [ ] **2.3** Install pre-commit hook in `agent-memory` invoking
+  - Verify: `bash ~/.config/memory/scripts/check-secrets.sh < <(echo "ghp_abc123...")` exits non-zero.
+- [ ] **2.3** Install pre-commit hook in `memory` invoking
   `scripts/check-secrets.sh` over staged files.
   - Verify: attempt to commit a file containing `ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA` is blocked.
 
-## Phase 3 — `agentmem` CLI
+## Phase 3 — `mem` CLI
 
-- [ ] **3.1** Initialize `package.json` and `tsconfig.json` in `agent-memory/`.
+- [ ] **3.1** Initialize `package.json` and `tsconfig.json` in `memory/`.
   Dependencies: `tsx`, `yaml`, `zod`, `simple-git`, `commander` (or `cac`).
 - [ ] **3.2** Implement `cli/lib/config.ts`: load + validate `.memory/config.yml`
   with Zod schema v1 from design Section 5.
   - Verify: unit test loads valid config; invalid config throws schema error.
-- [ ] **3.3** Implement `cli/lib/paths.ts`: resolve `agent_memory_path`,
+- [ ] **3.3** Implement `cli/lib/paths.ts`: resolve `memory_path`,
   `scratch_dir`, `lancedb_path`, `gitnexus_path` from config + env.
 - [ ] **3.4** Implement `cli/lib/global.ts`: `read_lesson`, `list_lessons`,
   `read_snippet`, `read_preferences`, `write_preferences`, `write_draft`,
@@ -68,18 +68,18 @@
   `push` per design 6 + 9. Scope: `global` | `project` | `both`.
 - [ ] **3.7** Implement `cli/lib/promote.ts`: `scratch_to_canonical`,
   `scratch_to_project_global`, `lesson_to_global`. All open draft PRs via `gh`
-  except `scratch_to_project_global` which commits in `agent-memory` only.
+  except `scratch_to_project_global` which commits in `memory` only.
 - [ ] **3.8** Implement `cli/lib/web.ts`: `capture` via webfetch fallback;
   Tavily MCP integration deferred.
 - [ ] **3.9** Implement `cli/lib/lance.ts`: stubs returning "not enabled" unless
   `lancedb_path` set.
 - [ ] **3.10** Implement `cli/index.ts`: command router for namespaces
   `global / repo / sync / promote / web / lance`.
-  - Verify: `npx tsx ~/.config/agent-memory/cli/index.ts repo read-config`
+  - Verify: `npx tsx ~/.config/memory/cli/index.ts repo read-config`
     in Fast Draft repo prints parsed config.
 - [ ] **3.11** Add shell alias to `~/.zshrc`:
-  `alias agentmem='npx tsx ~/.config/agent-memory/cli/index.ts'`.
-  - Verify: new shell, `agentmem --help` prints usage.
+  `alias mem='npx tsx ~/.config/memory/cli/index.ts'`.
+  - Verify: new shell, `mem --help` prints usage.
 
 ## Phase 4 — MCP Wrapper
 
@@ -87,7 +87,7 @@
 - [ ] **4.2** Implement `mcp-server/index.ts` importing CLI library functions
   and exposing them as MCP tools with namespaces from design Section 6.
   - Tool ID format: `<namespace>__<tool>` (e.g., `global__read_lesson`).
-- [ ] **4.3** JSON schemas for each tool live in `agent-memory/schemas/`.
+- [ ] **4.3** JSON schemas for each tool live in `memory/schemas/`.
   Wire via Zod `.zodToJsonSchema`.
 - [ ] **4.4** Smoke test: launch MCP via `npx tsx mcp-server/index.ts`, send
   `tools/list` over stdio, verify all tools enumerated.
@@ -107,10 +107,10 @@
   - Verify: `git check-ignore .scratch/foo` succeeds; `git check-ignore .memory/config.yml` fails.
 - [ ] **5.3** Create empty `.scratch/` with placeholder `.gitkeep` is NOT done —
   directory created on first write only.
-- [ ] **5.4** Create `agent-memory/projects/khangnghiem__fast-draft/` subtree:
+- [ ] **5.4** Create `memory/projects/khangnghiem__fast-draft/` subtree:
   `README.md` (license flags including GitNexus PolyForm note), `lessons/`,
   `sessions/`, `drafts/`, `transcripts/`, `web/`, `attachments/`. Commit + push
-  in `agent-memory`.
+  in `memory`.
 
 ## Phase 6 — OpenSpec Initialization
 
@@ -127,7 +127,7 @@
   `.agents/shared/canonical.md` per design Section 8 (read `.memory/config.yml`
   first, retrieval order, promotion via PR, secret hygiene).
 - [ ] **7.2** Add Fast Draft-specific paths to `.agents/overrides/repo.md`:
-  `~/.config/agent-memory/`, `.memory/config.yml`, MCP launch command,
+  `~/.config/memory/`, `.memory/config.yml`, MCP launch command,
   `project_id: khangnghiem__fast-draft`.
 - [ ] **7.3** Run `npm run render:agent-surfaces`. Commit regenerated
   `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`.
@@ -136,9 +136,9 @@
   ```json
   {
     "mcpServers": {
-      "agentmem": {
+      "mem": {
         "command": "npx",
-        "args": ["tsx", "/Users/khangnghiem/.config/agent-memory/mcp-server/index.ts"]
+        "args": ["tsx", "/Users/khangnghiem/.config/memory/mcp-server/index.ts"]
       }
     }
   }
@@ -159,9 +159,9 @@
 - [ ] **9.4** Agent calls `repo.write_scratch { path: "sessions/smoke-test.md", content: "...", mode: "replace" }`.
   - Verify: file exists at `.scratch/sessions/smoke-test.md`; not staged in git.
 - [ ] **9.5** Agent calls `promote.scratch_to_project_global { paths: ["sessions/smoke-test.md"] }`.
-  - Verify: file copied to `agent-memory/projects/khangnghiem__fast-draft/sessions/smoke-test.md`; commit present in `agent-memory` log.
+  - Verify: file copied to `memory/projects/khangnghiem__fast-draft/sessions/smoke-test.md`; commit present in `memory` log.
 - [ ] **9.6** Agent calls `sync.push { scope: "global" }`.
-  - Verify: `agent-memory` remote has new commit.
+  - Verify: `memory` remote has new commit.
 - [ ] **9.7** Agent calls `global.list_lessons { project_id: "khangnghiem__fast-draft" }`.
   - Verify: returns project lessons (empty list acceptable).
 
@@ -186,7 +186,7 @@
 
 | Criterion | Phase | Verified by |
 |----------|-------|-------------|
-| `agent-memory` repo with template structure | 1 | 1.3 |
+| `memory` repo with template structure | 1 | 1.3 |
 | CLI implements all tools | 3 | 3.10 |
 | MCP wrapper implements all tools | 4 | 4.4 |
 | `.memory/config.yml` valid schema v1 | 5 | 5.1 + 9.2 |

--- a/openspec/specs/agent-memory-harness/auto-retrieval.md
+++ b/openspec/specs/agent-memory-harness/auto-retrieval.md
@@ -1,0 +1,376 @@
+# Design: Auto-Retrieval Architecture
+
+> **Status:** draft (Council #2 approved, awaiting implementation)
+> **Related**: [`spec.md`](./spec.md), [`MEMORY_INIT.md`](../../../MEMORY_INIT.md)
+
+## Problem
+
+Agents currently must **manually** invoke `mem repo search <keywords>` or read
+specific memory files. There is no automatic retrieval at session start, which
+means:
+
+- New sessions start with zero memory context.
+- Agents rediscover known pitfalls (bounds ownership, pointer hijack, WASM sync)
+  on every new task.
+- Cross-machine continuity is broken: an agent on machine B doesn't know what
+  machine A learned yesterday unless the user manually runs lookups.
+
+## Goal
+
+When an agent starts a session in a project repo, it should **automatically**
+receive relevant memory context without manual triggers. This must be:
+
+- **Selective**: Don't dump the entire memory tree into context.
+- **Fast**: <2 seconds end-to-end.
+- **Relevant**: Distinguish project-specific from global memory.
+- **Non-blocking**: Failures degrade gracefully.
+
+## Trigger Model
+
+| Tier | Trigger | Behavior | Phase |
+|------|---------|----------|-------|
+| **T1: Session Start** | Agent session initialization | One-time retrieval of canonical docs + high-confidence project/global memory | **v1** |
+| **T2: Task-Scoped** | User prompt contains task keywords | Optional re-retrieval with task-specific query | **v1.5** |
+| **T3: Context Pressure** | Token usage >75% of limit | Evict/summarize old injections | **v2** |
+
+**T1 is mandatory baseline.** T2 is opt-in via config. T3 is aspirational.
+
+> **Note on MCP limitations**: MCP servers are stateless stdio — there is no
+> `onSessionStart` lifecycle. Host adapters (AGENTS.md instructions) must call
+> `context.bootstrap` as the first action. Hosts with real startup hooks may
+> inject automatically.
+
+## Retrieval Pipeline
+
+```
+TRIGGER: Session start
+    │
+    ▼
+[1] Sync check & fast-forward pull (timeout: 1500ms)
+    ├── success → continue with fresh index
+    ├── timeout/offline → continue with stale cache, flag stale=true
+    └── non-fast-forward → error (user must resolve), do NOT silently skip
+    │
+    ▼
+[2] Read .memory/config.yml → project_id, canonical_doc_paths, memory_path
+    │
+    ▼
+[3] Build query signals (parallel, cheap heuristics — NO LLM call)
+    ├── Detect project language from manifests (Cargo.toml, package.json)
+    ├── Detect task type from prompt keywords (feat/bug/refactor/docs)
+    └── Extract explicit tags if present in prompt
+    │
+    ▼
+[4] Collect candidates (parallel queries)
+    ├── Canonical docs (from config, max 3)
+    ├── Project lessons (scope: project, max 5)
+    ├── Project sessions ≤90 days (max 2)
+    └── Global lessons (scope: global, language-filtered, max 3)
+    │
+    ▼
+[5] Rank & deduplicate
+    ├── Score = 0.40*keyword_match + 0.25*tag_overlap + 0.15*profile_match
+    │           + 0.10*authority + 0.10*recency
+    ├── Authority order: canonical > project lessons > sessions > global lessons
+    └── Remove duplicates by content hash
+    │
+    ▼
+[6] Token-budget assembly
+    ├── Hard cap: 2000 tokens startup / 1000 tokens task-scoped
+    ├── Truncate lowest-ranked items first
+    └── Summarize items >300 tokens to first sentence + read_more handle
+    │
+    ▼
+[7] Return Memory Context Pack
+```
+
+**Performance target:** <2 seconds end-to-end (parallel I/O + cached index).
+
+## Selection / Ranking Strategy
+
+### Score formula (v1)
+
+```
+score =
+  0.40 * BM25(keywords, title + summary + headings)
++ 0.25 * tag_overlap(task_tags, item_tags)
++ 0.15 * profile_match(project_language, item_language_tag)
++ 0.10 * authority_bucket(canonical > project > global)
++ 0.10 * recency_decay(days_since_edit)
+- penalty_for_archive_path
+- penalty_for_language_mismatch
+```
+
+### Hard filters
+
+- **Language mismatch** → exclude entirely (Rust project shouldn't get JS lessons).
+- **Archive paths excluded** by default (`openspec/changes/archive/**`, `docs/superpowers/**`).
+- **Sessions >90 days** excluded unless tagged `permanent: true`.
+- **Transcripts, attachments, inbox, scratch** NEVER auto-inject.
+
+### Frontmatter (v1.5)
+
+Lessons and canonical docs may include YAML frontmatter:
+
+```yaml
+---
+id: fd-bounds-ownership
+scope: project          # project | global
+projects: [khangnghiem__fast-draft]
+tags: [rust, wasm, canvas, layout]
+language: rust          # primary language
+visibility: auto        # auto | manual-only | global-agent
+created: 2026-03-04
+confidence: high        # high | medium | low
+priority: normal        # high | normal | low
+summary: "Never let lower-authority layout overwrite measured bounds."
+---
+```
+
+## Context Injection Strategy
+
+**Primary contract: Memory Context Pack** (structured JSON). Hosts decide how to
+consume it:
+
+```json
+{
+  "pack_id": "ctx_20260506_abc123",
+  "project_id": "khangnghiem__fast-draft",
+  "freshness": {
+    "synced": true,
+    "last_pull": "2026-05-06T10:00:00Z",
+    "stale": false,
+    "warnings": []
+  },
+  "must_apply": [
+    {
+      "id": "fd-bounds-ownership",
+      "scope": "project",
+      "title": "Bounds ownership chain",
+      "summary": "JS measureText → SyncEngine → resolve_subtree → resolve_layout...",
+      "path": "projects/khangnghiem__fast-draft/lessons/bounds-ownership.md",
+      "relevance": 0.91,
+      "tokens": 120
+    }
+  ],
+  "maybe_relevant": [],
+  "read_more": [
+    {"tool": "global.read_lesson", "args": {"id": "fd-bounds-ownership"}}
+  ],
+  "total_tokens": 1800,
+  "items_found": 8
+}
+```
+
+**Delivery modes:**
+
+1. **Tool result** (portable, preferred): Agent calls `context.bootstrap` and
+   receives the pack as a tool result. Works with any MCP host.
+2. **System prompt prefix** (ergonomic): Hosts like OpenCode/Claude Code prepend
+   a markdown rendering of the pack to the system prompt. Requires host
+   cooperation.
+
+All retrieved memory is **advisory** — subordinate to user/system/developer
+instructions. Never let memory override explicit instructions.
+
+## Project vs Global Balancing
+
+| Scope | Budget (startup) | Budget (task-scoped) | Priority |
+|-------|-----------------|---------------------|----------|
+| Canonical/pinned docs | 30% (~600 tokens) | 20% (~200 tokens) | 1st |
+| Project lessons | 50% (~1000 tokens) | 50% (~500 tokens) | 2nd |
+| Project sessions (≤90d) | 10% (~200 tokens) | 20% (~200 tokens) | 3rd |
+| Global lessons (lang-matched) | 10% (~200 tokens) | 10% (~100 tokens) | 4th |
+| Global snippets | — | — | On-demand only |
+
+**Rules:**
+
+1. Project items always win ties over global items.
+2. Global lessons require language tag match + keyword match.
+3. Global items marked `applies_to: any` bypass language filter.
+4. Sessions require recency + relevance; never inject raw transcripts.
+
+## Freshness / Sync Guarantees
+
+```typescript
+interface SyncResult {
+  pulled: boolean;
+  commits_behind: number;
+  last_synced_at: string | null;
+  stale: boolean;
+  offline: boolean;
+  warnings: string[];
+}
+```
+
+**Protocol:**
+
+1. On session start: `git -C ~/.config/memory pull --ff-only` (timeout: 1500ms).
+2. If timeout/offline: use local cache, set `stale=true`, log warning.
+3. If non-fast-forward: surface as user-action-required error; do NOT silently skip.
+4. If dirty working tree: skip pull, use local cache, warn.
+5. Cache index by `memory_repo_HEAD + project_id + config_hash`.
+6. Never auto-commit, auto-stash, or auto-push during retrieval.
+
+**Push model:** Explicit only (`mem sync push` or `/memory-sync`). No automatic push.
+
+## Implementation Sketch
+
+### New MCP Tools
+
+```typescript
+// T1: Session startup retrieval
+"context.bootstrap": {
+  input: {
+    repo_root?: string,
+    task_hint?: string,           // optional keywords from first prompt
+    host?: { name: string; session_id?: string },
+    budget_tokens?: number,       // default: 2000
+    sync?: "pull_ff_only" | "if_stale" | "skip"
+  },
+  returns: MemoryContextPack
+}
+
+// T2: Task-scoped retrieval (optional, Phase 1.5)
+"context.retrieve": {
+  input: {
+    repo_root?: string,
+    query: string,
+    task_type?: "feature" | "bug" | "refactor" | "investigation" | "docs",
+    files?: string[],             // files mentioned in prompt
+    scopes?: ("canonical" | "project" | "global")[],
+    budget_tokens?: number,       // default: 1000
+    since_pack_id?: string        // diff from previous pack
+  },
+  returns: MemoryContextPack
+}
+
+// Status check (lightweight, no retrieval)
+"context.status": {
+  input: { repo_root?: string },
+  returns: {
+    configured: boolean,
+    project_id?: string,
+    memory_head?: string,
+    index_status: "fresh" | "stale" | "missing",
+    last_pull_at?: string,
+    warnings: string[]
+  }
+}
+```
+
+### Config Schema Additions (`.memory/config.yml`)
+
+```yaml
+schema: 2  # bump version
+
+auto_retrieval:
+  enabled: true
+
+  sync:
+    on_session_start: pull_ff_only  # pull_ff_only | if_stale | skip
+    timeout_ms: 1500
+    stale_after_minutes: 60
+    allow_stale: true
+
+  budgets:
+    startup_tokens: 2000
+    task_tokens: 1000
+    max_items: 12
+    snippet_chars: 700
+
+  project_profile:
+    languages: [rust, typescript]  # auto-detected + override
+    tags: [wasm, canvas, vscode]
+
+  scopes:
+    canonical_exclude:
+      - openspec/changes/archive/**
+      - docs/superpowers/specs/**
+    project_buckets: [README.md, lessons, sessions]
+    global_buckets: [lessons, snippets]
+    exclude_buckets: [transcripts, attachments, inbox, scratch, web]
+    require_global_tag_match: true
+
+  privacy:
+    auto_expose_global: tagged_only  # tagged_only | any | none
+    redact_secrets: true
+    include_sessions: false          # MUST be false by default
+    include_web: false
+```
+
+### New CLI Commands
+
+```bash
+# Session startup retrieval
+mem context bootstrap [--task-hint "rust wasm bug"] [--dry-run]
+
+# Task-scoped retrieval
+mem context retrieve --query "canvas bounds layout" --type bug
+
+# Status check
+mem context status
+```
+
+### Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `~/.config/memory/cli/src/context/bootstrap.ts` | New — core retrieval logic |
+| `~/.config/memory/cli/src/context/retrieve.ts` | New — task-scoped retrieval |
+| `~/.config/memory/cli/src/context/status.ts` | New — status check |
+| `~/.config/memory/cli/src/context/ranker.ts` | New — scoring + ranking |
+| `~/.config/memory/cli/src/context/packer.ts` | New — token budgeting + formatting |
+| `~/.config/memory/cli/src/sync/manager.ts` | Modify — add ff-only pull with timeout |
+| `~/.config/memory/mcp-server/index.ts` | Modify — register new tools |
+| `~/.config/memory/mcp-server/tools/context.ts` | New — MCP wrappers |
+| `.memory/config.yml` | Modify — add `auto_retrieval` section |
+| `AGENTS.md` | Modify — add session-start protocol |
+| `openspec/specs/agent-memory-harness/spec.md` | Modify — document auto-retrieval |
+
+## Failure Modes
+
+| Failure | Severity | Behavior | Agent-visible |
+|---------|----------|----------|---------------|
+| No `.memory/config.yml` | Low | Return empty pack, `configured: false` | Silent |
+| Memory repo not cloned | Medium | Return empty pack + bootstrap guidance | Warning with install link |
+| Git pull timeout (>1500ms) | Medium | Use stale cache, `stale: true` | Warning once per session |
+| Git pull non-fast-forward | High | Error — do NOT proceed with stale | Error: "Memory repo diverged. Run `mem sync resolve`" |
+| Dirty memory repo | Medium | Skip pull, use local cache | Warning |
+| No relevant memory found | Low | Return empty pack | Silent success |
+| Pack exceeds budget | Medium | Truncate lowest-ranked items | Silent — shorter item list |
+| MCP tool unavailable | Medium | Fall back to CLI: `mem context bootstrap` | Error with fallback command |
+| Schema version mismatch | Low | Parse v1 fields, ignore unknown | Warning |
+
+**All failures are non-blocking.** Auto-retrieval is advisory, never gating.
+
+## Privacy / Security
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Session transcripts auto-injected with secrets | 🔴 Critical | `include_sessions: false` hard default. Scan content before injection. |
+| Cross-project contamination via global lessons | 🟠 High | Validate `project_id`. Require language tag match. |
+| Secrets in memory retrieved without scanning | 🟠 High | Run lightweight regex scan on retrieved content. Redact patterns with `[REDACTED]`. |
+| Stale sensitive data in wrong context | 🟡 Medium | 90-day session TTL. Archive paths excluded. |
+| MCP input logging leaks prompt content | 🟡 Medium | `mem-mcp` must NOT log tool inputs by default. |
+| Wrong project_id retrieves wrong memory | 🟡 Medium | Validate `project_id` at bootstrap. Error on mismatch. |
+
+## Rollout Plan
+
+### Phase 1 (Immediate)
+- Implement `context.bootstrap` with keyword-only BM25 ranking.
+- Hardcode 4-layer priority (canonical → project lessons → sessions → global lessons).
+- 1500-token default cap, 12-item max.
+- Add `auto_retrieval` config section with `enabled` flag.
+- Update AGENTS.md with session-start protocol.
+
+### Phase 2 (Next)
+- Add `context.retrieve` for task-scoped queries.
+- Implement tag taxonomy and frontmatter parsing.
+- Add recency decay and priority tags.
+- Add secret redaction during retrieval.
+
+### Phase 3 (Future)
+- Optional LanceDB vector search (only if lexical proves insufficient).
+- Context-pressure summarization (T3).
+- Cross-session memory continuity.

--- a/openspec/specs/agent-memory-harness/spec.md
+++ b/openspec/specs/agent-memory-harness/spec.md
@@ -11,8 +11,8 @@ Give AI coding agents in this repo durable, multi-machine memory and a clean
 contract for routing reads and writes between:
 
 - the project repo (canonical docs, ephemeral `.scratch/`),
-- the global harness at `~/.config/agent-memory/` (cross-project lessons,
-  per-project subtree at `projects/khangnghiem__fast-draft/`).
+- the global harness at `~/.config/memory/` (cross-project lessons,
+   per-project subtree at `projects/khangnghiem__fast-draft/`).
 
 ## Components
 
@@ -20,19 +20,19 @@ contract for routing reads and writes between:
 
 | Path | Tracked? | Role |
 | --- | --- | --- |
-| `.memory/config.yml` | yes | Schema-v1 declaration: `project_id`, canonical doc paths, scratch dir, optional `lancedb_path` / `gitnexus_path`, `web_capture_target`, `agent_memory_path`. |
-| `.scratch/` | no (gitignored) | Ephemeral agent working memory. Promoted to the agent-memory subtree when worth keeping. |
+| `.memory/config.yml` | yes | Schema-v1 declaration: `project_id`, canonical doc paths, scratch dir, optional `lancedb_path` / `gitnexus_path`, `web_capture_target`, `memory_path`. |
+| `.scratch/` | no (gitignored) | Ephemeral agent working memory. Promoted to the memory subtree when worth keeping. |
 | `.memory/cache/`, `.gitnexus/`, `.lancedb/` | no (gitignored) | Per-machine indices; never committed. |
 
 ### 2. Global harness contract
 
-Lives at `~/.config/agent-memory/` (repo: `khangnghiem/agent-memory`).
+Lives at `~/.config/memory/` (repo: `khangnghiem/memory`).
 
 | Subtree | Role |
 | --- | --- |
 | `lessons/`, `snippets/`, `web/`, `inbox/` | Cross-project durable knowledge. |
 | `projects/khangnghiem__fast-draft/` | This repo's per-project subtree: `README.md`, `lessons/`, `sessions/`, `drafts/`, `transcripts/`, `web/`, `attachments/`, `inbox/`. |
-| `cli/` | `agentmem` CLI (TypeScript, run via tsx). |
+| `cli/` | `mem` CLI (TypeScript, run via tsx). |
 | `mcp-server/` | Stdio MCP wrapper exposing the CLI library as `<namespace>__<tool>` MCP tools. |
 | `scripts/check-secrets.sh` | Pre-commit secret scanner. |
 
@@ -43,7 +43,7 @@ Namespaced. Both the CLI and the MCP wrapper expose the same operations:
 - `global.*` — `read_lesson`, `list_lessons`, `read_snippet`, `read_preferences`, `write_preferences`, `write_draft`, `write_project_session`, `read_project_readme`, `search`.
 - `repo.*` — `read_config`, `read_canonical`, `read_scratch`, `write_scratch`, `search`, `openspec_status`, `openspec_propose`, `openspec_apply`, `openspec_archive`.
 - `sync.*` — `status`, `pull` (`--ff-only`), `push`, scoped `global` | `project` | `both`.
-- `promote.*` — `scratch_to_canonical` (opens draft PR), `scratch_to_project_global` (commits in agent-memory only), `lesson_to_global` (opens draft PR).
+- `promote.*` — `scratch_to_canonical` (opens draft PR), `scratch_to_project_global` (commits in memory only), `lesson_to_global` (opens draft PR).
 - `web.*` — `capture` via webfetch fallback (Tavily MCP deferred).
 - `lance.*` — stubs returning `{status: "NOT_ENABLED"}` until `lancedb_path` is set.
 
@@ -61,8 +61,8 @@ soon as the question is answered:
 ### Automatic retrieval triggers
 
 - **Session start**: if `.memory/config.yml` exists, agents SHOULD run
-  `git -C ~/.config/agent-memory pull --ff-only` followed by
-  `agentmem repo read-config` before planning work.
+  `git -C ~/.config/memory pull --ff-only` followed by
+  `mem repo read-config` before planning work.
 - **New feature / bug / refactor prompt**: agents SHOULD extract task keywords
   and run canonical `repo.search` plus relevant project/global lesson lookups
   before proposing a plan.
@@ -74,8 +74,8 @@ soon as the question is answered:
 Writes flow strictly upward, never sideways:
 
 ```
-.scratch/  ->  agent-memory/projects/<id>/<bucket>/   (promote.scratch_to_project_global)
-agent-memory/projects/<id>/lessons/<file>  ->  agent-memory/lessons/<file>   (promote.lesson_to_global, draft PR)
+.scratch/  ->  memory/projects/<id>/<bucket>/   (promote.scratch_to_project_global)
+memory/projects/<id>/lessons/<file>  ->  memory/lessons/<file>   (promote.lesson_to_global, draft PR)
 .scratch/<file>  ->  docs/<canonical>/<file>   (promote.scratch_to_canonical, draft PR)
 ```
 
@@ -84,7 +84,7 @@ never direct pushes to `main`.
 
 ## Secret hygiene
 
-- Pre-commit hook in `agent-memory` runs `scripts/check-secrets.sh` on staged
+- Pre-commit hook in `memory` runs `scripts/check-secrets.sh` on staged
   blobs and rejects on `sk-*`, `ghp_*`, `xoxb-*`, `AKIA*`, and 32+ char
   base64-in-credential-context.
 - Fast-draft adopts the same scanner via the `.githooks/pre-commit` chain.
@@ -94,20 +94,20 @@ never direct pushes to `main`.
 
 - No daemons. `git pull --ff-only` at session start; memory pushes happen via
   explicit memory sync, not project `/sync-push`.
-- The agent-memory repo lives on `main`; project-subtree commits land directly.
+- The memory repo lives on `main`; project-subtree commits land directly.
 - Fast-draft uses topic branches and PRs (no direct pushes to `main`).
 
 ### Memory commands
 
 Global `/memory-status` and `/memory-sync` command templates live in
-`~/.config/agent-memory` and are installed into agent-specific global command
-directories with `agentmem commands install`. Adopted project repos document the
+`~/.config/memory` and are installed into agent-specific global command
+directories with `mem commands install`. Adopted project repos document the
 policy, but do not need project-local command copies.
 
 - `/memory-status` is read-only: parse `.memory/config.yml`, inspect
-  `~/.config/agent-memory` git status, summarize scratch/project/global memory,
+  `~/.config/memory` git status, summarize scratch/project/global memory,
   and recommend next action.
-- `/memory-sync` operates only on `~/.config/agent-memory`: inspect dirty state
+- `/memory-sync` operates only on `~/.config/memory`: inspect dirty state
   before pulling, commit known durable promotion outputs only after scanning exact
   candidate paths and staged content with `scripts/check-secrets.sh`, pull
   `--ff-only` from a clean worktree, push committed-ahead memory automatically,
@@ -119,8 +119,8 @@ policy, but do not need project-local command copies.
 
 | Aspect | Verifier |
 | --- | --- |
-| Config parses | `agentmem repo read-config` exits 0 and prints resolved paths. |
-| Scratch round-trip | `agentmem repo write-scratch <p>` then `agentmem repo read-scratch <p>` returns body. |
-| Canonical search scope | `agentmem repo search <q>` only hits paths in `canonical_doc_paths`. |
-| MCP discovery | `agentmem-mcp` over stdio responds to `tools/list` with all `<ns>__<tool>` IDs. |
+| Config parses | `mem repo read-config` exits 0 and prints resolved paths. |
+| Scratch round-trip | `mem repo write-scratch <p>` then `mem repo read-scratch <p>` returns body. |
+| Canonical search scope | `mem repo search <q>` only hits paths in `canonical_doc_paths`. |
+| MCP discovery | `mem-mcp` over stdio responds to `tools/list` with all `<ns>__<tool>` IDs. |
 | `.scratch/` not staged | CI workflow `memory-scratch-guard` rejects PRs adding `.scratch/**`. |

--- a/openspec/specs/agent-memory-harness/spec.md
+++ b/openspec/specs/agent-memory-harness/spec.md
@@ -20,9 +20,9 @@ contract for routing reads and writes between:
 
 | Path | Tracked? | Role |
 | --- | --- | --- |
-| `.memory/config.yml` | yes | Schema-v1 declaration: `project_id`, canonical doc paths, scratch dir, optional `lancedb_path` / `gitnexus_path`, `web_capture_target`, `memory_path`. |
+| `.memory/config.yml` | yes | Schema-v1 declaration: `project_id`, canonical doc paths, scratch dir, optional `lancedb_path`, `web_capture_target`, `memory_path`. |
 | `.scratch/` | no (gitignored) | Ephemeral agent working memory. Promoted to the memory subtree when worth keeping. |
-| `.memory/cache/`, `.gitnexus/`, `.lancedb/` | no (gitignored) | Per-machine indices; never committed. |
+| `.memory/cache/`, `.lancedb/` | no (gitignored) | Per-machine indices; never committed. |
 
 ### 2. Global harness contract
 
@@ -123,4 +123,4 @@ policy, but do not need project-local command copies.
 | Scratch round-trip | `mem repo write-scratch <p>` then `mem repo read-scratch <p>` returns body. |
 | Canonical search scope | `mem repo search <q>` only hits paths in `canonical_doc_paths`. |
 | MCP discovery | `mem-mcp` over stdio responds to `tools/list` with all `<ns>__<tool>` IDs. |
-| `.scratch/` not staged | CI workflow `memory-scratch-guard` rejects PRs adding `.scratch/**`. |
+| `.scratch/` / `.memory/` not staged | CI workflow `memory-scratch-guard` rejects PRs adding `.scratch/**` and `.memory/**` (except `.memory/config.yml`). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fast-draft",
+  "name": "opencode-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Changes

- Added `sync-all` alias to MEMORY_INIT.md daily workflow
- Memory harness hardening from previous commits (hooks, CI guard, etc.)

## Related
- `~/.config/memory/sync.sh` — per-component sync
- `~/.config/sync-all.sh` — orchestrator for all configs