### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/site/layers.js
+++ b/site/layers.js
@@ -10,7 +10,7 @@ export function initLayersPanel(api) {
     path: '〜', text: 'T', style: '◆', edge: '⟶', note: '◇', spec: '◇'
   };
   
-  function escHtml(s) { return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+  function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#039;'); }
   
   /** Parse FD source into a hierarchical layer tree. */
   function parseLayerTree(source) {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `escHtml` function in `site/layers.js` failed to escape single quotes, leading to potential Cross-Site Scripting (XSS) via attribute breakouts. Additionally, it did not cast the input to a string, which could result in runtime `TypeError` crashes if passed null/undefined.
🎯 Impact: Untrusted data injected into `.fd` files or parsed configurations could execute arbitrary JavaScript within the application context.
🔧 Fix: Updated `escHtml` to forcefully cast input to string and securely escape single quotes (`'`) alongside other unsafe characters.
✅ Verification: Ran `cargo test`, `pnpm test`, and executed a headless Playwright script to verify the fix correctly blocked injected quote breakouts without regressing standard DOM rendering.

---
*PR created automatically by Jules for task [11519324636810513142](https://jules.google.com/task/11519324636810513142) started by @khangnghiem*