### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in notes panel

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+## 2024-05-18 - XSS Vulnerability in Spec Panel Notes
+**Vulnerability:** Found an XSS vulnerability in `site/app.js` where untrusted node notes (parsed via marked.parse) were directly assigned to `body.innerHTML` without sanitization.
+**Learning:** Even when using a markdown parser, the output html can still contain executable scripts if not properly sanitized, especially when the notes data comes from external .fd files.
+**Prevention:** Always sanitize dynamically generated HTML from markdown parsers using `window.DOMPurify.sanitize` (including necessary data attributes via `ADD_ATTR`) before inserting it into the DOM via `innerHTML`. If DOMPurify is not available, fallback to rendering as plain text.

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,9 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify
+          ? window.DOMPurify.sanitize(rendered)
+          : `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The output of `marked.parse(processedNote)` was directly assigned to `body.innerHTML` without sanitization. Untrusted user data from notes could contain malicious scripts.
🎯 Impact: Cross-Site Scripting (XSS). An attacker could craft a malicious note in a `.fd` file that, when viewed in the web app, executes arbitrary JavaScript in the context of the user's browser.
🔧 Fix: Wrapped the HTML rendering logic in a check for `window.DOMPurify`. If available, it sanitizes the HTML. If not, it safely falls back to escaping the text and wrapping it in `<pre>` tags.
✅ Verification: Ran `node --check site/app.js` and verified syntax. Ran `pnpm lint`, `pnpm test`, and `pnpm run build:webview` in `fd-vscode`. Received a "Correct" rating from the code review tool.

---
*PR created automatically by Jules for task [1905424848336776624](https://jules.google.com/task/1905424848336776624) started by @khangnghiem*