### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in specs panel markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+## 2026-05-09 - Secure Markdown Rendering Fallback
+**Vulnerability:** XSS vulnerability in `site/app.js` where user-controlled Markdown notes were directly injected via `innerHTML` after parsing with `marked`.
+**Learning:** When implementing conditional sanitization (e.g., `window.DOMPurify ? sanitize(...) : fallback`), the fallback path must fail securely. Simply passing the raw, unescaped string breaks Markdown rendering functionality (no newlines/formatting) and leaves the XSS vulnerability if the sanitizer dependency fails to load.
+**Prevention:** Ensure the fallback path gracefully escapes HTML characters (`<`, `>`) and wraps the text in appropriate container tags (like `<pre>`) to maintain layout stability and security when the primary sanitization library is missing.

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,7 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify ? window.DOMPurify.sanitize(rendered) : `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `site/app.js` file previously rendered user-controlled markdown notes via `marked.parse(processedNote)` and directly appended the output to `innerHTML`. This allowed arbitrary script execution if a malicious `.fd` file contained script tags in its notes.
🎯 Impact: Attackers could execute arbitrary JavaScript in the context of the user's Fast Draft web session if they open a malicious file containing crafted markdown notes.
🔧 Fix: Sanitized the output of `marked.parse` using `DOMPurify.sanitize` (which is already loaded globally via CDN in `site/index.html`). Added a secure fallback that escapes HTML tags and wraps the content in `<pre>` blocks if `DOMPurify` fails to load.
✅ Verification: Ran `node --check site/app.js` to verify syntax. Reviewed the logic to confirm the fix safely escapes characters or sanitizes them without breaking the original formatting.

---
*PR created automatically by Jules for task [12844402514657536717](https://jules.google.com/task/12844402514657536717) started by @khangnghiem*