### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in markdown rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,8 @@
+## 2026-06-19 - XSS Vulnerability in Markdown Rendering in Specs Panel
+**Vulnerability:** Found an XSS vulnerability in `site/app.js` where untrusted markdown notes were rendered to HTML via `marked.parse` and directly appended to the DOM (`innerHTML`) without sanitization.
+**Learning:** Rendering markdown directly to HTML can execute script tags or other malicious payloads embedded within the markdown if the input is untrusted or user-controlled.
+**Prevention:** Always sanitize the resulting HTML from markdown parsers (e.g., using `DOMPurify.sanitize`) before inserting it into the DOM, taking care to preserve expected structural or functional attributes using `ADD_ATTR`.
+
 ## 2026-03-10 - Cross-Site Scripting (XSS) in Renamify Panel
 **Vulnerability:** Found an XSS vulnerability in `fd-vscode/src/webview-html.ts` where untrusted node IDs (`p.oldId` and `p.newId`) from the extension's `.fd` files were directly interpolated into `row.innerHTML` in the Renamify panel.
 **Learning:** Even though the source is internal extension files, untrusted input rendered directly as `innerHTML` causes an XSS injection risk.

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,7 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify ? window.DOMPurify.sanitize(rendered, { ADD_ATTR: ['data-note-node', 'data-node'] }) : rendered;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Untrusted markdown notes rendered via `marked.parse` in `site/app.js`'s `renderSpecsPanel` were directly appended to the DOM using `innerHTML` without sanitization.
🎯 **Impact:** If an attacker creates an `.fd` file with malicious scripts hidden in node notes, they could execute arbitrary JavaScript in a victim's browser when they open the Spec Panel.
🔧 **Fix:** Wrapped the HTML output of `marked.parse` in `window.DOMPurify.sanitize()` before appending it to the DOM. Configured `ADD_ATTR` to retain custom data attributes required by the Spec Panel's interactivity.
✅ **Verification:** Verified the fix logic in code, tested syntax with `node --check site/app.js`, and confirmed code review rating is #Correct#.

---
*PR created automatically by Jules for task [16491052846319131800](https://jules.google.com/task/16491052846319131800) started by @khangnghiem*