### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+## 2026-05-31 - Missing Sanitization for Markdown Parsing in Specs Panel
+**Vulnerability:** In `site/app.js`'s `renderSpecsPanel`, raw HTML generated from user markdown via `marked.parse` was appended to `innerHTML` without proper sanitization.
+**Learning:** Even though the notes logic uses custom application data, un-sanitized parsed markdown directly exposes an XSS vulnerability when users provide malicious input in their `.fd` specs. Fallbacks that simply escape the raw markdown string will break the internal HTML structures expected by the logic, so conditional paths must properly use tools like `DOMPurify` to safely strip only harmful payloads while retaining custom required tags and attributes.
+**Prevention:** Always ensure HTML output produced by markdown parsers is passed through a sanitizer like `DOMPurify` before being set via `innerHTML`, making sure to whitelist necessary custom data attributes (like `data-note-node`).

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,9 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify
+          ? window.DOMPurify.sanitize(rendered, { ADD_ATTR: ['data-note-node', 'data-node'] })
+          : `<pre>${rendered.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: `site/app.js` rendered output from `marked.parse` into `body.innerHTML` without sanitizing it first, causing an XSS vulnerability when parsing user-defined `.fd` specification notes.
* 🎯 Impact: A malicious actor could provide a `.fd` file with a carefully crafted markdown spec containing malicious `<script>` tags or inline script attributes (e.g., `onerror=...`), enabling code execution on the user's browser in the Fast Draft environment.
* 🔧 Fix: Conditionally routed the `marked.parse(processedNote)` output through `window.DOMPurify.sanitize`, explicitly allowing necessary application-specific `data-note-node` and `data-node` custom attributes so functionality stays intact while mitigating script injection.
* ✅ Verification: Verified using standard test suites. A user attempting to add `<script>alert(1)</script>` in a note will no longer see it execute when opening the inspector panel in the Fast Draft site app.

---
*PR created automatically by Jules for task [1193620481541016024](https://jules.google.com/task/1193620481541016024) started by @khangnghiem*