### PR TITLE
📝 Scribe: Add missing doc comments to public items

### DIFF
--- a/crates/fd-core/src/completion.rs
+++ b/crates/fd-core/src/completion.rs
@@ -1,5 +1,6 @@
 use std::cmp::min;
 
+/// Specifies the type of completion item for rendering different icons/styles.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionKind {
     Keyword,
@@ -9,6 +10,7 @@ pub enum CompletionKind {
     Reference,
 }
 
+/// Represents a single completion suggestion provided to the editor.
 #[derive(Debug, Clone)]
 pub struct CompletionItemData {
     pub label: &'static str,
@@ -17,6 +19,7 @@ pub struct CompletionItemData {
     pub snippet: Option<&'static str>,
 }
 
+/// Returns standard structural completions available at the top-level of a `.fd` file.
 pub fn top_level_items() -> Vec<CompletionItemData> {
     vec![
         CompletionItemData {
@@ -78,6 +81,7 @@ pub fn top_level_items() -> Vec<CompletionItemData> {
     ]
 }
 
+/// Returns standard completions available inside the body of a node (e.g., properties, nested nodes).
 pub fn node_body_items() -> Vec<CompletionItemData> {
     vec![
         CompletionItemData {
@@ -227,6 +231,7 @@ pub fn node_body_items() -> Vec<CompletionItemData> {
     ]
 }
 
+/// Provides completions for the value of a specific property (e.g., specific colors for `fill:`).
 pub fn value_completions_data(property: &str) -> Vec<CompletionItemData> {
     let values: &[(&str, &str)] = match property {
         "layout" => &[
@@ -295,6 +300,7 @@ pub fn value_completions_data(property: &str) -> Vec<CompletionItemData> {
     items
 }
 
+/// Computes the depth of nested curly braces `{}` up to a specific line and column.
 pub fn compute_brace_depth(text: &str, line: usize, col: usize) -> usize {
     let mut depth: i32 = 0;
     for (i, ln) in text.lines().enumerate() {

--- a/crates/fd-core/src/model.rs
+++ b/crates/fd-core/src/model.rs
@@ -149,6 +149,7 @@ pub enum Paint {
 
 // ─── Stroke ──────────────────────────────────────────────────────────────
 
+/// Represents the styling of a line or border, including color, width, and flow animations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stroke {
     pub paint: Paint,
@@ -157,6 +158,7 @@ pub struct Stroke {
     pub join: StrokeJoin,
 }
 
+/// Determines the shape of the endpoints of a stroke (e.g., Round, Square).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StrokeCap {
     Butt,
@@ -164,6 +166,7 @@ pub enum StrokeCap {
     Square,
 }
 
+/// Determines the shape of the corners of a stroke (e.g., Miter, Round, Bevel).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StrokeJoin {
     Miter,
@@ -197,6 +200,7 @@ pub const DEFAULT_FONT_SIZE: f32 = 14.0;
 /// Default font weight for text nodes without an explicit font spec.
 pub const DEFAULT_FONT_WEIGHT: u16 = 400;
 
+/// Specifies the typography settings for a text element (family, size, weight, line height).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FontSpec {
     pub family: String,
@@ -251,6 +255,7 @@ pub enum ImageFit {
 
 // ─── Shadow ──────────────────────────────────────────────────────────────
 
+/// Describes a drop shadow effect applied to an element.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Shadow {
     pub offset_x: f32,

--- a/crates/fd-editor/src/commands.rs
+++ b/crates/fd-editor/src/commands.rs
@@ -42,6 +42,7 @@ pub struct CommandStack {
 }
 
 impl CommandStack {
+    /// Creates a new undo/redo history manager with the specified maximum depth.
     pub fn new(max_depth: usize) -> Self {
         Self {
             undo_stack: Vec::with_capacity(max_depth),
@@ -209,10 +210,12 @@ impl CommandStack {
         Some((desc, is_snapshot))
     }
 
+    /// Returns true if there are commands in the undo history that can be undone.
     pub fn can_undo(&self) -> bool {
         !self.undo_stack.is_empty()
     }
 
+    /// Returns true if there are commands in the redo history that can be redone.
     pub fn can_redo(&self) -> bool {
         !self.redo_stack.is_empty()
     }

--- a/crates/fd-editor/src/input.rs
+++ b/crates/fd-editor/src/input.rs
@@ -170,6 +170,7 @@ impl InputEvent {
         }
     }
 
+    /// Helper to construct a pointer move event.
     pub fn from_pointer_move(x: f32, y: f32, pressure: f32, modifiers: Modifiers) -> Self {
         Self::PointerMove {
             x,
@@ -179,6 +180,7 @@ impl InputEvent {
         }
     }
 
+    /// Helper to construct a pointer up event.
     pub fn from_pointer_up(x: f32, y: f32, modifiers: Modifiers) -> Self {
         Self::PointerUp { x, y, modifiers }
     }

--- a/crates/fd-editor/src/tools.rs
+++ b/crates/fd-editor/src/tools.rs
@@ -65,6 +65,7 @@ pub enum ResizeHandle {
 
 // ─── Select Tool ─────────────────────────────────────────────────────────
 
+/// The default selection tool, allowing users to select, move, and resize nodes.
 pub struct SelectTool {
     /// Currently selected node(s) — logical selection for operations.
     pub selected: Vec<NodeId>,
@@ -105,6 +106,7 @@ impl Default for SelectTool {
 }
 
 impl SelectTool {
+    /// Creates a new Selection tool instance.
     pub fn new() -> Self {
         Self {
             selected: Vec::new(),
@@ -445,6 +447,7 @@ impl Tool for SelectTool {
 
 // ─── Rect Tool ───────────────────────────────────────────────────────────
 
+/// Tool for drawing rectangular shapes on the canvas.
 pub struct RectTool {
     drawing: bool,
     dragged: bool,
@@ -466,6 +469,7 @@ impl Default for RectTool {
 }
 
 impl RectTool {
+    /// Creates a new Rectangle tool instance.
     pub fn new() -> Self {
         Self {
             drawing: false,
@@ -661,6 +665,7 @@ impl Tool for RectTool {
 
 // ─── Pen Tool (freehand) ─────────────────────────────────────────────────
 
+/// Tool for freehand drawing of paths and scribbles on the canvas.
 pub struct PenTool {
     drawing: bool,
     /// Points with pressure: (x, y, pressure 0.0–1.0).
@@ -679,6 +684,7 @@ impl Default for PenTool {
 }
 
 impl PenTool {
+    /// Creates a new Pen tool instance.
     pub fn new() -> Self {
         Self {
             drawing: false,
@@ -890,6 +896,7 @@ fn subsample_points(pts: &[(f32, f32, f32)], max_pts: usize) -> Vec<(f32, f32, f
 
 // ─── Ellipse Tool ────────────────────────────────────────────────────────
 
+/// Tool for drawing elliptical and circular shapes on the canvas.
 pub struct EllipseTool {
     drawing: bool,
     dragged: bool,
@@ -908,6 +915,7 @@ impl Default for EllipseTool {
 }
 
 impl EllipseTool {
+    /// Creates a new Ellipse tool instance.
     pub fn new() -> Self {
         Self {
             drawing: false,
@@ -1071,6 +1079,7 @@ impl Tool for EllipseTool {
 
 // ─── Text Tool ───────────────────────────────────────────────────────────
 
+/// Tool for inserting text labels onto the canvas.
 pub struct TextTool {
     placed: bool,
 }
@@ -1082,6 +1091,7 @@ impl Default for TextTool {
 }
 
 impl TextTool {
+    /// Creates a new Text tool instance.
     pub fn new() -> Self {
         Self { placed: false }
     }
@@ -1124,6 +1134,7 @@ impl Tool for TextTool {
 
 // ─── Arrow Tool (edge/connector) ─────────────────────────────────────────
 
+/// Tool for drawing connecting edges and arrows between nodes.
 pub struct ArrowTool {
     /// Start position of the drag (scene-space).
     pub start_pos: Option<(f32, f32)>,
@@ -1144,6 +1155,7 @@ impl Default for ArrowTool {
 }
 
 impl ArrowTool {
+    /// Creates a new Arrow tool instance.
     pub fn new() -> Self {
         Self {
             start_pos: None,
@@ -1336,6 +1348,7 @@ impl Default for EraserTool {
 }
 
 impl EraserTool {
+    /// Creates a new Eraser tool instance.
     pub fn new() -> Self {
         Self {
             erased_ids: Vec::new(),
@@ -1409,6 +1422,7 @@ impl Default for LassoTool {
 }
 
 impl LassoTool {
+    /// Creates a new Lasso tool instance.
     pub fn new() -> Self {
         Self {
             polygon: Vec::new(),

--- a/crates/fd-render/src/canvas.rs
+++ b/crates/fd-render/src/canvas.rs
@@ -28,6 +28,7 @@ pub struct Canvas {
 }
 
 impl Canvas {
+    /// Creates a new Canvas engine instance configured for either rendering or hit testing.
     pub fn new(config: CanvasConfig) -> Self {
         Self { config }
     }

--- a/crates/fd-wasm/src/svg.rs
+++ b/crates/fd-wasm/src/svg.rs
@@ -40,6 +40,7 @@ fn paint_to_svg_color(p: &fd_core::model::Paint) -> String {
     }
 }
 
+/// Renders the scene graph to an SVG string.
 pub fn render_svg(
     graph: &SceneGraph,
     bounds: &HashMap<NodeIndex, ResolvedBounds>,


### PR DESCRIPTION
Added missing `///` doc comments to various public structs, enums, and functions across the workspace to improve code documentation. Files modified include completion.rs, model.rs, canvas.rs, commands.rs, input.rs, tools.rs, and svg.rs. All tests and checks have passed successfully.

---
*PR created automatically by Jules for task [15938100980697435144](https://jules.google.com/task/15938100980697435144) started by @khangnghiem*