### PR TITLE
📝 Scribe: Add pen drawing example and doc comments

### DIFF
--- a/crates/fd-core/src/completion.rs
+++ b/crates/fd-core/src/completion.rs
@@ -1,5 +1,6 @@
 use std::cmp::min;
 
+/// Represents the type/kind of an autocompletion item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionKind {
     Keyword,
@@ -9,6 +10,7 @@ pub enum CompletionKind {
     Reference,
 }
 
+/// Data payload for a single autocompletion item.
 #[derive(Debug, Clone)]
 pub struct CompletionItemData {
     pub label: &'static str,
@@ -17,6 +19,7 @@ pub struct CompletionItemData {
     pub snippet: Option<&'static str>,
 }
 
+/// Returns the top-level completion items (e.g., node types, styles).
 pub fn top_level_items() -> Vec<CompletionItemData> {
     vec![
         CompletionItemData {
@@ -78,6 +81,7 @@ pub fn top_level_items() -> Vec<CompletionItemData> {
     ]
 }
 
+/// Returns completion items that are valid inside a node body (e.g., properties).
 pub fn node_body_items() -> Vec<CompletionItemData> {
     vec![
         CompletionItemData {
@@ -227,6 +231,7 @@ pub fn node_body_items() -> Vec<CompletionItemData> {
     ]
 }
 
+/// Returns available completion values for a specific property.
 pub fn value_completions_data(property: &str) -> Vec<CompletionItemData> {
     let values: &[(&str, &str)] = match property {
         "layout" => &[
@@ -295,6 +300,7 @@ pub fn value_completions_data(property: &str) -> Vec<CompletionItemData> {
     items
 }
 
+/// Computes the brace nesting depth at a given line and column.
 pub fn compute_brace_depth(text: &str, line: usize, col: usize) -> usize {
     let mut depth: i32 = 0;
     for (i, ln) in text.lines().enumerate() {

--- a/crates/fd-wasm/src/svg.rs
+++ b/crates/fd-wasm/src/svg.rs
@@ -40,6 +40,8 @@ fn paint_to_svg_color(p: &fd_core::model::Paint) -> String {
     }
 }
 
+/// Renders the given scene graph as an SVG string.
+/// This maps the scene graph nodes and styles into corresponding SVG elements.
 pub fn render_svg(
     graph: &SceneGraph,
     bounds: &HashMap<NodeIndex, ResolvedBounds>,

--- a/examples/pen_drawing.fd
+++ b/examples/pen_drawing.fd
@@ -1,0 +1,63 @@
+# Pen / Freehand Drawing Showcase
+# Demonstrates Catmull-Rom curves and multiple paths
+
+style title_text {
+  font: "Inter" bold 24
+  fill: #111827
+  align: center middle
+}
+
+style annotation_text {
+  font: "Inter" medium 14
+  fill: #6B7280
+  align: center middle
+}
+
+text @title "Pen Tool & Freehand Drawing" {
+  use: title_text
+  w: 400 h: 40
+}
+
+# Example 1: Catmull-Rom Curve
+# [auto] container (2 children)
+group @curve_example {
+  text @_curve_label "Smooth Catmull-Rom Curve" {
+    use: annotation_text
+    w: 200 h: 30
+  }
+
+  path @smooth_curve {
+    stroke: #3B82F6 4.0
+    d: M 0 100 C 50 20 150 20 200 100 C 250 180 350 180 400 100
+  }
+}
+
+# Example 2: Multiple Paths (Signature)
+# [auto] container (2 children)
+group @signature_example {
+  text @_sig_label "Multiple Disconnected Paths" {
+    use: annotation_text
+    w: 200 h: 30
+  }
+
+  path @signature {
+    stroke: #111827 3.0
+    d: M 50 20 C 80 20 80 80 50 100 C 20 100 20 60 20 60 M 120 20 L 120 100 M 120 20 C 180 20 180 100 120 100 M 200 60 C 220 20 250 20 260 60 C 270 100 220 100 240 50
+  }
+}
+
+# Example 3: Closed Shape
+# [auto] container (2 children)
+group @closed_shape {
+  text @_closed_label "Closed Freehand Shape" {
+    use: annotation_text
+    w: 200 h: 30
+  }
+
+  path @blob {
+    fill: #FCA5A5
+    stroke: #EF4444 4.0
+    opacity: 0.8
+    d: M 150 0 C 250 0 300 100 250 180 C 150 220 50 180 0 100 C -20 20 50 0 150 0 Z
+  }
+}


### PR DESCRIPTION
**What**: 
- Added a new example file `examples/pen_drawing.fd` demonstrating freehand drawing and Catmull-Rom curves.
- Added missing documentation (`///`) to public items in `crates/fd-core/src/completion.rs` and `crates/fd-wasm/src/svg.rs`.

**Why**: 
- To fulfill the Scribe agent directive of picking an underused feature and creating a showcase `.fd` file.
- To improve repository health and developer experience by ensuring public Rust APIs are well-documented.

**Impact**: 
- Provides an easy reference for how to create and style paths in Fast Draft documents.
- Makes the code completion and SVG export APIs easier to understand for future developers.

**Measurement**:
- The `.fd` document parses correctly using `fdraft check`.
- All `cargo` test suites continue to pass successfully.

---
*PR created automatically by Jules for task [17526938477256341644](https://jules.google.com/task/17526938477256341644) started by @khangnghiem*