### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in Markdown notes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,8 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+
+## 2024-05-15 - Sanitizing Markdown Notes Output
+**Vulnerability:** XSS vulnerability in frontend due to unsanitized Markdown notes being directly assigned to `innerHTML`.
+**Learning:** Using `marked.parse` for rendering markdown notes generated arbitrary HTML content that lacked proper XSS sanitization, which when injected directly using `innerHTML` exposed the app to script injections.
+**Prevention:** Always use `window.DOMPurify.sanitize` to sanitize untrusted markdown/HTML strings before rendering to `innerHTML`, especially making sure to use `ADD_ATTR` for custom properties required for click-to-select logic.

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,7 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify ? window.DOMPurify.sanitize(rendered, { ADD_ATTR: ['data-note-node', 'data-node'] }) : `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The output of `marked.parse(processedNote)` was directly injected into the application's HTML via `body.innerHTML` without sanitization. In cases where malicious markdown contains script tags or inline handlers, it results in an XSS vulnerability.
🎯 Impact: An attacker could craft a malicious `.md` file or note that executes arbitrary JavaScript when the user views the note in the panel, potentially stealing secrets or acting on behalf of the user within the Fast Draft environment.
🔧 Fix: Sanitized the parsed markdown output utilizing `window.DOMPurify.sanitize(rendered, { ADD_ATTR: ['data-note-node', 'data-node'] })` specifically on the parsed input rather than the entire HTML document. Also implemented a secure fallback, encoding HTML explicitly in situations where DOMPurify might not be accessible.
✅ Verification: Tested via syntax checking `node --check site/app.js` and confirmed DOMPurify usage aligns securely with XSS prevention strategies.

---
*PR created automatically by Jules for task [3766300934175151797](https://jules.google.com/task/3766300934175151797) started by @khangnghiem*