### PR TITLE
⚡ Bolt: [performance improvement] Reduce redundant iterations in Spec View parsing

### DIFF
--- a/fd-vscode/src/panels/spec-view.ts
+++ b/fd-vscode/src/panels/spec-view.ts
@@ -412,11 +412,22 @@ export class FdSpecViewPanel {
     html += `<span class="kind-badge${isGeneric ? " spec" : ""}">${escapeHtml(kind || "spec")}</span>`;
     html += `</div>`;
 
-    const descriptions = annotations.filter((a) => a.type === "description");
-    const accepts = annotations.filter((a) => a.type === "accept");
-    const statuses = annotations.filter((a) => a.type === "status");
-    const priorities = annotations.filter((a) => a.type === "priority");
-    const tags = annotations.filter((a) => a.type === "tag");
+    // PERFORMANCE OPTIMIZATION:
+    // Single-pass iteration to categorize annotations instead of 5 separate .filter() calls.
+    // Reduces O(5N) iterations to O(N), improving render performance for specs with many annotations.
+    const descriptions: { type: string; value: string }[] = [];
+    const accepts: { type: string; value: string }[] = [];
+    const statuses: { type: string; value: string }[] = [];
+    const priorities: { type: string; value: string }[] = [];
+    const tags: { type: string; value: string }[] = [];
+
+    for (const a of annotations) {
+      if (a.type === "description") descriptions.push(a);
+      else if (a.type === "accept") accepts.push(a);
+      else if (a.type === "status") statuses.push(a);
+      else if (a.type === "priority") priorities.push(a);
+      else if (a.type === "tag") tags.push(a);
+    }
 
     for (const d of descriptions) {
       html += `<div class="description">${escapeHtml(d.value)}</div>`;


### PR DESCRIPTION
💡 What: Replaced 5 consecutive `.filter()` calls on the `annotations` array with a single `for...of` loop in `fd-vscode/src/panels/spec-view.ts`.

🎯 Why: Categorizing annotations by type using separate passes created O(5N) iterations and generated unnecessary intermediate arrays. A single pass handles all categorizations simultaneously.

📊 Impact: Reduces time complexity from O(5N) to O(N) when parsing spec blocks. While small for minor documents, this improves rendering performance and prevents UI lag when opening documents with a large number of annotations.

🔬 Measurement: Verify by opening the Spec View panel in `fd-vscode`. `pnpm test` confirms that parsing correctness and behavior remain fully intact.

---
*PR created automatically by Jules for task [2454354959083740546](https://jules.google.com/task/2454354959083740546) started by @khangnghiem*