### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in spec notes rendering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Several `escapeHtml` implementations used DOM manipulation (`document.createElement('div').innerHTML`) or incomplete string replacement, failing to escape single and double quotes.
 **Learning:** Incomplete escaping allows XSS payloads to break out of HTML attributes (e.g., `<input value="${escapeHtml(userInput)}">`).
 **Prevention:** Always use `String(text)` cast combined with a comprehensive replace chain for `&`, `<`, `>`, `"`, and `'` (e.g., `&#039;`) in custom string escaping functions.
+## 2024-06-21 - Missing DOMPurify Sanitization on Rendered Markdown Notes
+**Vulnerability:** Untrusted spec notes were rendered via `marked.parse()` and appended directly to `innerHTML` in `site/app.js` without any sanitization.
+**Learning:** Parsing markdown to HTML does not inherently make it safe from XSS. Any parsed markdown from untrusted sources must still be sanitized before DOM insertion.
+**Prevention:** Always sanitize dynamically rendered HTML blocks (e.g. from `marked`) with `DOMPurify` before injecting them via `innerHTML`. Use conditional fallback (`window.DOMPurify ? DOMPurify.sanitize(...) : ...`) if the library is optionally loaded.

--- a/site/app.js
+++ b/site/app.js
@@ -2724,7 +2724,7 @@ function renderSpecsPanel() {
 
       if (typeof marked !== 'undefined') {
         const rendered = marked.parse(processedNote);
-        html += rendered;
+        html += window.DOMPurify ? window.DOMPurify.sanitize(rendered, { ADD_ATTR: ['data-note-node', 'data-node'] }) : rendered;
       } else {
         html += `<pre>${processedNote.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`;
       }


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: Untrusted spec notes were rendered via `marked.parse()` and appended directly to `innerHTML` in `site/app.js` without any sanitization.

🎯 **Impact**: If a user loads a workspace containing malicious `.fd` spec notes, arbitrary JavaScript could be executed in the user's browser (XSS). 

🔧 **Fix**: Added `DOMPurify.sanitize()` conditional logic to sanitize the output from `marked.parse` before concatenating it to the HTML string. We also kept the `ADD_ATTR` configuration so functional attributes aren't stripped.

✅ **Verification**: 
- Validated via `node --check site/app.js`
- Inspected the fix to ensure the `DOMPurify` optional logic mirrors existing safe usages in `site/ai-chat.js`.

---
*PR created automatically by Jules for task [8102138957986238944](https://jules.google.com/task/8102138957986238944) started by @khangnghiem*