### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in DOMPurify fallbacks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+## 2024-05-18 - XSS Vulnerability in Sanitization Fallbacks
+**Vulnerability:** In `site/ai-chat.js` and `site/app.js`, when `DOMPurify` was unavailable, the application fell back to rendering unescaped, raw HTML (via `unsafeHTML` or `marked.parse` output) directly into `innerHTML`.
+**Learning:** Fallback paths for security controls (like sanitizers) are critical points of failure. If a sanitizer fails to load, failing open (rendering unescaped content) introduces an XSS vector.
+**Prevention:** Always ensure fallback paths fail securely. If a required sanitizer is unavailable, fall back to escaping the raw content (e.g., using `escapeHtml`) and wrapping it in safe container tags (like `<pre>`) to prevent layout breakage and XSS.

--- a/site/ai-chat.js
+++ b/site/ai-chat.js
@@ -512,7 +512,7 @@ function addMessage(role, content, getEditorContent, setEditorContent) {
     div.textContent = '✦ Thinking…';
   } else {
     const unsafeHTML = renderAssistantMessage(content, getEditorContent, setEditorContent);
-    div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(unsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : unsafeHTML;
+    div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(unsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : `<pre>${escapeHtml(content)}</pre>`;
     wireApplySkipButtons(div, getEditorContent, setEditorContent);
   }
 
@@ -628,7 +628,7 @@ async function sendMessage(getEditorContent, setEditorContent) {
 
       const performRender = () => {
         const unsafeHTML = renderAssistantMessage(accumulated, getEditorContent, setEditorContent) + '<span class="ai-cursor">█</span>';
-        div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(unsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : unsafeHTML;
+        div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(unsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : `<pre>${escapeHtml(accumulated)}</pre><span class="ai-cursor">█</span>`;
         wireApplySkipButtons(div, getEditorContent, setEditorContent);
         messages.scrollTop = messages.scrollHeight;
         renderPending = false;
@@ -711,7 +711,7 @@ async function sendMessage(getEditorContent, setEditorContent) {
       const finalContent = accumulated || '⚠️ The AI returned an empty response. This may be a temporary issue — try again or simplify your prompt.';
       chatHistory.push({ role: 'assistant', content: finalContent });
       const finalUnsafeHTML = renderAssistantMessage(finalContent, getEditorContent, setEditorContent);
-      div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(finalUnsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : finalUnsafeHTML;
+      div.innerHTML = window.DOMPurify ? DOMPurify.sanitize(finalUnsafeHTML, { ADD_ATTR: ['data-fd', 'data-bid'] }) : `<pre>${escapeHtml(finalContent)}</pre>`;
       wireApplySkipButtons(div, getEditorContent, setEditorContent);
       messages.scrollTop = messages.scrollHeight;
     } else {

--- a/site/app.js
+++ b/site/app.js
@@ -2724,9 +2724,9 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify ? window.DOMPurify.sanitize(rendered) : `<pre>${escapeHtml(processedNote)}</pre>`;
       } else {
-        html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
+        html += `<pre>${escapeHtml(processedNote)}</pre>`;
       }
     }
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** When the `DOMPurify` library failed to load or was unavailable, the application fell back to directly setting `innerHTML` with `unsafeHTML` (in `site/ai-chat.js`) or unescaped `marked.parse` output (in `site/app.js`). This fail-open behavior could allow Cross-Site Scripting (XSS) via maliciously crafted AI responses or parsed markdown notes.
🎯 **Impact:** If `DOMPurify` is blocked (e.g., by network issues or extensions), an attacker could execute arbitrary JavaScript in the context of the Fast Draft application by supplying malicious input.
🔧 **Fix:** Changed the fallback logic in `site/ai-chat.js` and `site/app.js` to fail securely. If `DOMPurify` is unavailable, the application now escapes the raw text content using the existing `escapeHtml` function and wraps it in safe `<pre>` container tags.
✅ **Verification:**
- Verified syntax with `node --check`.
- Ran `pnpm lint` and `pnpm run build:webview` within `fd-vscode`.
- Fallbacks correctly invoke `escapeHtml`.

---
*PR created automatically by Jules for task [552532114348271063](https://jules.google.com/task/552532114348271063) started by @khangnghiem*