### PR TITLE
🎨 Palette: Add ARIA labels to canvas chrome buttons and search inputs

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
 
             <!-- ─── Top-Left Canvas Chrome ─── -->
             <div id="chrome-left" class="canvas-chrome canvas-chrome-left">
-              <button class="canvas-chrome-btn" id="sidebar-toggle-btn" title="Toggle sidebar (\)">
+              <button class="canvas-chrome-btn" id="sidebar-toggle-btn" title="Toggle sidebar (\)" aria-label="Toggle sidebar">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><rect x="1" y="2" width="14" height="12" rx="2"/><line x1="6" y1="2" x2="6" y2="14"/></svg>
               </button>
             </div>
@@ -126,7 +126,7 @@
             <div id="chrome-right" class="canvas-chrome canvas-chrome-right">
               <!-- Share dropdown -->
               <div class="chrome-dropdown-container" id="share-dropdown-container">
-                <button class="canvas-chrome-btn" id="share-btn-chrome" title="Share & Export">
+                <button class="canvas-chrome-btn" id="share-btn-chrome" title="Share & Export" aria-label="Share and Export" aria-haspopup="menu">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M8 2v8"/><path d="M4 6l4-4 4 4"/><path d="M13 10v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3"/></svg>
                 </button>
                 <div class="chrome-dropdown chrome-dropdown-right" id="share-dropdown">
@@ -138,7 +138,7 @@
               </div>
               <!-- Settings dropdown -->
               <div class="chrome-dropdown-container" id="settings-dropdown-container">
-                <button class="canvas-chrome-btn" id="settings-gear-btn" title="Settings">
+                <button class="canvas-chrome-btn" id="settings-gear-btn" title="Settings" aria-label="Settings" aria-haspopup="menu">
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6.86 1.58a.5.5 0 0 1 .5-.42h1.28a.5.5 0 0 1 .5.42l.18 1.29a5.5 5.5 0 0 1 1.32.76l1.22-.4a.5.5 0 0 1 .6.22l.64 1.1a.5.5 0 0 1-.1.63l-1.04.89a5.5 5.5 0 0 1 0 1.53l1.04.89a.5.5 0 0 1 .1.63l-.64 1.1a.5.5 0 0 1-.6.22l-1.22-.4a5.5 5.5 0 0 1-1.32.76l-.18 1.29a.5.5 0 0 1-.5.42H7.36a.5.5 0 0 1-.5-.42l-.18-1.29a5.5 5.5 0 0 1-1.32-.76l-1.22.4a.5.5 0 0 1-.6-.22l-.64-1.1a.5.5 0 0 1 .1-.63l1.04-.89a5.5 5.5 0 0 1 0-1.53l-1.04-.89a.5.5 0 0 1-.1-.63l.64-1.1a.5.5 0 0 1 .6-.22l1.22.4a5.5 5.5 0 0 1 1.32-.76l.18-1.29Z"/><circle cx="8" cy="8" r="2.5"/></svg>
                 </button>
                 <div class="chrome-dropdown chrome-dropdown-right" id="settings-dropdown">
@@ -165,7 +165,7 @@
                   <a class="chrome-dropdown-item" href="https://github.com/khangnghiem/fast-draft" target="_blank" rel="noopener"><span class="cd-icon">🐙</span><span class="cd-label">GitHub</span></a>
                 </div>
               </div>
-              <button class="canvas-chrome-btn" id="hamburger-toggle-btn" title="Toggle right panel">
+              <button class="canvas-chrome-btn" id="hamburger-toggle-btn" title="Toggle right panel" aria-label="Toggle right panel">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><rect x="1" y="2" width="14" height="12" rx="2"/><line x1="10" y1="2" x2="10" y2="14"/></svg>
               </button>
             </div>
@@ -371,7 +371,7 @@
                             <path d="M12 5v14M5 12h14"/>
                           </svg>
                         </button>
-                        <textarea class="ai-chat-input" id="ai-chat-input" placeholder="Describe your design changes..." rows="1" maxlength="500"></textarea>
+                        <textarea class="ai-chat-input" id="ai-chat-input" placeholder="Describe your design changes..." rows="1" maxlength="500" aria-label="AI chat input"></textarea>
                       </div>
                       <div class="ai-chat-input-footer">
                         <div class="ai-model-selector">
@@ -387,7 +387,7 @@
                 <div class="rp-pane" data-rpane="search">
                   <div class="search-input-area">
                     <div class="search-input-row">
-                      <input type="text" class="search-input" id="search-input" placeholder="Search nodes, text, styles…" autocomplete="off" spellcheck="false" />
+                      <input type="text" class="search-input" id="search-input" placeholder="Search nodes, text, styles…" aria-label="Search document" autocomplete="off" spellcheck="false" />
                       <span class="search-count" id="search-count"></span>
                     </div>
                     <div class="search-controls">


### PR DESCRIPTION
**💡 What:**
Added explicit `aria-label` attributes to several icon-only buttons and standalone inputs in `site/index.html` (e.g., sidebar toggles, settings gear, share dropdown, AI chat, and document search). Added `aria-haspopup="menu"` to the settings and share buttons.

**🎯 Why:**
These interactive elements lacked clear, programmatically determinable names since they relied solely on icons or `title`/`placeholder` attributes. This prevented screen reader users from understanding the purpose of these primary controls. 

**📸 Before/After:**
*(Visuals remain unchanged as this is purely a semantic HTML update. See attached Playwright screenshot in verification.)*

**♿ Accessibility:**
* Improved keyboard and screen reader navigation by ensuring all main structural toggles and inputs announce clear, descriptive actions.
* Properly marks the share and settings buttons as menus with `aria-haspopup="menu"` to indicate their interactive dropdown behavior.

---
*PR created automatically by Jules for task [832090009530892505](https://jules.google.com/task/832090009530892505) started by @khangnghiem*